### PR TITLE
Fix lazy container bug

### DIFF
--- a/addon/views/lazy-container.js
+++ b/addon/views/lazy-container.js
@@ -82,7 +82,7 @@ StyleBindingsMixin, {
       var itemIndex = startIndex + i;
       childView = childViews.objectAt(itemIndex % numShownViews);
       var item = content.objectAt(itemIndex);
-      if (item !== childView.get('content')) {
+      if (childView && item !== childView.get('content')) {
         childView.teardownContent();
         childView.set('itemIndex', itemIndex);
         childView.set('content', item);


### PR DESCRIPTION
When changing content of ember-table I end up with an error stating
that I can't call get on undefined. This stems from a problem with
lazy container where the container views length is longer than the
actual number of views. I'm unsure if this is an ember problem or if
its something to do with the implementation of lazy container itself.

It might be that you can't rely on ember having created all the views.
Checking to see if the view exists before settings its content fixes
this and I have had no noticeable problems with this extra check.

![screen shot 2015-06-19 at 19 49 41](https://cloud.githubusercontent.com/assets/4038905/8260794/c95108cc-16bd-11e5-98a2-f255b4dff667.png)