### PR TITLE
update copy:tests task to allow localhost:8000/tests to run

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -163,17 +163,22 @@ module.exports = function (grunt) {
       tests: {
         files: [
           {
-            expand: true,
-            flatten: true,
-            cwd: 'dependencies/',
-            src: ['**/*.js'],
-            dest: 'tests/lib'
+            src: ['vendor/qunit/qunit/qunit.css'],
+            dest: 'tests/css/qunit.css'
           }, {
-            expand: true,
             flatten: true,
-            cwd: 'dependencies/',
-            src: ['**/*.css'],
-            dest: 'tests/css'
+            expand: true,
+            src: [
+              'vendor/qunit/qunit/qunit.js',
+              'vendor/ember/ember.js',
+              'vendor/handlebars/handlebars.js',
+              'vendor/modernizr/modernizr.js',
+              'vendor/d3/d3.js',
+              'vendor/jquery/jquery.js',
+              'vendor/jquery-ui/ui/jquery-ui.custom.js',
+              'vendor/jquery-mousewheel/jquery.mousewheel.js'
+            ],
+            dest: 'tests/lib/'
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ To view examples, start the node server. From the root directory:
 
 You can view the examples at http://localhost:8000/gh_pages.
 
+You can run the tests at http://localhost:8000/tests.
+
 ## Dependencies
 * ember
 * jquery-ui

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,13 +10,13 @@
     <link rel="stylesheet" type="text/css" href="../dist/ember-table.css">
     <link rel="stylesheet" type="text/css" href="css/qunit.css">
 
-    <script src="lib/modernizr-2.6.1.min.js"></script>
-    <script src="lib/jquery-1.10.2.min.js"></script>
-    <script src="lib/jquery-ui/jquery-ui-1.10.1.custom.min.js"></script>
+    <script src="lib/modernizr.js"></script>
+    <script src="lib/jquery.js"></script>
+    <script src="lib/jquery-ui.custom.js"></script>
     <script src="lib/jquery.mousewheel.js"></script>
     <script src="lib/handlebars.js"></script>
     <script src="lib/ember.js"></script>
-    <script src="lib/d3.v2.js"></script>
+    <script src="lib/d3.js"></script>
     <script src='lib/qunit.js'></script>
 
     <script src="../dist/ember-table.js"></script>


### PR DESCRIPTION
I'm interested in using Ember Table in Ember 1.7. If I bump the bower dependency and rebuild it seems like everything in /examples works OK. However I wasn't able to run the tests without reorganizing the dependencies. So here's a PR to fix that. Any other changes needed let me know.
