### PR TITLE
'template'/'templateName' is not appropriate for components that are reg...

### DIFF
--- a/src/component.coffee
+++ b/src/component.coffee
@@ -6,7 +6,7 @@
 Ember.Table.EmberTableComponent =
 Ember.Component.extend Ember.AddeparMixins.StyleBindingsMixin,
 Ember.AddeparMixins.ResizeHandlerMixin,
-  templateName:   'components/ember-table'
+  layoutName:   'components/ember-table'
   classNames:     ['ember-table-tables-container']
   styleBindings:  ['height']
   height:         Ember.computed.alias '_tablesContainerHeight'


### PR DESCRIPTION
...istered via Handlebars.helper,

layoutName should be used instead,

for more info, please see: https://github.com/emberjs/ember.js/issues/4030.
