### PR TITLE
Table fillup mode

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -292,7 +292,8 @@ export default class EmberTable2 extends Component {
         }
       } else if (tableFillupMode === TABLE_FILLUP_MODE_LAST_COLUMN) {
         // Add all delta to last column
-        columns[columns.length - 1].set('width', columns[columns.length - 1].get('width') + delta);
+        const lastColumn = columns[columns.length - 1];
+        lastColumn.set('width', lastColumn.get('width') + delta);
       }
     }
   }

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -13,6 +13,9 @@ const HEAD_ALIGN_BAR_WIDTH = 5;
 const COLUMN_MODE_STANDARD = 'standard';
 const COLUMN_MODE_FLUID = 'fluid';
 
+const COLUMN_FILLUP_MODE_PROPORTIONAL = 'proportional';
+const COLUMN_FILLUP_MODE_FIRST_COLUMN = 'first_column';
+
 const SELECTION_MODE_NONE = 'none';
 const SELECTION_MODE_SINGLE = 'single';
 const SELECTION_MODE_MULTIPLE = 'multiple';
@@ -54,7 +57,9 @@ export default class EmberTable2 extends Component {
    * does nothing), 'single' (clicking on a row selects it and deselects other rows), and 'multiple'
    * (multiple rows can be selected through ctrl/cmd-click or shift-click).
    */
-  @property selectionMode = 'single';
+  @property selectionMode = SELECTION_MODE_SINGLE;
+
+  @property columnsFillupMode = SELECTION_MODE_SINGLE;
 
   /**
    * A temporary element created when moving column. This element represents the current position
@@ -260,12 +265,14 @@ export default class EmberTable2 extends Component {
     const columns = this.get('columns');
     const tableWidth = this.get('_width');
     const sum = this.get('allColumnWidths');
+    const columnsFillupMode = this.get('columnsFillupMode');
 
-    if (sum < tableWidth - 1) {
+    // if (sum < tableWidth - 1) {
+    if (sum !== tableWidth) {
       let delta = tableWidth - sum - 1;
       // If the table has fixed column, add all width difference to the fixed column. Otherwise,
       // split the diff among all columns.
-      if (this.get('hasFixedColumn')) {
+      if (columnsFillupMode === COLUMN_FILLUP_MODE_FIRST_COLUMN) {
         const [column] = columns;
         column.set('width', column.get('width') + delta);
       } else {

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -13,10 +13,10 @@ const HEAD_ALIGN_BAR_WIDTH = 5;
 const COLUMN_MODE_STANDARD = 'standard';
 const COLUMN_MODE_FLUID = 'fluid';
 
-const TABLE_FILLUP_MODE_NONE = 'none';
-const TABLE_FILLUP_MODE_EQUAL_COLUMN = 'equal_column';
-const TABLE_FILLUP_MODE_FIRST_COLUMN = 'first_column';
-const TABLE_FILLUP_MODE_LAST_COLUMN = 'last_column';
+const TABLE_RESIZE_MODE_NONE = 'none';
+const TABLE_RESIZE_MODE_EQUAL_COLUMN = 'equal_column';
+const TABLE_RESIZE_MODE_FIRST_COLUMN = 'first_column';
+const TABLE_RESIZE_MODE_LAST_COLUMN = 'last_column';
 
 const SELECTION_MODE_NONE = 'none';
 const SELECTION_MODE_SINGLE = 'single';
@@ -69,7 +69,7 @@ export default class EmberTable2 extends Component {
    * 3) "first_column": extra space is added into the first column.
    * 4) "last_column": extra space is added into the last column.
    */
