### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "ember-table",
-  "version": "0.5.0",
   "dependencies": {
     "antiscroll": "azirbel/antiscroll#90391fb371c7be769bc32e7287c5271981428356",
     "handlebars": "~1.3.0",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property