### PR TITLE
Add renderAll property

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -129,6 +129,12 @@ export default class EmberTable2 extends Component {
    */
   @property _width = 0;
 
+  /**
+   * A variable that tells vertical-collection if all table rows should be rendered. If true,
+   * occlusion is disabled and there may be significant performance penalties.
+   */
+  @property renderAll = false;
+
   @property lastSelectedIndex = -1;
 
   @computed('numFixedColumns')

--- a/addon/templates/components/ember-table.hbs
+++ b/addon/templates/components/ember-table.hbs
@@ -44,7 +44,7 @@
         estimateHeight=estimateRowHeight
         staticHeight=staticHeight
         containerSelector=".et-tbody-container"
-
+        renderAll=renderAll
         as |rowValue rowIndex|
       }}
         {{yield (hash


### PR DESCRIPTION
Add the `renderAll` property to `ember-table.hbs` and `ember-table.js` so occlusion can be disabled in the `vertical-collection` component. This allows all table content to be rendered in the DOM so it can be printed. By default, lazy rendering with `vertical-collection` only adds a sub-set of table rows to the DOM.

`renderAll=true` renders all table content to the DOM.
`renderAll=false` (the default) uses `vertical-collection` to occlude table data that is not visible.
