### PR TITLE
linked list tree: added doc, small refactors

### DIFF
--- a/addon/components/tree-table.js
+++ b/addon/components/tree-table.js
@@ -24,7 +24,7 @@ export default class TreeTable extends EmberTable {
     if (row.collapse) {
       tree.expand(row);
     } else {
-      tree.collapseNode(row);
+      tree.collapse(row);
     }
   }
 }

--- a/addon/utils/linked-list-tree.js
+++ b/addon/utils/linked-list-tree.js
@@ -16,9 +16,8 @@ export default class LinkedListTree extends EmberObject {
   constructor(root) {
     super();
 
-    root.updateNext(null);
-    root.updateNodeCountAndIndex(-1);
-    root.updateDepth(-1);
+    root.initializePointers(null);
+    root.initializeMetadata(-1, -1);
 
     this.pointerIndex = 0;
     // Root is a virtual node and will not be used for display
@@ -39,7 +38,7 @@ export default class LinkedListTree extends EmberObject {
     return this.pointerNode;
   }
 
-  _updateParentNodeCount(node, delta) {
+  _updateAncestorNodeCount(node, delta) {
     node = node.parent;
     while (node !== null) {
       node.nodeCountDelta += delta;
@@ -73,7 +72,7 @@ export default class LinkedListTree extends EmberObject {
     }
 
     set(row, 'collapse', true);
-    this._updateParentNodeCount(row, 1 - (row.nodeCount + row.nodeCountDelta));
+    this._updateAncestorNodeCount(row, 1 - (row.nodeCount + row.nodeCountDelta));
     this.notifyPropertyChange('[]');
   }
 
@@ -89,7 +88,7 @@ export default class LinkedListTree extends EmberObject {
     row.next = row.originalNext;
 
     set(row, 'collapse', false);
-    this._updateParentNodeCount(row, (row.nodeCount + row.nodeCountDelta) - 1);
+    this._updateAncestorNodeCount(row, (row.nodeCount + row.nodeCountDelta) - 1);
     this.notifyPropertyChange('[]');
   }
 }

--- a/addon/utils/tree-node.js
+++ b/addon/utils/tree-node.js
@@ -1,29 +1,56 @@
-
+/**
+ * A node in a LinkedListTree. To traverse the tree, use the next and previous pointers.
+ *
+ * The other pointers (nextOnCollapse, originalNext, previousStack) are used to manipulate
+ * linked list pointers during collapse / expand operations.
+ */
 export default class TreeNode {
   parent = null;
   children = null;
   value = null;
 
   /**
-   * Current next node (apply for both case expand & collapse).
+   * Current next node in linked list.
    */
   next = null;
 
   /**
-   * The next node when this tree collapse. This next node is usually the next sibling in the tree
-   * or next sibling of one of its ancestor.
+   * The next node when this tree is collapsed. This next node is usually the next sibling
+   * in the tree or next sibling of one of its ancestor.
    */
   nextOnCollapse = null;
 
   /**
-   * Original next node when tree is fully expanded.
+   * Next node when tree is fully expanded.
    */
   originalNext = null;
 
   /**
-   * Current previous node (apply for both case expand & collapse).
+   * Current previous node in linked list.
    */
   previous = null;
+
+  /**
+   * A stack of previous nodes. Imagine a tree like this:
+   *
+   * A
+   * |-B
+   * | |-C
+   * |   |-D
+   * |-E
+   *
+   * When expanded, the previous of E is D.  If C collapses, then E's previous is
+   * now C. If B then collapses, then E's previous is now B. Tree now looks like this:
+   *
+   * A
+   * |-B*
+   * |-E
+   *
+   * When we expand B, we want to know E's previous without traversing the whole
+   * B subtree. Thus, we need to store the stack of previous nodes for E, and we can
+   * determine the new previous node for E by popping off of this stack. (it's C)
+   */
+  previousStack = null;
 
   /**
    * Total number of node in this subtree (including this node).
@@ -39,21 +66,20 @@ export default class TreeNode {
 
   collapse = false;
 
-  constructor(parent, value) {
+  /**
+   * Creates a new tree node. To set its parent, call `addChild` on the parent node.
+   */
+  constructor(value) {
     this.children = [];
-    this.parent = parent;
     this.value = value;
   }
 
   addChild(child) {
+    child.parent = this;
     this.children.push(child);
   }
 
-  setNext(node) {
-    this.next = node;
-  }
-
-  _setNextNode(node) {
+  _setOriginalNext(node) {
     this.next = node;
     this.originalNext = node;
 
@@ -62,13 +88,43 @@ export default class TreeNode {
     }
   }
 
+  /**
+   * Push a new previous pointer for this node during a collapse operation.
+   *
+   * NOT to be used for adding / removing nodes.
+   *
+   * See jsdoc for the `previousStack` attribute.
+   */
+  pushPrevious(newPrevious) {
+    if (this.previousStack === null) {
+      this.previousStack = [this.previous];
+    } else {
+      this.previousStack.push(this.previous);
+    }
+    this.previous = newPrevious;
+  }
+
+  /**
+   * Pop a previous pointer off the stack and set the previous to that.
+   *
+   * Used during an expand operation
+   *
+   * See jsdoc for the `previousStack` attribute.
+   */
+  popPrevious() {
+    this.previous = this.previousStack.pop();
+    if (this.previousStack.length === 0) {
+      this.previousStack = null;
+    }
+  }
+
   updateNext(nextNode) {
     let { children } = this;
 
     if (children.length > 0) {
-      this._setNextNode(children[0]);
+      this._setOriginalNext(children[0]);
     } else {
-      this._setNextNode(nextNode);
+      this._setOriginalNext(nextNode);
       return;
     }
 
@@ -108,9 +164,6 @@ export default class TreeNode {
   }
 
   nextWithDirection(direction) {
-    if (direction < 0) {
-      return this.previous;
-    }
-    return this.next;
+    return direction < 0 ? this.previous : this.next;
   }
 }

--- a/addon/utils/tree-node.js
+++ b/addon/utils/tree-node.js
@@ -169,7 +169,7 @@ export default class TreeNode {
     nextIndex++;
 
     for (let child of this.children) {
-      child.initializeMetadata(depth, nextIndex);
+      child.initializeMetadata(depth + 1, nextIndex);
       nextIndex += child.nodeCount;
       this.nodeCount += child.nodeCount;
     }

--- a/addon/utils/tree-node.js
+++ b/addon/utils/tree-node.js
@@ -84,7 +84,7 @@ export default class TreeNode {
   }
 
   /**
-   * Add a child to this node. Only use this during initial tree construction.
+   * Add a child to this node. Will not update any pointers.
    */
   addChild(child) {
     child.parent = this;

--- a/tests/dummy/app/controllers/demo.js
+++ b/tests/dummy/app/controllers/demo.js
@@ -23,13 +23,13 @@ export default Controller.extend({
   },
 
   rows: computed(function() {
-    let topRow = new TreeNode(null, this.getRow('Top Row'));
+    let topRow = new TreeNode(this.getRow('Top Row'));
     for (let i = 0; i < 10; i++) {
-      let header = new TreeNode(topRow, this.getRow(`Header ${i}`));
+      let header = new TreeNode(this.getRow(`Header ${i}`));
       for (let j = 0; j < 10; j++) {
-        let group = new TreeNode(header, this.getRow(`Group ${j}`));
+        let group = new TreeNode(this.getRow(`Group ${j}`));
         for (let k = 0; k < 10; k++) {
-          group.addChild(new TreeNode(group, this.getRow(`Leaf ${k}`)));
+          group.addChild(new TreeNode(this.getRow(`Leaf ${k}`)));
         }
 
         header.addChild(group);
@@ -38,7 +38,7 @@ export default Controller.extend({
       topRow.addChild(header);
     }
 
-    let root = new TreeNode(null, null);
+    let root = new TreeNode(null);
     root.addChild(topRow);
 
     return new LinkedListTree(root);

--- a/tests/dummy/app/pods/index/template.hbs
+++ b/tests/dummy/app/pods/index/template.hbs
@@ -4,4 +4,5 @@
   <li><a href="/simple">Simple table</a></li>
   <li><a href="/demo">Advanced table</a></li>
   <li><a href="/docs">Document & Examples</a></li>
+  <li><a href="/tests">Run tests</a></li>
 </ul>

--- a/tests/helpers/tree-generator.js
+++ b/tests/helpers/tree-generator.js
@@ -1,14 +1,14 @@
 import TreeNode from 'dummy/utils/tree-node';
 
 const generateBasicRoot = (childCount = 10) => {
-  let topRow = new TreeNode(null, 'Top Row');
+  let topRow = new TreeNode('Top Row');
 
   for (let i = 0; i < childCount; i++) {
-    let header = new TreeNode(topRow, `Header ${i}`);
+    let header = new TreeNode(`Header ${i}`);
     for (let j = 0; j < childCount; j++) {
-      let group = new TreeNode(header, `Group ${j}`);
+      let group = new TreeNode(`Group ${j}`);
       for (let k = 0; k < childCount; k++) {
-        group.addChild(new TreeNode(group, `Leaf ${k}`));
+        group.addChild(new TreeNode(`Leaf ${k}`));
       }
 
       header.addChild(group);
@@ -17,7 +17,7 @@ const generateBasicRoot = (childCount = 10) => {
     topRow.addChild(header);
   }
 
-  let root = new TreeNode(null, 'Root');
+  let root = new TreeNode('Root');
   root.addChild(topRow);
 
   root.updateNext(null);

--- a/tests/helpers/tree-generator.js
+++ b/tests/helpers/tree-generator.js
@@ -20,8 +20,8 @@ const generateBasicRoot = (childCount = 10) => {
   let root = new TreeNode('Root');
   root.addChild(topRow);
 
-  root.updateNext(null);
-  root.updateNodeCountAndIndex(-1);
+  root.initializePointers(null);
+  root.initializeMetadata(-1, -1);
 
   return root;
 };

--- a/tests/unit/utils/linked-list-tree-test.js
+++ b/tests/unit/utils/linked-list-tree-test.js
@@ -29,7 +29,7 @@ test('Test expanding and collapsing rows', function(assert) {
   let tree = new LinkedListTree(generateBasicRoot());
 
   let node = tree.objectAt(24); // Group 2
-  tree.collapseNode(node);
+  tree.collapse(node);
 
   // Collapse a Group row
   assert.equal(tree.get('length'), 1101);
@@ -39,7 +39,7 @@ test('Test expanding and collapsing rows', function(assert) {
 
   // Collapse a Header row
   node = tree.objectAt(1); // Header 0
-  tree.collapseNode(node);
+  tree.collapse(node);
   assert.equal(node.value, 'Header 0');
   assert.equal(node.nodeCountDelta, -10);
   assert.equal(tree.get('length'), 1001);
@@ -61,10 +61,10 @@ test('Previous node is correct after several rows collapse & expansion.', functi
   let tree = new LinkedListTree(generateBasicRoot(3));
 
   // Collapse Top Row -> Header 0 -> Group 2
-  tree.collapseNode(tree.objectAt(10));
+  tree.collapse(tree.objectAt(10));
 
   // Collapse Top Row -> Header 0
-  tree.collapseNode(tree.objectAt(1));
+  tree.collapse(tree.objectAt(1));
 
   // Expand Top Row -> Header 0
   tree.expand(tree.objectAt(1));

--- a/tests/unit/utils/tree-node-test.js
+++ b/tests/unit/utils/tree-node-test.js
@@ -3,7 +3,6 @@ import { generateBasicRoot } from 'dummy/tests/helpers/tree-generator';
 
 module('Unit | Utility | tree node');
 
-// Replace this with your real tests.
 test('Test next and preivous nodes', function(assert) {
   let root = generateBasicRoot();
   let firstRow = root.next;


### PR DESCRIPTION
Going to implement add/remove node functionality.  Wanted to do a little bit of code cleanup ahead of that.  Most of it is minor (renaming methods, making it more clear whats private).  The two larger changes:

1. Previously, the tree kept track of every node's previous stack.  Now, the node itself keeps track.  This is consistent with all the other pointers (which get kept by the nodes themselves).

2. The TreeNode constructor does not take a `parent` anymore, doing `addChild` will set the `parent` property.  This makes it harder to construct a malformed tree.

reviewers: @Addepar/ice 