### PR TITLE
Fixed findRow, which always returned null, to use findBy().

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -575,13 +575,7 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   },
 
   findRow: function(content) {
-    // TODO(azirbel): Replace with filter
-    this.get('bodyContent').forEach(function(row) {
-      if (row.get('content') === content) {
-        return row;
-      }
-    });
-    return null;
+    return this.get('bodyContent').findBy('content', content) || null;
   },
 
   rowIndex: function(row) {

--- a/tests/unit/ember-table-test.js
+++ b/tests/unit/ember-table-test.js
@@ -1,0 +1,21 @@
+import { test, moduleForComponent } from 'ember-qunit';
+import Ember from "ember";
+
+moduleForComponent('ember-table', '[Unit] TableComponent', {
+  needs: ['template:components/ember-table']
+});
+
+test("findRow returns the row containing the content", function(assert){
+  var rowA = Ember.Object.create({content: 'A'}),
+      rowB = Ember.Object.create({content: 'B'}),
+      rowC = Ember.Object.create({content: 'C'});
+  var table = this.subject({
+    bodyContent: [
+      rowA,
+      rowB,
+      rowC
+    ]
+  });
+
+  assert.equal(table.findRow('B'), rowB, 'The row was found');
+});


### PR DESCRIPTION
Currently `findRow` always returns null, because the return within the `forEach` closure function only returns from the closure, not from `findRow()`. This PR uses `findBy` to locate the row. It maintains the intended functionality of returning null when the content is not found, rather than undefined as is returned by `findBy`.
