### PR TITLE
Columns reorder fix, Ember 1.8.1 changed removeObject (Issue #243)

### DIFF
--- a/src/component.coffee
+++ b/src/component.coffee
@@ -120,7 +120,10 @@ Ember.AddeparMixins.ResizeHandlerMixin,
 
   onColumnSort: (column, newIndex) ->
     columns  = @get 'tableColumns'
-    columns.removeObject column
+
+    columns = $.grep columns, (n, i) ->
+      n isnt column
+
     columns.insertAt newIndex, column
     @prepareTableColumns()
 


### PR DESCRIPTION
Ember 1.8.1 is firing some methods from new Morph library when calling removeObject, and this was removing the columns from DOM, causing a null problem.

The problem is described here: https://github.com/Addepar/ember-table/issues/243

Using Jquery grep remove only the column to reorder, and prevent this from happening