-  @property tableFillupMode = TABLE_FILLUP_MODE_NONE;
+  @property tableResizeMode = TABLE_RESIZE_MODE_NONE;
 
   /**
    * A temporary element created when moving column. This element represents the current position
@@ -274,22 +274,22 @@ export default class EmberTable2 extends Component {
     const columns = this.get('columns');
     const tableWidth = this.get('_width');
     const sum = this.get('allColumnWidths');
-    const tableFillupMode = this.get('tableFillupMode');
+    const tableResizeMode = this.get('tableResizeMode');
 
     if (sum !== tableWidth) {
       const delta = tableWidth - sum - 1;
       // Distribute the delta in pixel among columns according to the table fill up mode.
-      if (tableFillupMode === TABLE_FILLUP_MODE_FIRST_COLUMN) {
+      if (tableResizeMode === TABLE_RESIZE_MODE_FIRST_COLUMN) {
         const [column] = columns;
         column.set('width', column.get('width') + delta);
-      } else if (tableFillupMode === TABLE_FILLUP_MODE_EQUAL_COLUMN) {
+      } else if (tableResizeMode === TABLE_RESIZE_MODE_EQUAL_COLUMN) {
         // Split delta by their proportion.
         const columnDelta = delta / columns.length;
         for (let i = 0; i < columns.length; i++) {
           const column = columns[i];
           column.set('width', Math.min(column.get('width') + columnDelta), column.get('minWidth'));
         }
-      } else if (tableFillupMode === TABLE_FILLUP_MODE_LAST_COLUMN) {
+      } else if (tableResizeMode === TABLE_RESIZE_MODE_LAST_COLUMN) {
         // Add all delta to last column
         const lastColumn = columns[columns.length - 1];
         lastColumn.set('width', lastColumn.get('width') + delta);

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -276,7 +276,7 @@ export default class EmberTable2 extends Component {
     const columnsFillupMode = this.get('columnsFillupMode');
 
     if (sum !== tableWidth) {
-      let delta = tableWidth - sum - 1;
+      const delta = tableWidth - sum - 1;
       // If the table has fixed column, add all width difference to the fixed column. Otherwise,
       // split the diff among all columns.
       if (columnsFillupMode === COLUMN_FILLUP_MODE_FIRST_COLUMN) {
@@ -284,7 +284,7 @@ export default class EmberTable2 extends Component {
         column.set('width', column.get('width') + delta);
       } else if (columnsFillupMode === COLUMN_FILLUP_MODE_PROPORTIONAL) {
         // Split delta equally among columns.
-        let columnDelta = delta / columns.length;
+        const columnDelta = delta / columns.length;
         for (let i = 0; i < columns.length; i++) {
           const column = columns[i];
           column.set('width', Math.min(column.get('width') + columnDelta), column.get('minWidth'));

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -278,8 +278,7 @@ export default class EmberTable2 extends Component {
 
     if (sum !== tableWidth) {
       const delta = tableWidth - sum - 1;
-      // If the table has fixed column, add all width difference to the fixed column. Otherwise,
-      // split the diff among all columns.
+      // Distribute the delta in pixel among columns according to the table fill up mode.
       if (tableFillupMode === TABLE_FILLUP_MODE_FIRST_COLUMN) {
         const [column] = columns;
         column.set('width', column.get('width') + delta);

--- a/tests/dummy/app/controllers/simple.js
+++ b/tests/dummy/app/controllers/simple.js
@@ -1,0 +1,41 @@
+import Controller from '@ember/controller';
+import ColumnDefinition from '../models/column-definition';
+import { computed } from 'ember-decorators/object';
+import { A as emberA } from '@ember/array';
+
+const COLUMN_COUNT = 3;
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+export default class SimpleController extends Controller {
+  @computed
+  rows() {
+    const rows = emberA();
+    for (let i = 0; i < 1000; i++) {
+      const obj = {};
+      for (let j = 0; j < COLUMN_COUNT; j++) {
+        obj[ALPHABET[j % 26]] = ALPHABET[j % 26];
+      }
+      rows.pushObject(obj);
+    }
+
+    return rows;
+  }
+
+  @computed
+  columns() {
+    const columns = emberA();
+    const columnWidth = 180;
+
+    for (let j = 0; j < COLUMN_COUNT; j++) {
+      columns.pushObject(ColumnDefinition.create({
+        columnName: `Col ${ALPHABET[j % 26]}`,
+        valuePath: ALPHABET[j % 26],
+        width: columnWidth,
+        isResizable: true,
+        isReorderable: true
+      }));
+    }
+
+    return columns;
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,7 @@ const Router = EmberRouter.extend({
 
 Router.map(function() {
   this.route('demo');
+  this.route('simple');
   this.route('custom-component');
   this.route('addepar');
 });

--- a/tests/dummy/app/templates/simple.hbs
+++ b/tests/dummy/app/templates/simple.hbs
@@ -1,0 +1,17 @@
+<div class="demo-container">
+  {{#ember-table
+    rows=rows
+    columns=columns
+    columnsFillupMode="proportional"
+    as |t|
+  }}
+    {{#ember-table-row
+      row=t
+
+      as |cell|
+    }}
+
+      {{cell.value}}
+    {{/ember-table-row}}
+  {{/ember-table}}
+</div>

--- a/tests/dummy/app/templates/simple.hbs
+++ b/tests/dummy/app/templates/simple.hbs
@@ -2,7 +2,7 @@
   {{#ember-table
     rows=rows
     columns=columns
-    columnsFillupMode="proportional"
+    tableFillupMode="equal_column"
     as |t|
   }}
     {{#ember-table-row

--- a/tests/dummy/app/templates/simple.hbs
+++ b/tests/dummy/app/templates/simple.hbs
@@ -2,7 +2,7 @@
   {{#ember-table
     rows=rows
     columns=columns
-    tableFillupMode="equal_column"
+    tableResizeMode="equal_column"
     as |t|
   }}
     {{#ember-table-row

--- a/tests/dummy/app/templates/simple.hbs
+++ b/tests/dummy/app/templates/simple.hbs
@@ -7,10 +7,8 @@
   }}
     {{#ember-table-row
       row=t
-
       as |cell|
     }}
-
       {{cell.value}}
     {{/ember-table-row}}
   {{/ember-table}}

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -107,7 +107,7 @@ export const fullTable = hbs`
   </div>
 `;
 
-export async function setupFullTable(testContext, tableOptions = DEFAULT_TABLE_OPTIONS,
+export function setupFullTable(testContext, tableOptions = DEFAULT_TABLE_OPTIONS,
   columnOptions = DEFAULT_FULL_TABLE_COLUMN_OPTIONS, rowComponent = 'ember-table-row') {
   const rowCount = 20;
   const columnCount = 10;
@@ -122,5 +122,5 @@ export async function setupFullTable(testContext, tableOptions = DEFAULT_TABLE_O
   testContext.set('tableRows', generateRows(rowCount, columnCount));
   testContext.set('rowComponent', rowComponent);
   testContext.render(fullTable);
-  await waitForRender();
+  return waitForRender();
 }

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -14,6 +14,11 @@ export const DEFAULT_FULL_TABLE_COLUMN_OPTIONS = {
   isReorderable: true
 };
 
+export const DEFAULT_ROW_COLUMN_COUNT = {
+  rowCount: 20,
+  columnCount: 10
+};
+
 export function generateRows(rowCount, columnCount) {
   const arr = emberA();
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -107,17 +112,20 @@ export const fullTable = hbs`
   </div>
 `;
 
-export function setupFullTable(testContext, tableOptions = DEFAULT_TABLE_OPTIONS,
-  columnOptions = DEFAULT_FULL_TABLE_COLUMN_OPTIONS, rowComponent = 'ember-table-row') {
-  const rowCount = 20;
-  const columnCount = 10;
-
+export function setupFullTable(
+    testContext,
+    tableOptions = DEFAULT_TABLE_OPTIONS,
+    columnOptions = DEFAULT_FULL_TABLE_COLUMN_OPTIONS,
+    rowColumnCount = DEFAULT_ROW_COLUMN_COUNT,
+    rowComponent = 'ember-table-row'
+  ) {
   for (const property in tableOptions) {
     if (tableOptions.hasOwnProperty(property)) {
       testContext.set(property, tableOptions[property]);
     }
   }
 
+  const { rowCount, columnCount } = rowColumnCount;
   testContext.set('tableColumns', generateColumns(columnCount, columnOptions));
   testContext.set('tableRows', generateRows(rowCount, columnCount));
   testContext.set('rowComponent', rowComponent);

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -5,7 +5,8 @@ import ColumnDefinition from 'ember-table/models/column-definition';
 
 export const DEFAULT_TABLE_OPTIONS = {
   numFixedColumns: 1,
-  columnMode: 'standard'
+  columnMode: 'standard',
+  columnsFillupMode: 'none'
 };
 
 export const DEFAULT_FULL_TABLE_COLUMN_OPTIONS = {
@@ -90,6 +91,7 @@ export const fullTable = hbs`
       rows=tableRows
       numFixedColumns=numFixedColumns
       columnMode=columnMode
+      columnsFillupMode=columnsFillupMode
 
       as |r|
     }}

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -19,6 +19,8 @@ export const DEFAULT_ROW_COLUMN_COUNT = {
   columnCount: 10
 };
 
+export const DEFAULT_COLUMN_WIDTH = 180;
+
 export function generateRows(rowCount, columnCount) {
   const arr = emberA();
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -39,7 +41,7 @@ export function generateRows(rowCount, columnCount) {
 export function generateColumns(columnCount, columnOptions) {
   const arr = emberA();
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-  const columnWidth = 180;
+  const columnWidth = DEFAULT_COLUMN_WIDTH;
 
   arr.pushObject(ColumnDefinition.create({
     columnName: 'Column id',

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -6,7 +6,7 @@ import ColumnDefinition from 'ember-table/models/column-definition';
 export const DEFAULT_TABLE_OPTIONS = {
   numFixedColumns: 1,
   columnMode: 'standard',
-  columnsFillupMode: 'none'
+  tableFillupMode: 'none'
 };
 
 export const DEFAULT_FULL_TABLE_COLUMN_OPTIONS = {
@@ -91,7 +91,7 @@ export const fullTable = hbs`
       rows=tableRows
       numFixedColumns=numFixedColumns
       columnMode=columnMode
-      columnsFillupMode=columnsFillupMode
+      tableFillupMode=tableFillupMode
 
       as |r|
     }}

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -6,7 +6,7 @@ import ColumnDefinition from 'ember-table/models/column-definition';
 export const DEFAULT_TABLE_OPTIONS = {
   numFixedColumns: 1,
   columnMode: 'standard',
-  tableFillupMode: 'none'
+  tableResizeMode: 'none'
 };
 
 export const DEFAULT_FULL_TABLE_COLUMN_OPTIONS = {
@@ -98,7 +98,7 @@ export const fullTable = hbs`
       rows=tableRows
       numFixedColumns=numFixedColumns
       columnMode=columnMode
-      tableFillupMode=tableFillupMode
+      tableResizeMode=tableResizeMode
 
       as |r|
     }}

--- a/tests/integration/components/ember-table-test.js
+++ b/tests/integration/components/ember-table-test.js
@@ -50,7 +50,7 @@ for (const customHeader of customHeaderTests) {
   // Test resizing column
   test(`Test ${headerTest}resizing column`, async function(assert) {
     const tableOptions = { headerComponent: customHeader };
-    setupFullTable(this, merge(tableOptions, DEFAULT_FULL_TABLE_COLUMN_OPTIONS));
+    await setupFullTable(this, merge(tableOptions, DEFAULT_FULL_TABLE_COLUMN_OPTIONS));
 
     let originalWidth = tableHelpers.getHeaderElement(2).offsetWidth;
     await tableHelpers.resizeColumn(2, 30);
@@ -67,7 +67,7 @@ for (const customHeader of customHeaderTests) {
   // Test resizing fluid column
   test(`Test ${headerTest}resizing fluid column`, async function(assert) {
     const tableOptions = { headerComponent: customHeader, columnMode: 'fluid' };
-    setupFullTable(this, merge(tableOptions, DEFAULT_FULL_TABLE_COLUMN_OPTIONS));
+    await setupFullTable(this, merge(tableOptions, DEFAULT_FULL_TABLE_COLUMN_OPTIONS));
 
     const originalWidth = tableHelpers.getHeaderElement(2).offsetWidth;
     await tableHelpers.resizeColumn(2, 30);
@@ -79,7 +79,7 @@ for (const customHeader of customHeaderTests) {
 
   // Reodering columns with fixed column
   test(`Test ${headerTest}reordering columns with fixed column`, async function(assert) {
-    setupFullTable(this);
+    await setupFullTable(this);
 
     // Case 1: Try to swap column A with fixed column. The table should prevent that action.
     await tableHelpers.moveTableColumn(2, -1);
@@ -98,7 +98,7 @@ for (const customHeader of customHeaderTests) {
 
   // Reodering columns without fixed column
   test(`Test ${headerTest}reordering columns without fixed column`, async function(assert) {
-    setupFullTable(this, {}, {
+    await setupFullTable(this, {}, {
       isReorderable: true,
       headerComponent: customHeader
     });
@@ -114,20 +114,26 @@ for (const customHeader of customHeaderTests) {
       'First column does not change');
   });
 
-  test(`Test ${headerTest}column fill up proportional mode`, async function(assert) {
-    setupFullTable(this, { columnsFillupMode: "proportional" }, { headerComponent: customHeader });
-
-    await scrollTo(find('[data-test-body-container]'), 0, 10);
+  test(`Test ${headerTest}column fill up - proportional mode`, async function(assert) {
+    await setupFullTable(this, { columnsFillupMode: "proportional" }, { headerComponent: customHeader });
 
     for (let i = 1; i <= 10; i++) {
       assert.ok(Math.abs(tableHelpers.getHeaderElement(i).offsetWidth - 128) <= 2,
         'Table header have same width in proportional fill up mode.');
     }
   });
+
+  test(`Test ${headerTest}column fill up - none mode`, async function(assert) {
+    await setupFullTable(this, {}, { headerComponent: customHeader });
+
+    for (let i = 1; i <= 10; i++) {
+      assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, 180,
+        'Table header have same width in proportional fill up mode.');
+    }
+  });
 }
 
 test('Test custom row', async function(assert) {
-  setupFullTable(this, {}, {}, 'custom-row');
-  await waitForRender();
+  await setupFullTable(this, {}, {}, 'custom-row');
   assert.ok(find('tbody tr').className.indexOf('custom-row') >= 0, 'Table has custom row');
 });

--- a/tests/integration/components/ember-table-test.js
+++ b/tests/integration/components/ember-table-test.js
@@ -5,7 +5,8 @@ import {
   generateColumns,
   generateRows,
   setupFullTable,
-  DEFAULT_FULL_TABLE_COLUMN_OPTIONS
+  DEFAULT_FULL_TABLE_COLUMN_OPTIONS,
+  DEFAULT_ROW_COLUMN_COUNT
 } from '../../helpers/test-scenarios';
 import waitForRender from 'dummy/tests/helpers/wait-for-render';
 import {
@@ -134,9 +135,43 @@ for (const customHeader of customHeaderTests) {
         'Table header have same width in proportional fill up mode.');
     }
   });
+
+  test(`Test ${headerTest}column fill up - first column mode`, async function(assert) {
+    await setupFullTable(this, { tableFillupMode: 'first_column' },
+      { headerComponent: customHeader }, { rowCount: 20, columnCount: 3 });
+
+    const headerCount = findAll('.et-thead tr th').length;
+    const tableWidth = find('.et-thead').offsetWidth;
+    const firstColumnWidth = tableHelpers.getHeaderElement(1).offsetWidth;
+
+    assert.ok(
+      Math.abs(tableWidth - firstColumnWidth - 180 * (headerCount - 1)) <= 1,
+      'First column takes extra sapce in first column fill up mode.');
+    for (let i = 2; i <= headerCount; i++) {
+      assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, 180,
+        'Other columns keep same width in first column fill up mode.');
+    }
+  });
+
+  test(`Test ${headerTest}column fill up - last column mode`, async function(assert) {
+    await setupFullTable(this, { tableFillupMode: 'last_column' },
+      { headerComponent: customHeader }, { rowCount: 20, columnCount: 3 });
+
+    const headerCount = findAll('.et-thead tr th').length;
+    const tableWidth = find('.et-thead').offsetWidth;
+    const lastColumnWidth = tableHelpers.getHeaderElement(headerCount).offsetWidth;
+
+    assert.ok(
+      Math.abs(tableWidth - lastColumnWidth - 180 * (headerCount - 1)) <= 1,
+      'Last column takes extra sapce in last column fill up mode.');
+    for (let i = 1; i < headerCount; i++) {
+      assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, 180,
+        'Other columns keep same width in last column fill up mode.');
+    }
+  });
 }
 
 test('Test custom row', async function(assert) {
-  await setupFullTable(this, {}, {}, 'custom-row');
+  await setupFullTable(this, {}, {}, DEFAULT_ROW_COLUMN_COUNT, 'custom-row');
   assert.ok(find('tbody tr').className.indexOf('custom-row') >= 0, 'Table has custom row');
 });

--- a/tests/integration/components/ember-table-test.js
+++ b/tests/integration/components/ember-table-test.js
@@ -115,7 +115,7 @@ for (const customHeader of customHeaderTests) {
   });
 
   test(`Test ${headerTest}column fill up - proportional mode`, async function(assert) {
-    await setupFullTable(this, { columnsFillupMode: "proportional" }, { headerComponent: customHeader });
+    await setupFullTable(this, { columnsFillupMode: 'proportional' }, { headerComponent: customHeader });
 
     for (let i = 1; i <= 10; i++) {
       assert.ok(Math.abs(tableHelpers.getHeaderElement(i).offsetWidth - 128) <= 2,

--- a/tests/integration/components/ember-table-test.js
+++ b/tests/integration/components/ember-table-test.js
@@ -117,8 +117,10 @@ for (const customHeader of customHeaderTests) {
   test(`Test ${headerTest}column fill up - proportional mode`, async function(assert) {
     await setupFullTable(this, { columnsFillupMode: 'proportional' }, { headerComponent: customHeader });
 
-    for (let i = 1; i <= 10; i++) {
-      assert.ok(Math.abs(tableHelpers.getHeaderElement(i).offsetWidth - 128) <= 2,
+    const headerCount = findAll('.et-thead tr th').length;
+    const expectedWidth = find('.et-thead tr').offsetWidth / headerCount;
+    for (let i = 1; i <= headerCount; i++) {
+      assert.ok(Math.abs(tableHelpers.getHeaderElement(i).offsetWidth - expectedWidth) <= 1,
         'Table header have same width in proportional fill up mode.');
     }
   });
@@ -126,7 +128,8 @@ for (const customHeader of customHeaderTests) {
   test(`Test ${headerTest}column fill up - none mode`, async function(assert) {
     await setupFullTable(this, {}, { headerComponent: customHeader });
 
-    for (let i = 1; i <= 10; i++) {
+    const headerCount = findAll('.et-thead tr th').length;
+    for (let i = 1; i <= headerCount; i++) {
       assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, 180,
         'Table header have same width in proportional fill up mode.');
     }

--- a/tests/integration/components/ember-table-test.js
+++ b/tests/integration/components/ember-table-test.js
@@ -116,29 +116,29 @@ for (const customHeader of customHeaderTests) {
       'First column does not change');
   });
 
-  test(`Test ${headerTest}column fill up - equal column mode`, async function(assert) {
-    await setupFullTable(this, { tableFillupMode: 'equal_column' }, { headerComponent: customHeader });
+  test(`Test ${headerTest}column resize - equal column mode`, async function(assert) {
+    await setupFullTable(this, { tableResizeMode: 'equal_column' }, { headerComponent: customHeader });
 
     const headerCount = findAll('.et-thead tr th').length;
     const expectedWidth = find('.et-thead tr').offsetWidth / headerCount;
     for (let i = 1; i <= headerCount; i++) {
       assert.ok(Math.abs(tableHelpers.getHeaderElement(i).offsetWidth - expectedWidth) <= 1,
-        'Table header have same width in proportional fill up mode.');
+        'Table header have same width in equal resize mode.');
     }
   });
 
-  test(`Test ${headerTest}column fill up - none mode`, async function(assert) {
-    await setupFullTable(this, { tableFillupMode: 'none' }, { headerComponent: customHeader });
+  test(`Test ${headerTest}column resize - none mode`, async function(assert) {
+    await setupFullTable(this, { tableResizeMode: 'none' }, { headerComponent: customHeader });
 
     const headerCount = findAll('.et-thead tr th').length;
     for (let i = 1; i <= headerCount; i++) {
       assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, DEFAULT_COLUMN_WIDTH,
-        'Table header have same width in none fill up mode.');
+        'Table header keeps origial width in none resize mode.');
     }
   });
 
-  test(`Test ${headerTest}column fill up - first column mode`, async function(assert) {
-    await setupFullTable(this, { tableFillupMode: 'first_column' },
+  test(`Test ${headerTest}column resize - first column mode`, async function(assert) {
+    await setupFullTable(this, { tableResizeMode: 'first_column' },
       { headerComponent: customHeader }, { rowCount: 20, columnCount: 3 });
 
     const headerCount = findAll('.et-thead tr th').length;
@@ -147,15 +147,15 @@ for (const customHeader of customHeaderTests) {
 
     assert.ok(
       Math.abs(tableWidth - firstColumnWidth - DEFAULT_COLUMN_WIDTH * (headerCount - 1)) <= 1,
-      'First column takes extra space in first column fill up mode.');
+      'First column takes extra space in first column resize mode.');
     for (let i = 2; i <= headerCount; i++) {
       assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, DEFAULT_COLUMN_WIDTH,
-        'Other columns keep same width in first column fill up mode.');
+        'Other columns keep same width in first column resize mode.');
     }
   });
 
-  test(`Test ${headerTest}column fill up - last column mode`, async function(assert) {
-    await setupFullTable(this, { tableFillupMode: 'last_column' },
+  test(`Test ${headerTest}column resize - last column mode`, async function(assert) {
+    await setupFullTable(this, { tableResizeMode: 'last_column' },
       { headerComponent: customHeader }, { rowCount: 20, columnCount: 3 });
 
     const headerCount = findAll('.et-thead tr th').length;
@@ -164,10 +164,10 @@ for (const customHeader of customHeaderTests) {
 
     assert.ok(
       Math.abs(tableWidth - lastColumnWidth - DEFAULT_COLUMN_WIDTH * (headerCount - 1)) <= 1,
-      'Last column takes extra space in last column fill up mode.');
+      'Last column takes extra space in last column resize mode.');
     for (let i = 1; i < headerCount; i++) {
       assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, DEFAULT_COLUMN_WIDTH,
-        'Other columns keep same width in last column fill up mode.');
+        'Other columns keep same width in last column resize mode.');
     }
   });
 }

--- a/tests/integration/components/ember-table-test.js
+++ b/tests/integration/components/ember-table-test.js
@@ -6,7 +6,8 @@ import {
   generateRows,
   setupFullTable,
   DEFAULT_FULL_TABLE_COLUMN_OPTIONS,
-  DEFAULT_ROW_COLUMN_COUNT
+  DEFAULT_ROW_COLUMN_COUNT,
+  DEFAULT_COLUMN_WIDTH
 } from '../../helpers/test-scenarios';
 import waitForRender from 'dummy/tests/helpers/wait-for-render';
 import {
@@ -127,12 +128,12 @@ for (const customHeader of customHeaderTests) {
   });
 
   test(`Test ${headerTest}column fill up - none mode`, async function(assert) {
-    await setupFullTable(this, {}, { headerComponent: customHeader });
+    await setupFullTable(this, { tableFillupMode: 'none' }, { headerComponent: customHeader });
 
     const headerCount = findAll('.et-thead tr th').length;
     for (let i = 1; i <= headerCount; i++) {
-      assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, 180,
-        'Table header have same width in proportional fill up mode.');
+      assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, DEFAULT_COLUMN_WIDTH,
+        'Table header have same width in none fill up mode.');
     }
   });
 
@@ -145,10 +146,10 @@ for (const customHeader of customHeaderTests) {
     const firstColumnWidth = tableHelpers.getHeaderElement(1).offsetWidth;
 
     assert.ok(
-      Math.abs(tableWidth - firstColumnWidth - 180 * (headerCount - 1)) <= 1,
-      'First column takes extra sapce in first column fill up mode.');
+      Math.abs(tableWidth - firstColumnWidth - DEFAULT_COLUMN_WIDTH * (headerCount - 1)) <= 1,
+      'First column takes extra space in first column fill up mode.');
     for (let i = 2; i <= headerCount; i++) {
-      assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, 180,
+      assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, DEFAULT_COLUMN_WIDTH,
         'Other columns keep same width in first column fill up mode.');
     }
   });
@@ -162,10 +163,10 @@ for (const customHeader of customHeaderTests) {
     const lastColumnWidth = tableHelpers.getHeaderElement(headerCount).offsetWidth;
 
     assert.ok(
-      Math.abs(tableWidth - lastColumnWidth - 180 * (headerCount - 1)) <= 1,
-      'Last column takes extra sapce in last column fill up mode.');
+      Math.abs(tableWidth - lastColumnWidth - DEFAULT_COLUMN_WIDTH * (headerCount - 1)) <= 1,
+      'Last column takes extra space in last column fill up mode.');
     for (let i = 1; i < headerCount; i++) {
-      assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, 180,
+      assert.equal(tableHelpers.getHeaderElement(i).offsetWidth, DEFAULT_COLUMN_WIDTH,
         'Other columns keep same width in last column fill up mode.');
     }
   });

--- a/tests/integration/components/ember-table-test.js
+++ b/tests/integration/components/ember-table-test.js
@@ -114,8 +114,8 @@ for (const customHeader of customHeaderTests) {
       'First column does not change');
   });
 
-  test(`Test ${headerTest}column fill up - proportional mode`, async function(assert) {
-    await setupFullTable(this, { columnsFillupMode: 'proportional' }, { headerComponent: customHeader });
+  test(`Test ${headerTest}column fill up - equal column mode`, async function(assert) {
+    await setupFullTable(this, { tableFillupMode: 'equal_column' }, { headerComponent: customHeader });
 
     const headerCount = findAll('.et-thead tr th').length;
     const expectedWidth = find('.et-thead tr').offsetWidth / headerCount;

--- a/tests/integration/components/ember-table-test.js
+++ b/tests/integration/components/ember-table-test.js
@@ -113,6 +113,17 @@ for (const customHeader of customHeaderTests) {
       customHeader ? 'Custom header Col A' : 'Col A',
       'First column does not change');
   });
+
+  test(`Test ${headerTest}column fill up proportional mode`, async function(assert) {
+    setupFullTable(this, { columnsFillupMode: "proportional" }, { headerComponent: customHeader });
+
+    await scrollTo(find('[data-test-body-container]'), 0, 10);
+
+    for (let i = 1; i <= 10; i++) {
+      assert.ok(Math.abs(tableHelpers.getHeaderElement(i).offsetWidth - 128) <= 2,
+        'Table header have same width in proportional fill up mode.');
+    }
+  });
 }
 
 test('Test custom row', async function(assert) {


### PR DESCRIPTION
Add table fill up mode for table when total columns width does not match table width. The extra space can go to either the first column or be distributed equally among all columns.