### PR TITLE
Reduce press time wait for hammer

### DIFF
--- a/addon/components/ember-table-header.js
+++ b/addon/components/ember-table-header.js
@@ -85,7 +85,7 @@ export default class EmberTableHeader extends EmberTableBaseCell {
 
     let hammer = new Hammer(this.element);
 
-    hammer.add(new Hammer.Press({ time: 10 }));
+    hammer.add(new Hammer.Press({ time: 0 }));
 
     hammer.on('press', (ev) => {
       let box = this.element.getBoundingClientRect();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-cli-eslint": "^4.0.0",
     "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-qunit": "4.0.0",
+    "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",


### PR DESCRIPTION
Upgrading to `ember-cli-qunit` causes some test to fail. Its version has been pinned to `4.0.0` for a while.

After some investigation, I notice that the press event is not triggered with newer version of `ember-cli-qunit`. This fixes the issue by reducing press wait time.