### PR TITLE
chore(deps): Update legacy shim and @argument

### DIFF
--- a/addon/components/ember-table-footer.js
+++ b/addon/components/ember-table-footer.js
@@ -30,7 +30,7 @@ export default class EmberTableFooter extends EmberTableBaseCell {
   }
 
   @action
-  onFooterEvent() {
+  sendFooterEvent() {
     this.sendAction('onFooterEvent', ...arguments);
   }
 }

--- a/addon/components/ember-table-header.js
+++ b/addon/components/ember-table-header.js
@@ -225,7 +225,7 @@ export default class EmberTableHeader extends EmberTableBaseCell {
   }
 
   @action
-  onHeaderEvent() {
+  sendHeaderEvent() {
     this.sendAction('onHeaderEvent', ...arguments);
   }
 }

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -720,12 +720,12 @@ export default class EmberTable extends Component {
   }
 
   @action
-  onHeaderEvent() {
+  sendHeaderEvent() {
     this.sendAction('onHeaderEvent', ...arguments);
   }
 
   @action
-  onFooterEvent() {
+  sendFooterEvent() {
     this.sendAction('onFooterEvent', ...arguments);
   }
 }

--- a/addon/templates/components/ember-table-footer.hbs
+++ b/addon/templates/components/ember-table-footer.hbs
@@ -6,7 +6,7 @@
         rowValue=rowValue
         rowIndex=rowIndex
         columnIndex=columnIndex
-        onFooterEvent="onFooterEvent"
+        onFooterEvent="sendFooterEvent"
       }}
       {{/component}}
     {{else}}
@@ -20,7 +20,7 @@
       rowValue=rowValue
       rowIndex=rowIndex
       columnIndex=columnIndex
-      onFooterEvent="onFooterEvent"
+      onFooterEvent="sendFooterEvent"
     }}
     {{/component}}
   {{else}}

--- a/addon/templates/components/ember-table-header.hbs
+++ b/addon/templates/components/ember-table-header.hbs
@@ -4,7 +4,7 @@
       {{#component column.headerComponent
         column=column
         columnIndex=columnIndex
-        onHeaderEvent="onHeaderEvent"
+        onHeaderEvent="sendHeaderEvent"
       }}
       {{/component}}
     {{else}}
@@ -21,7 +21,7 @@
     {{#component column.headerComponent
       column=column
       columnIndex=columnIndex
-      onHeaderEvent="onHeaderEvent"
+      onHeaderEvent="sendHeaderEvent"
     }}
     {{/component}}
   {{else}}

--- a/addon/templates/components/ember-table.hbs
+++ b/addon/templates/components/ember-table.hbs
@@ -11,7 +11,7 @@
           onColumnResizeEnded="onColumnResizeEnded"
           onColumnReorder="onColumnReorder"
           onColumnReorderEnded="onColumnReorderEnded"
-          onHeaderEvent="onHeaderEvent"
+          onHeaderEvent="sendHeaderEvent"
           width=column.width
         }}
       {{/each}}
@@ -30,7 +30,7 @@
               onColumnResizeEnded="onColumnResizeEnded"
               onColumnReorder="onColumnReorder"
               onColumnReorderEnded="onColumnReorderEnded"
-              onHeaderEvent="onHeaderEvent"
+              onHeaderEvent="sendHeaderEvent"
               width=column.width
             }}
           {{/each}}
@@ -70,7 +70,7 @@
             rowIndex=footerRowIndex
             columnIndex=columnIndex
             numFixedColumns=numFixedColumns
-            onFooterEvent="onFooterEvent"
+            onFooterEvent="sendFooterEvent"
           }}
         {{/each}}
         </tr>

--- a/package.json
+++ b/package.json
@@ -19,21 +19,19 @@
   },
   "dependencies": {
     "@addepar/ice-box": "^0.1.3",
-    "@ember-decorators/argument": "^0.8.8",
+    "@ember-decorators/argument": "^0.8.10",
     "@ember-decorators/babel-transforms": "^0.1.1",
     "@html-next/vertical-collection": "1.0.0-beta.10",
     "css-element-queries": "^0.4.0",
-    "ember": "^1.0.3",
     "ember-cli-babel": "^6.7.1",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-node-assets": "^0.2.2",
     "ember-cli-sass": "^7.0.0",
     "ember-compatibility-helpers": "^0.1.2",
     "ember-decorators": "^1.3.3",
-    "ember-legacy-class-transform": "^0.1.4",
+    "ember-legacy-class-shim": "^1.0.0",
     "ember-raf-scheduler": "^0.1.0",
-    "hammerjs": "^2.0.8",
-    "install": "^0.10.1"
+    "hammerjs": "^2.0.8"
   },
   "devDependencies": {
     "@addepar/eslint-config": "^3.0.0",


### PR DESCRIPTION
After some recent research we've been able to make the legacy class transforms and `@argument` more efficient overall, and more inline with the future version of ES classes. This PR bumps the dependencies to the most recent releases.