### PR TITLE
Models with an active property become dirty on hover.

### DIFF
--- a/src/controllers.coffee
+++ b/src/controllers.coffee
@@ -18,9 +18,11 @@ Ember.Table.ColumnDefinition = Ember.Object.extend
 ################################################################################
 Ember.Table.Row = Ember.ObjectController.extend
   content:  null
+  parent: null,
   isHovering: no
   isSelected: no
   isShowing:  yes
+  handleActiveBinding: 'parent.handleActive'
 
 Ember.Table.RowArrayProxy = Ember.ArrayProxy.extend
   tableRowClass: null
@@ -53,6 +55,7 @@ Ember.Table.TableController = Ember.Controller.extend
   footerHeight: 30
   hasHeader: yes
   hasFooter: yes
+  handleActive: yes
 
   tableRowClass: 'Ember.Table.Row'
 
@@ -64,6 +67,7 @@ Ember.Table.TableController = Ember.Controller.extend
     Ember.Table.RowArrayProxy.create
       tableRowClass: tableRowClass
       content: @get('content')
+      parent: @
   .property 'content', 'tableRowClass'
 
   # Array of Ember.Table.Row

--- a/src/views.coffee
+++ b/src/views.coffee
@@ -46,23 +46,24 @@ Ember.Table.LazyTableBlock = Ember.LazyContainerView.extend
   , 'scrollLeft'
 
 Ember.Table.TableRow = Ember.LazyItemView.extend
-  templateName:   'table-row'
-  classNames:     'table-row'
-  classNameBindings: ['row.active:active', 'row.selected:selected']
-  styleBindings:  ['width', 'height']
-  rowBinding:     'content'
-  columnsBinding: 'parentView.columns'
-  widthBinding:   'controller._rowWidth'
-  heightBinding:  'controller.rowHeight'
+  templateName:        'table-row'
+  classNames:          'table-row'
+  classNameBindings:   ['row.active:active', 'row.selected:selected']
+  styleBindings:       ['width', 'height']
+  rowBinding:          'content'
+  columnsBinding:      'parentView.columns'
+  widthBinding:        'controller._rowWidth'
+  heightBinding:       'controller.rowHeight'
+  handleActiveBinding: 'controller.handleActive'
   mouseEnter: (event) ->
     row = @get 'row'
-    row.set 'active', yes if row
+    row.set 'active', yes if row and @get 'handleActive'
   mouseLeave: (event) ->
     row = @get 'row'
-    row.set 'active', no if row
+    row.set 'active', no if row and @get 'handleActive'
   teardownContent: ->
     row = @get 'row'
-    row.set 'active', no if row
+    row.set 'active', no if row and @get 'handleActive'
 
 Ember.Table.TableCell = Ember.View.extend Ember.StyleBindingsMixin,
   templateName:   'table-cell'


### PR DESCRIPTION
Some of our models have a property named `active`, so when the records row is hovered on, the model `active` property gets set and the record becomes dirty.

Need either the ability to turn that functionality off or make it not set the active property on the model.
