### PR TITLE
Corrected README.md to mention Node instead of Python to serve examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ grunt
 ```
 
 ### Viewing Examples
-From the root directory: `$ python -m SimpleHTTPServer`.
+From the root directory: `$ node examples.js`.
 Hit up : `http://localhost:8000/examples`
 
 ## Dependencies


### PR DESCRIPTION
After pull request #67, the README still referred to Python instead of mentioning Node. This PR fixes that.
