### PR TITLE
Add link to JS Bin example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Table built using [Ember.js](http://emberjs.com/) that lazily renders rows.
 http://addepar.github.com/ember-table/
 
 ## JS Bin Starter Kit
-http://emberjs.jsbin.com/tesiw/1/
+http://emberjs.jsbin.com/zozonuxu/1/edit
 
 ## Getting Started
 


### PR DESCRIPTION
I'll submit another PR to overhaul the README soon; for now I just want to make this available.
