### PR TITLE
Build to an ignored dist dir so submodules aren't dirty after build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 build
 examples/*/*.js
+dist

--- a/grunt.js
+++ b/grunt.js
@@ -1,5 +1,5 @@
-var DIST_FILE     = 'ember-table.js';
-var DIST_FILE_MIN = 'ember-table.min.js';
+var DIST_FILE     = 'dist/ember-table.js';
+var DIST_FILE_MIN = 'dist/ember-table.min.js';
 var BUILD_TASKS   = 'coffee handlebars concat min';
 var JS_FILES      = [
   'build/utils/scrollbar_width_helper.js',


### PR DESCRIPTION
We have ember-table as a submodule and after building with grunt, the submodule is marked as dirty.
