### PR TITLE
Put resize sensor code in a run loop as resize sensor uses RAF

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -175,8 +175,10 @@ export default class EmberTable2 extends Component {
     });
 
     this._tableResizeSensor = new ResizeSensor(this.element, () => {
-      this.set('_width', this.element.offsetWidth);
-      this.fillupColumn();
+      run(() => {
+        this.set('_width', this.element.offsetWidth);
+        this.fillupColumn();
+      });
     });
   }
 


### PR DESCRIPTION
Under the hood, the `ResizeSensor` is calling the callback in a RAF. This breaks tests when table size changes. To fix this, we put the callback in a `run` loop. 

Further work to use `ember-resize-sensor` to replace ResizeSensor lib comes in separate PR.  

