### PR TITLE
Update .npmignore to prevent packaging tmp dir

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 bower_components/
 tests/
+tmp/
 
 .bowerrc
 .editorconfig


### PR DESCRIPTION
The ember-cli addon blueprint generates the .npmignore and previous to 0.2.2 did not ignore the tmp directory causing large packages. This change is direct from https://github.com/ember-cli/ember-cli/pull/3539