### PR TITLE
Improved antiscroll rebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-release
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -311,10 +311,10 @@ StyleBindingsMixin, ResizeHandlerMixin, {
       return;
     }
     // updating antiscroll
-    this.$('.antiscroll-wrap').antiscroll().data('antiscroll').rebuild();
     if (this.get('columnsFillTable')) {
       this.doForceFillColumns();
     }
+    this.scheduleAntiscrollRebuild();
   },
 
   // Iteratively adjusts column widths to adjust to a changed table width.

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -290,7 +290,9 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   },
 
   rebuildAntiscroll() {
-    if (this._state !== 'inDOM'){ return; }
+    if (this._state !== 'inDOM'){ 
+      return;
+    }
 
     this.$('.antiscroll-wrap').antiscroll();
   },

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -137,7 +137,7 @@ StyleBindingsMixin, ResizeHandlerMixin, {
           value = resolvedContent;
         });
 
-        // returns [] if the promise doesn't resolve immediately, or 
+        // returns [] if the promise doesn't resolve immediately, or
         // the resolved value if it's ready
         return value;
       }
@@ -282,7 +282,17 @@ StyleBindingsMixin, ResizeHandlerMixin, {
     this.set('_height', this.$().parent().height());
     // we need to wait for the table to be fully rendered before antiscroll can
     // be used
-    Ember.run.next(this, this.updateLayout);
+    this.scheduleAntiscrollRebuild();
+  },
+
+  scheduleAntiscrollRebuild() {
+    Ember.run.scheduleOnce('afterRender', this, this.rebuildAntiscroll);
+  },
+
+  rebuildAntiscroll() {
+    if (this._state !== 'inDOM'){ return; }
+
+    this.$('.antiscroll-wrap').antiscroll();
   },
 
   tableWidthNowTooSmall: function() {

--- a/tests/acceptance/resize-container-test.js
+++ b/tests/acceptance/resize-container-test.js
@@ -29,21 +29,26 @@ skip("columnsFillTable=true and canAutoResize=true fills up the table", function
   });
 });
 
