### PR TITLE
Fix collapse bug

### DIFF
--- a/addon/utils/tree-node.js
+++ b/addon/utils/tree-node.js
@@ -27,11 +27,6 @@ export default class TreeNode {
   @property previous = null;
 
   /**
-   * Original previous node when the tree is fully expanded.
-   */
-  @property originalPrevious = null;
-
-  /**
    * Total number of node in this subtree (including this node).
    */
   @property nodeCount = null;
@@ -65,7 +60,6 @@ export default class TreeNode {
 
     if (node != null) {
       node.previous = this;
-      node.originalPrevious = this;
     }
   }
 

--- a/tests/helpers/tree-generator.js
+++ b/tests/helpers/tree-generator.js
@@ -1,13 +1,13 @@
 import TreeNode from 'dummy/utils/tree-node';
 
-const generateBasicRoot = () => {
+const generateBasicRoot = (childCount = 10) => {
   const topRow = new TreeNode(null, 'Top Row');
 
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < childCount; i++) {
     const header = new TreeNode(topRow, `Header ${i}`);
-    for (let j = 0; j < 10; j++) {
+    for (let j = 0; j < childCount; j++) {
       const group = new TreeNode(header, `Group ${j}`);
-      for (let k = 0; k < 10; k++) {
+      for (let k = 0; k < childCount; k++) {
         group.addChild(new TreeNode(group, `Leaf ${k}`));
       }
 

--- a/tests/unit/utils/linked-list-tree-test.js
+++ b/tests/unit/utils/linked-list-tree-test.js
@@ -56,3 +56,23 @@ test('Test expanding and collapsing rows', function(assert) {
   assert.equal(node.value, 'Group 2');
   assert.equal(tree.get('length'), 1111);
 });
+
+test('Previous node is correct after several rows collapse & expansion.', function(assert) {
+  const tree = new LinkedListTree(generateBasicRoot(3));
+
+  // Collapse Top Row -> Header 0 -> Group 2
+  tree.collapseNode(tree.objectAt(10));
+
+  // Collapse Top Row -> Header 0
+  tree.collapseNode(tree.objectAt(1));
+
+  // Expand Top Row -> Header 0
+  tree.expand(tree.objectAt(1));
+
+  // Move to pointer to the row 36
+  tree.objectAt(0);
+  tree.objectAt(36);
+
+  assert.equal(tree.objectAt(0).value, 'Top Row');
+  assert.equal(tree.objectAt(1).value, 'Header 0');
+});


### PR DESCRIPTION
Repro steps: 

1) Collapse Group 2
![screen1](https://user-images.githubusercontent.com/11281370/32522216-4eabf3d0-c3cb-11e7-8a06-cea408968311.png)

2) collapse Header 0
![screen2](https://user-images.githubusercontent.com/11281370/32522225-55c9cf98-c3cb-11e7-83b5-ae9768a32f23.png)

3) Expand Header 0...

The row order is not in correct order. 

This bug happens because the previous node of `Header 1` is updated twice but we have only 1 variable to store previous node. Correct solution is to have an array to store previous nodes. Previous node could be pushed or popped from array when row is collapsed/expanded. 