### PR TITLE
Pass list of arguments instead of the first arguments.

### DIFF
--- a/addon/components/ember-table-header.js
+++ b/addon/components/ember-table-header.js
@@ -147,7 +147,7 @@ export default class EmberTableHeader extends EmberTableBaseCell {
   }
 
   @action
-  onHeaderEvent(data) {
-    this.sendAction('onHeaderEvent', data);
+  onHeaderEvent() {
+    this.sendAction('onHeaderEvent', ...arguments);
   }
 }

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -541,7 +541,7 @@ export default class EmberTable2 extends Component {
   }
 
   @action
-  onHeaderEvent(data) {
-    this.sendAction('onHeaderEvent', data);
+  onHeaderEvent() {
+    this.sendAction('onHeaderEvent', ...arguments);
   }
 }


### PR DESCRIPTION
The `onHeaderEvent` API currently passes only 1 argument to the parent component/controller. It should pass the list of all object instead. 