### PR TITLE
Added minimum jQuery UI build info to site

### DIFF
--- a/app/templates/ember_table/overview.hbs
+++ b/app/templates/ember_table/overview.hbs
@@ -32,7 +32,11 @@
       <h3>Dependencies</h3>
       <ul class="styled">
         <li><a target="_BLANK" href="http://emberjs.com/">Ember.js</a></li>
-        <li><a target="_BLANK" href="http://jqueryui.com/">jquery-ui</a></li>
+        <li><a target="_BLANK" href="http://jqueryui.com/download/#!components=1110001010000000000000000000000000">
+          jquery-ui
+          <br>
+          <small>only core, widget, mouse, resizable, and sortable modules required</small>
+        </a></li>
         <li><a target="_BLANK" href="https://github.com/brandonaaron/jquery-mousewheel">jquery.mousewheel.js</a></li>
         <li><a target="_BLANK" href="https://github.com/LearnBoost/antiscroll">antiscroll.js</a></li>
       </ul>


### PR DESCRIPTION
The entire jQuery UI package weighs in at 228k after minifcation. The modules that are required for ember-table are only 55k after min. After digging through the code, it appears that only the following modules are required:
- core
- widgets
- mouse
- resizable
- sortable

So it would probably be helpful to include this info in the docs to avoid users downloading the entire package when it isn't necessary.
