### PR TITLE
Selection action

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -105,6 +105,10 @@ StyleBindingsMixin, ResizeHandlerMixin, {
     }
   }).property('persistedSelection.[]', 'rangeSelection.[]', 'selectionMode'),
 
+  _selectionChanged: Ember.observer('selection', function() {
+    this.sendAction('selectionChanged', this.get('selection'));
+  }),
+
   // ---------------------------------------------------------------------------
   // Internal properties
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add an action which gets fired when the selection changes with the current selection. 
May want to deprecate two way selection binding to adhere more to the Data down, actions up pattern.
