### PR TITLE
Restructured antiscroll dependency

### DIFF
--- a/blueprints/ember-table/index.js
+++ b/blueprints/ember-table/index.js
@@ -8,7 +8,9 @@ module.exports = {
         // Antiscroll seems to be abandoned by its original authors. We need
         // two things: (1) a version in package.json, and (2) the name of the
         // package must be "antiscroll" to satisfy ember-cli.
-        'name': 'git://github.com/Addepar/antiscroll.git#e0d1538cf4f3fd61c5bedd6168df86d651f125da'
+        'name': 'antiscroll',
+        'source': 'git://github.com/Addepar/antiscroll#e0d1538cf4f3fd61c5bedd6168df86d651f125da',
+        'version': 'e0d1538cf4f3fd61c5bedd6168df86d651f125da'
       },
       {
         'name': 'jquery-mousewheel',


### PR DESCRIPTION
This fixes the following issue:

https://github.com/Addepar/ember-table/issues/369

My bower version is 1.4.1.
