### PR TITLE
StyleBindingsMixin: dasherize style name

### DIFF
--- a/dependencies/ember-addepar-mixins/style_bindings.js
+++ b/dependencies/ember-addepar-mixins/style_bindings.js
@@ -13,7 +13,7 @@ Ember.AddeparMixins.StyleBindingsMixin = Ember.Mixin.create({
     if (Ember.typeOf(value) === 'number') {
       value = value + this.get('unitType');
     }
-    return "" + styleName + ":" + value + ";";
+    return Ember.String.dasherize("" + styleName) + ":" + value + ";";
   },
   applyStyleBindings: function() {
     var lookup, properties, styleBindings, styleComputed, styles,


### PR DESCRIPTION
Automatically translate definitions of Javascript style attributes such as "marginTop" into the correct CSS name (i.e. "margin-top")