-skip("columnsFillTable=false does not fill up the table", function(assert){
+test("columnsFillTable=false does not fill up the table", function(assert){
   visit('/resize-container-test?rowCount=12&columnsFillTable=false');
   showHalf();
   andThen(function(){
     showScrollbarsWhenNecessary();
     assert.ok(horizontalScrollShown());
-    const antiscrollInner = getAntiscrollInner();
-    const scrollLeft = antiscrollInner.scrollLeft();
-    antiscrollInner.scrollLeft(20);
-    assert.equal(antiscrollInner.scrollLeft(), 20, "antiscroll inner should have scroll position of 20");
+    const $rightBlock = rightBlock();
+    assert.equal($rightBlock.scrollLeft(), 0, "left scroll is 0 before scrolling");
+    // scroll right block by 50 px
+    $rightBlock.scrollLeft(50);
+    assert.equal($rightBlock.scrollLeft(), 50, "antiscroll inner should have scroll position of 50");
   });
 });
 
-function getAntiscrollInner() {
+function inner() {
   return $('.antiscroll-inner');
+}
+
+function rightBlock() {
+  return $('.ember-table-table-scrollable-wrapper .ember-table-right-table-block');
 }
 
 function showScrollbarsWhenNecessary() {

--- a/tests/acceptance/resize-container-test.js
+++ b/tests/acceptance/resize-container-test.js
@@ -1,0 +1,68 @@
+import Ember from 'ember';
+import {
+  module,
+  test,
+  skip
+  } from 'qunit';
+import startApp from '../helpers/start-app';
+import {setRandomSeed} from 'dummy/utils/random';
+
+var application;
+
+module('Acceptance: Resize Container', {
+  beforeEach: function() {
+    application = startApp();
+    setRandomSeed(6);
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+skip("columnsFillTable=true and canAutoResize=true fills up the table", function(assert) {
+  visit('/resize-container-test?rowCount=12');
+  andThen(function(){
+    showScrollbarsWhenNecessary();
+    assert.ok(!verticalScrollShown(), "12 rows don't fill up the table, therefore vertical scollbar is not show");
+    assert.ok(!horizontalScrollShown(), "columnsFillTable with canAutoResize fills up the table without showing horizontal scroll");
+  });
+});
+
+skip("columnsFillTable=false does not fill up the table", function(assert){
+  visit('/resize-container-test?rowCount=12&columnsFillTable=false');
+  showHalf();
+  andThen(function(){
+    showScrollbarsWhenNecessary();
+    assert.ok(horizontalScrollShown());
+    const antiscrollInner = getAntiscrollInner();
+    const scrollLeft = antiscrollInner.scrollLeft();
+    antiscrollInner.scrollLeft(20);
+    assert.equal(antiscrollInner.scrollLeft(), 20, "antiscroll inner should have scroll position of 20");
+  });
+});
+
+function getAntiscrollInner() {
+  return $('.antiscroll-inner');
+}
+
+function showScrollbarsWhenNecessary() {
+  // enter mouse into table to cause scrollbars to show
+  $('.antiscroll-wrap').mouseenter();
+}
+
+function horizontalScrollShown() {
+  return $('.antiscroll-scrollbar-horizontal.antiscroll-scrollbar-shown:visible').length > 0;
+}
+
+function verticalScrollShown() {
+  return $('.antiscroll-scrollbar-vertical.antiscroll-scrollbar-shown:visible').length > 0;
+}
+
+function showHalf() {
+  click('button:contains(Show Half)');
+}
+
+function showFull() {
+  click('button:contains(Show Full)');
+}

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  isTestRoute: Ember.computed.match('currentRouteName', /-test$/)
+});

--- a/tests/dummy/app/controllers/resize-container-test.js
+++ b/tests/dummy/app/controllers/resize-container-test.js
@@ -1,0 +1,77 @@
+import Ember from 'ember';
+import ColumnDefinition from 'ember-table/models/column-definition';
+import {randomNumber, randomDate} from '../utils/random';
+
+const {observer, $, View} = Ember;
+
+export default Ember.Controller.extend({
+  queryParams: ['rowCount', 'columnsFillTable'],
+  isFullWidth: true,
+  columnsFillTable: true,
+  tableColumns: Ember.computed(function() {
+    var dateColumn = ColumnDefinition.create({
+      savedWidth: 150,
+      textAlign: 'text-align-left',
+      headerCellName: 'Date',
+      getCellContent: function(row) {
+        return row.get('date').toDateString();
+      }
+    });
+    var openColumn = ColumnDefinition.create({
+      headerCellName: 'Open',
+      canAutoResize: true,
+      getCellContent: function(row) {
+        return row.get('open').toFixed(2);
+      }
+    });
+    var highColumn = ColumnDefinition.create({
+      headerCellName: 'High',
+      canAutoResize: true,
+      getCellContent: function(row) {
+        return row.get('high').toFixed(2);
+      }
+    });
+    var lowColumn = ColumnDefinition.create({
+      headerCellName: 'Low',
+      canAutoResize: true,
+      getCellContent: function(row) {
+        return row.get('low').toFixed(2);
+      }
+    });
+    var closeColumn = ColumnDefinition.create({
+      headerCellName: 'Close',
+      canAutoResize: true,
+      getCellContent: function(row) {
+        return row.get('close').toFixed(2);
+      }
+    });
+    return [dateColumn, openColumn, highColumn, lowColumn, closeColumn];
+  }),
+  tableContent: Ember.computed('rowCount', function() {
+    const rowCount = this.get('rowCount');
+    var content = [];
+    var date;
+    for (var i = 0; i < rowCount; i++) {
+      date = randomDate(new Date(2000, 1, 5), new Date(2012, 2, 2));
+      content.pushObject({
+        date: date,
+        open: randomNumber(100) - 50,
+        high: randomNumber(100) - 50,
+        low: randomNumber(100) - 50,
+        close: randomNumber(100) - 50,
+        volume: randomNumber(100) * 1000000
+      });
+    }
+    return content;
+  }),
+  isFullWidthObserver: observer('isFullWidth', function(){
+    const id = $('.ember-table-tables-container').attr('id');
+    const component = View.views[id];
+    Ember.run.scheduleOnce('afterRender', component, component.elementSizeDidChange);
+  }),
+  actions: {
+    toggleWidth() {
+      this.toggleProperty('isFullWidth');
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -24,6 +24,8 @@ Router.map(function() {
   this.route('community-examples');
 
   this.route('license');
+
+  this.route('resize-container-test');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -28,8 +28,9 @@
 {{!-- Main Container --}}
 <div class="container">
   <div class="row">
-
-    {{partial "sub-navigation"}}
+    {{#unless isTestRoute}}
+      {{partial "sub-navigation"}}
+    {{/unless}}
 
     {{outlet}}
   </div>

--- a/tests/dummy/app/templates/resize-container-test.hbs
+++ b/tests/dummy/app/templates/resize-container-test.hbs
@@ -1,0 +1,24 @@
+<h2>Resize Container Test</h2>
+<div class="row">
+  <div class="form-group col-sm-6">
+    <button type="button" class="resize-container-button btn btn-lg btn-default btn-sm" {{action 'toggleWidth'}}>
+      {{if isFullWidth 'Show Half' 'Show Full'}}
+    </button>
+  </div>
+</div>
+<div class="row">
+  <div class="table-container {{if isFullWidth 'col-sm-12' 'col-sm-6'}}">
+    {{ember-table
+      hasFooter=false
+      columnsFillTable=columnsFillTable
+      columns=tableColumns
+      content=tableContent
+      rowHeight=30
+    }}
+  </div>
+</div>
+<style type="text/css">
+  .table-container {
+    height: 400px;
+  }
+</style>


### PR DESCRIPTION
- Added resize-container-test route that shows table that's resized when container size changes
- Added test that shows that scrollbar gets broken when resizing a table
- Added skipped test that shows an unnecessary scrollbar when rendering the table will `columnsFillTable=true`
