### PR TITLE
Fix for horizontal scroll

### DIFF
--- a/src/component.coffee
+++ b/src/component.coffee
@@ -167,6 +167,10 @@ Ember.AddeparMixins.ResizeHandlerMixin,
     additionWidthPerColumn = Math.floor(remainingWidth / columnsToResize.length)
     columnsToResize.forEach (column) ->
       columnWidth = column.get('columnWidth') + additionWidthPerColumn
+      minWidth = column.get("minWidth")
+    if minWidth and minWidth > columnWidth
+      column.set "columnWidth", minWidth
+    else
       column.set 'columnWidth', columnWidth
 
   onBodyContentLengthDidChange: Ember.observer ->


### PR DESCRIPTION
Horizontal scroll brakes if in last column canAutoResize is set to true.
Honoring minWidth will fix that.