### PR TITLE
Prevent jQuery UI from moving DOM nodes itself, otherwise Ember’s morph ...

### DIFF
--- a/src/views.coffee
+++ b/src/views.coffee
@@ -182,6 +182,7 @@ Ember.View.extend Ember.AddeparMixins.StyleBindingsMixin,
 
   onColumnSortDone: (event, ui) ->
     newIndex = ui.item.index()
+    @$('> div').sortable('cancel') # Prevent jQuery UI from moving the DOM itself
     view     = Ember.View.views[ui.item.attr('id')]
     column   = view.get 'column'
     @get('controller').onColumnSort column, newIndex


### PR DESCRIPTION
...library will lose track of DOM