### PR TITLE
StyleBindingsMixin: none check guard

### DIFF
--- a/dependencies/ember-addepar-mixins/style_bindings.js
+++ b/dependencies/ember-addepar-mixins/style_bindings.js
@@ -7,7 +7,7 @@ Ember.AddeparMixins.StyleBindingsMixin = Ember.Mixin.create({
   createStyleString: function(styleName, property) {
     var value;
     value = this.get(property);
-    if (value === void 0) {
+    if (Ember.isNone(value)) {
       return;
     }
     if (Ember.typeOf(value) === 'number') {


### PR DESCRIPTION
Switch to Ember.isNone(value) to prevent null from being pulled in as real values.
