### PR TITLE
Don't test with release/beta/canary versions of Ember

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,9 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH


### PR DESCRIPTION
Ember Table will need major refactors to work with Ember 1.13, so
testing against these versions of Ember using `ember-try` doesn't make
sense.

@Addepar/ui2-developers @embersherpa