### PR TITLE
Fix rendering issue in Linux Chrome v38

### DIFF
--- a/src/css/ember-table.less
+++ b/src/css/ember-table.less
@@ -102,6 +102,8 @@
   // Let Antiscroll handle the overflow
   overflow: hidden;
   position: relative;
+  // fix bug in Chrome 38 where anti-aliasing forces text to wrap
+  white-space: nowrap;
   z-index: 3;
   .box-sizing();
 }


### PR DESCRIPTION
The Chrome update made rows a tiny bit wider, so that non-fixed columns are forced to "wrap to the next line"... but the "next line" is below everything in the fixed columns! See http://stackoverflow.com/questions/26495735/google-chrome-rendering-floated-text-on-multiple-lines.

This is probably a hack, but forces the text not to wrap. This should be ok because ember-table computes and sets widths.
