### PR TITLE
Updating dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "ember": "1.4.0",
     "handlebars": "~1.3.0",
     "jquery": "1.10.2",
-    "jquery-mousewheel": "3.1.4",
+    "jquery-mousewheel": "~3.1.4",
     "jquery-ui": "1.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- Uses daviesgeek repo ( it adds the `bower.json` )
- Be less strict with `jquery-mousewheel` version to avoid fixing manually conflicts
