### PR TITLE
Missing dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Hit up : `http://localhost:8000/examples`
 * ember.js
 * jquery-ui
 * jquery.mousewheel.js
+* antiscroll.js
 
 ## TODO
 * Bug fixes—we are aware that there are bugs. Please help us out by filing github issues or submitting pull requests!


### PR DESCRIPTION
The dependency on antiscroll.js is missing from the README (though it's present on gh_pages).
