### PR TITLE
ES getter function with @computed to avoid DEPRECATION warnings

### DIFF
--- a/addon/components/ember-table-footer.js
+++ b/addon/components/ember-table-footer.js
@@ -10,7 +10,7 @@ export default class EmberTableFooter extends EmberTableBaseCell {
   @property classNameBindings = ['isFixed::et-tf'];
 
   @computed('column.valuePath', 'rowValue')
-  footerValue() {
+  get footerValue() {
     let valuePath = this.get('column.valuePath');
     let rowValue = this.get('rowValue');
 

--- a/addon/components/ember-table-header.js
+++ b/addon/components/ember-table-header.js
@@ -52,7 +52,7 @@ export default class EmberTableHeader extends EmberTableBaseCell {
   }
 
   @computed('column.subcolumns.length')
-  columnSpan() {
+  get columnSpan() {
     let subcolumnsLength = get(this, 'column.subcolumns.length');
     if (isNone(subcolumnsLength) || subcolumnsLength <= 1) {
       return 1;
@@ -62,7 +62,7 @@ export default class EmberTableHeader extends EmberTableBaseCell {
   }
 
   @computed('tableHasSubcolumns', 'column.subcolumns.length')
-  rowSpan() {
+  get rowSpan() {
     if (this.get('tableHasSubcolumns') !== true) {
       return 1;
     }

--- a/addon/components/ember-table-row.js
+++ b/addon/components/ember-table-row.js
@@ -42,7 +42,7 @@ export default class EmberTableRow extends Component {
   }
 
   @computed('columns.[]')
-  cells() {
+  get cells() {
     let _rowComponent = this;
     let _cache = this.get('cellCache');
     let columns = this.get('columns');
@@ -79,7 +79,7 @@ export default class EmberTableRow extends Component {
   }
 
   @computed('row.api.staticRowHeight')
-  style() {
+  get style() {
     let staticRowHeight = this.get('row.api.staticRowHeight');
     if (!isNone(staticRowHeight)) {
       return `height: ${staticRowHeight}px;`;

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -331,12 +331,12 @@ export default class EmberTable2 extends Component {
   }
 
   @computed('hasFixedColumn', 'bodyColumns.firstObject.width')
-  fixedColumnWidth() {
+  get fixedColumnWidth() {
     return this.get('hasFixedColumn') === true ? this.get('bodyColumns.firstObject.width') : 0;
   }
 
   @computed('columns.@each.subcolumns')
-  hasSubcolumns() {
+  get hasSubcolumns() {
     let columns = this.get('columns');
     for (let i = 0; i < get(columns, 'length'); i++) {
       let subcolumns = get(columns[i], 'subcolumns');
@@ -353,7 +353,7 @@ export default class EmberTable2 extends Component {
    * concatentation of all subcolumns.
    */
   @computed('hasSubcolumns', 'columns.@each.subcolumns')
-  bodyColumns() {
+  get bodyColumns() {
     if (this.get('hasSubcolumns') !== true) {
       return this.get('columns');
     }
@@ -379,7 +379,7 @@ export default class EmberTable2 extends Component {
     'bodyColumns.firstObject.width',
     'allColumnWidths',
     '_width'
-  ) horizontalScrollWrapperStyle() {
+  ) get horizontalScrollWrapperStyle() {
     let columns = this.get('bodyColumns');
     let visibility = this.get('_width') < this.get('allColumnWidths') ? 'visibility' : 'hidden';
     let left = this.get('hasFixedColumn') ? get(columns[0], 'width') : 0;
@@ -392,7 +392,7 @@ export default class EmberTable2 extends Component {
    * table's width and the table and the element can share same scrolling.
    */
   @computed('hasFixedColumn', 'bodyColumns.@each.width')
-  horizontalScrollStyle() {
+  get horizontalScrollStyle() {
     let style = '';
     let hasFixedColumn = this.get('hasFixedColumn');
     let columns = this.get('bodyColumns');
@@ -407,7 +407,7 @@ export default class EmberTable2 extends Component {
   }
 
   @computed('columns.@each.width')
-  allColumnWidths() {
+  get allColumnWidths() {
     let columns = this.get('columns');
     let sum = 0;
     for (let i = 0; i < columns.length; i++) {
@@ -426,7 +426,7 @@ export default class EmberTable2 extends Component {
     'estimateRowHeight',
     'staticHeight'
   )
-  api() {
+  get api() {
     let staticHeight = this.get('staticHeight');
     let staticRowHeight = null;
     if (staticHeight === true) {

--- a/tests/dummy/app/components/tree-table-grouping-cell.js
+++ b/tests/dummy/app/components/tree-table-grouping-cell.js
@@ -9,7 +9,7 @@ export default class TreeTableGroupingCell extends Component {
   @property attributeBindings = ['style:style'];
 
   @computed('cell.row.value')
-  style() {
+  get style() {
     let rowNode = this.get('cell.row.value');
     return htmlSafe(`padding-left: ${rowNode.depth * 20}px;`);
   }

--- a/tests/dummy/app/controllers/simple.js
+++ b/tests/dummy/app/controllers/simple.js
@@ -8,7 +8,7 @@ const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 export default class SimpleController extends Controller {
   @computed
-  rows() {
+  get rows() {
     let rows = emberA();
     for (let i = 0; i < 1000; i++) {
       let obj = {};
@@ -22,7 +22,7 @@ export default class SimpleController extends Controller {
   }
 
   @computed
-  columns() {
+  get columns() {
     let columns = emberA();
     let columnWidth = 180;
 


### PR DESCRIPTION
Simple change in .js files to avoid deprecation warnings from decorators.js

deprecate.js:115 DEPRECATION: using @computed with functions directly will be removed in future versions, using ES getter/setter functions instead [deprecation id: macro-computed-deprecated]