### PR TITLE
Remove problematic CSS !importants

### DIFF
--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -257,10 +257,7 @@
   // This is not scalable for multiple frozen columns
   margin-left: 0;
   margin-right: 0;
-}
-
-.ember-table-left-table-block .ember-table-cell {
-  border-right: 1px solid @table-col-border-color !important;
+  border-right: 1px solid @table-col-border-color;
 }
 
 /* Header Container */

--- a/addon/styles/themes/financial.less
+++ b/addon/styles/themes/financial.less
@@ -54,7 +54,7 @@
   }
 
   .ember-table-left-table-block .ember-table-cell {
-    border-right: 16px solid transparent !important;
+    border-right: 16px solid transparent;
   }
 
   /* Header Container */


### PR DESCRIPTION
While refactoring the CSS for tables in the product, I realized there are some `!important`s in Ember Table itself that could be removed. I only addressed the couple that were directly affecting our overwriting CSS, I didn't do a major overhaul. The ones I removed weren't even really needed in the first place, the selectors were specific enough already so I have no idea why !important was used.

@Addepar/design @cyril-sf @shiller-addepar @embooglement 