### PR TITLE
LinkedListTree supports adding and removing rows dynamically

### DIFF
--- a/addon/components/tree-table.js
+++ b/addon/components/tree-table.js
@@ -24,7 +24,7 @@ export default class TreeTable extends EmberTable {
     if (row.collapse) {
       tree.expand(row);
     } else {
-      tree.collapseNode(row);
+      tree.collapse(row);
     }
   }
 }

--- a/addon/utils/linked-list-tree.js
+++ b/addon/utils/linked-list-tree.js
@@ -16,9 +16,8 @@ export default class LinkedListTree extends EmberObject {
   constructor(root) {
     super();
 
-    root.updateNext(null);
-    root.updateNodeCountAndIndex(-1);
-    root.updateDepth(-1);
+    root.initializePointers(null);
+    root.initializeMetadata(-1, -1);
 
     this.pointerIndex = 0;
     // Root is a virtual node and will not be used for display
@@ -39,7 +38,7 @@ export default class LinkedListTree extends EmberObject {
     return this.pointerNode;
   }
 
-  _updateParentNodeCount(node, delta) {
+  _updateAncestorNodeCount(node, delta) {
     node = node.parent;
     while (node !== null) {
       node.nodeCountDelta += delta;
@@ -73,7 +72,7 @@ export default class LinkedListTree extends EmberObject {
     }
 
     set(row, 'collapse', true);
-    this._updateParentNodeCount(row, 1 - (row.nodeCount + row.nodeCountDelta));
+    this._updateAncestorNodeCount(row, 1 - (row.nodeCount + row.nodeCountDelta));
     this.notifyPropertyChange('[]');
   }
 
@@ -89,7 +88,7 @@ export default class LinkedListTree extends EmberObject {
     row.next = row.originalNext;
 
     set(row, 'collapse', false);
-    this._updateParentNodeCount(row, (row.nodeCount + row.nodeCountDelta) - 1);
+    this._updateAncestorNodeCount(row, (row.nodeCount + row.nodeCountDelta) - 1);
     this.notifyPropertyChange('[]');
   }
 }

--- a/addon/utils/linked-list-tree.js
+++ b/addon/utils/linked-list-tree.js
@@ -1,4 +1,6 @@
 import EmberObject, { set } from '@ember/object';
+import TreeNode from './tree-node';
+import { isEmpty } from '@ember/utils';
 
 /**
  * A tree that supports traversing the tree in DFS order (either forward or backwards)
@@ -90,5 +92,102 @@ export default class LinkedListTree extends EmberObject {
     set(row, 'collapse', false);
     this._updateAncestorNodeCount(row, (row.nodeCount + row.nodeCountDelta) - 1);
     this.notifyPropertyChange('[]');
+  }
+
+  /**
+   * Create a new TreeNode with rowValue as its value and append it to the children of parent
+   */
+  add(rowValue, parent) {
+    this._movePointerToRow(parent);
+    let node = new TreeNode(rowValue);
+
+    if (isEmpty(parent.children)) {
+      node.previous = parent;
+      // my parent's nextOnCollapse doesn't change if i add children.
+    } else {
+      node.previous = parent.children[parent.children.length - 1];
+      node.previous.nextOnCollapse = node;
+    }
+    let originalNext = node.previous.originalNext;
+    node.previous.originalNext = node;
+    // if my previous is a collapsed parent, then don't change the
+    // next on my previous
+    if (parent !== node.previous || !parent.collapse) {
+      node.previous.next = node;
+    }
+
+    // since i'm a leaf node, i can't be collapsed
+    node.originalNext = originalNext;
+    node.nextOnCollapse = originalNext;
+    node.next = originalNext;
+
+    parent.addChild(node);
+
+    node.depth = node.parent.depth + 1;
+
+    this._recountAfterUpdate(node.parent, 1);
+    this._resetIndices(node, node.originalNext.index);
+    this.notifyPropertyChange('[]');
+  }
+
+  /**
+   * Remove a leaf node from the tree.
+   */
+  remove(node) {
+    if (node.nodeCount > 1) {
+      throw Error('can only remove leaf nodes');
+    }
+
+    let parent = node.parent;
+    let previous = node.previous;
+    let next = node.next;
+    // i have no previous siblings
+    if (node.previous === parent) {
+      parent.originalNext = next;
+      if (!parent.collapse) {
+        parent.next = parent.originalNext;
+      }
+    // i have a previous sibling
+    } else {
+      previous.originalNext = node.originalNext;
+      previous.nextOnCollapse = node.nextOnCollapse;
+      previous.next = previous.collapse ? node.nextOnCollapse : node.originalNext;
+    }
+  }
+
+  /**
+   * Readjust all the indices starting from `node`. This will start
+   * by setting the index on `node` to `index`;
+   */
+  _resetIndices(node, index) {
+    while (node) {
+      node.index = index;
+      index++;
+      node = node.originalNext;
+    }
+  }
+
+  /**
+   * Recount after a leaf node was inserted or deleted. Goes up
+   * the ancestor tree, adjusting all the nodeCount and nodeCountDelta.
+   *
+   * @param startNode the node to start the updates
+   * @param direction either +1 if added or -1 if removed
+   */
+  _recountAfterUpdate(startNode, direction) {
+    let node = startNode;
+    let anyCollapsed = false;
+    while (node) {
+      node.nodeCount += direction;
+      if (node.nodeCountDelta < 0) {
+        node.nodeCountDelta -= direction;
+        anyCollapsed = true;
+      }
+      node = node.parent;
+    }
+    if (!anyCollapsed) {
+      // if i'm not in a collapsed part of the tree, i need to adjust length
+      this.set('length', this.get('length') + direction);
+    }
   }
 }

--- a/addon/utils/linked-list-tree.js
+++ b/addon/utils/linked-list-tree.js
@@ -45,6 +45,9 @@ export default class LinkedListTree extends EmberObject {
   }
 
   collapse(row) {
+    if (row.collapse) {
+      return;
+    }
     // an collapse may mess up the pointer index, so we reset it
     this.resetPointer();
     this._collapse(row);
@@ -52,6 +55,9 @@ export default class LinkedListTree extends EmberObject {
   }
 
   expand(row) {
+    if (!row.collapse) {
+      return;
+    }
     // an expansion may mess up the pointer index, so we reset it
     this.resetPointer();
     this._expand(row);
@@ -59,21 +65,34 @@ export default class LinkedListTree extends EmberObject {
   }
 
   /**
-   * Remove a row from the tree, rebuild the linked list and notify dependents that
-   * the linked list has changed.
+   * Remove a row from the tree.
+   *
+   * This operation is very slow right now, as it rebuilds the entire pointer structure. It
+   * may be optimized in the future.
    */
   remove(row) {
-    let i = row.parent.indexOf(row);
-    row.parent.splice(i, 1);
+    let siblings = row.parent.children;
+    let i = siblings.indexOf(row);
+    if (i === -1) {
+      throw Error('row was not in the tree');
+    }
+    siblings.splice(i, 1);
     this._init();
   }
 
   /**
-   * Create a new TreeNode with rowValue as its value and append it to the children of parent
+   * Create a `new TreeNode` with `rowValue` as its value and append it to the children of parent.
+   *
+   * This operation is very slow right now, as it rebuilds the entire pointer structure. It
+   * may be optimized in the future.
+   *
+   * @returns newly created TreeNode
    */
   add(rowValue, parent) {
-    parent.children.push(new TreeNode(rowValue));
+    let newNode = new TreeNode(rowValue);
+    parent.addChild(newNode);
     this._init();
+    return newNode;
   }
 
   /**
@@ -84,7 +103,7 @@ export default class LinkedListTree extends EmberObject {
     this.root.initializeMetadata(-1, -1);
     this.resetPointer();
     this._recollapse(this.root);
-    this.set('length', this.root.nodeCount - 1);
+    this.set('length', this.root.visibleNodeCount() - 1);
     this.notifyPropertyChange('[]');
   }
 
@@ -92,9 +111,6 @@ export default class LinkedListTree extends EmberObject {
    * Expands the row; updates pointers and counts.
    */
   _expand(row) {
-    if (!row.collapse) {
-      return;
-    }
     // Update next & previous link.
     let newNextNode = row.next;
     if (newNextNode !== null) {
@@ -103,16 +119,13 @@ export default class LinkedListTree extends EmberObject {
     row.next = row.originalNext;
 
     set(row, 'collapse', false);
-    this._updateAncestorNodeCount(row, (row.nodeCount + row.nodeCountDelta) - 1);
+    this._updateAncestorNodeCount(row, row.visibleNodeCount() - 1);
   }
 
   /**
    * Collapse the row; updates pointers and counts.
    */
   _collapse(row) {
-    if (row.collapse) {
-      return;
-    }
     // Update next & previous link.
     let newNextNode = row.nextOnCollapse;
     row.next = newNextNode;
@@ -121,7 +134,7 @@ export default class LinkedListTree extends EmberObject {
     }
 
     set(row, 'collapse', true);
-    this._updateAncestorNodeCount(row, 1 - (row.nodeCount + row.nodeCountDelta));
+    this._updateAncestorNodeCount(row, 1 - row.visibleNodeCount());
   }
 
   /**

--- a/addon/utils/tree-node.js
+++ b/addon/utils/tree-node.js
@@ -1,29 +1,56 @@
-
+/**
+ * A node in a LinkedListTree. To traverse the tree, use the next and previous pointers.
+ *
+ * The other pointers (nextOnCollapse, originalNext, previousStack) are used to manipulate
+ * linked list pointers during collapse / expand operations.
+ */
 export default class TreeNode {
   parent = null;
   children = null;
   value = null;
 
   /**
-   * Current next node (apply for both case expand & collapse).
+   * Current next node in linked list.
    */
   next = null;
 
   /**
-   * The next node when this tree collapse. This next node is usually the next sibling in the tree
-   * or next sibling of one of its ancestor.
+   * The next node when this tree is collapsed. This next node is usually the next sibling
+   * in the tree or next sibling of one of its ancestor.
    */
   nextOnCollapse = null;
 
   /**
-   * Original next node when tree is fully expanded.
+   * Next node when tree is fully expanded.
    */
   originalNext = null;
 
   /**
-   * Current previous node (apply for both case expand & collapse).
+   * Current previous node in linked list.
    */
   previous = null;
+
+  /**
+   * A stack of previous nodes. Imagine a tree like this:
+   *
+   * A
+   * |-B
+   * | |-C
+   * |   |-D
+   * |-E
+   *
+   * When expanded, the previous of E is D.  If C collapses, then E's previous is
+   * now C. If B then collapses, then E's previous is now B. Tree now looks like this:
+   *
+   * A
+   * |-B*
+   * |-E
+   *
+   * When we expand B, we want to know E's previous without traversing the whole
+   * B subtree. Thus, we need to store the stack of previous nodes for E, and we can
+   * determine the new previous node for E by popping off of this stack. (it's C)
+   */
+  previousStack = null;
 
   /**
    * Total number of node in this subtree (including this node).
@@ -39,21 +66,20 @@ export default class TreeNode {
 
   collapse = false;
 
-  constructor(parent, value) {
+  /**
+   * Creates a new tree node. To set its parent, call `addChild` on the parent node.
+   */
+  constructor(value) {
     this.children = [];
-    this.parent = parent;
     this.value = value;
   }
 
   addChild(child) {
+    child.parent = this;
     this.children.push(child);
   }
 
-  setNext(node) {
-    this.next = node;
-  }
-
-  _setNextNode(node) {
+  _setOriginalNext(node) {
     this.next = node;
     this.originalNext = node;
 
@@ -62,13 +88,43 @@ export default class TreeNode {
     }
   }
 
+  /**
+   * Push a new previous pointer for this node during a collapse operation.
+   *
+   * NOT to be used for adding / removing nodes.
+   *
+   * See jsdoc for the `previousStack` attribute.
+   */
+  pushPrevious(newPrevious) {
+    if (this.previousStack === null) {
+      this.previousStack = [this.previous];
+    } else {
+      this.previousStack.push(this.previous);
+    }
+    this.previous = newPrevious;
+  }
+
+  /**
+   * Pop a previous pointer off the stack and set the previous to that.
+   *
+   * Used during an expand operation
+   *
+   * See jsdoc for the `previousStack` attribute.
+   */
+  popPrevious() {
+    this.previous = this.previousStack.pop();
+    if (this.previousStack.length === 0) {
+      this.previousStack = null;
+    }
+  }
+
   updateNext(nextNode) {
     let { children } = this;
 
     if (children.length > 0) {
-      this._setNextNode(children[0]);
+      this._setOriginalNext(children[0]);
     } else {
-      this._setNextNode(nextNode);
+      this._setOriginalNext(nextNode);
       return;
     }
 
@@ -108,9 +164,6 @@ export default class TreeNode {
   }
 
   nextWithDirection(direction) {
-    if (direction < 0) {
-      return this.previous;
-    }
-    return this.next;
+    return direction < 0 ? this.previous : this.next;
   }
 }

--- a/addon/utils/tree-node.js
+++ b/addon/utils/tree-node.js
@@ -91,6 +91,10 @@ export default class TreeNode {
     this.children.push(child);
   }
 
+  lastChild() {
+    return this.children.length ? this.children[this.children.length - 1] : null;
+  }
+
   _setOriginalNext(node) {
     this.next = node;
     this.originalNext = node;
@@ -102,6 +106,28 @@ export default class TreeNode {
 
   originalPrevious() {
     return this.previousStack ? this.previousStack[0] : this.previous;
+  }
+
+  /**
+   * Count of nodes minus hidden nodes.
+   * This is only accurate if neither me or my ancestors are collapsed.
+   */
+  visibleNodeCount() {
+    return this.nodeCount + this.nodeCountDelta;
+  }
+
+  /**
+   * @returns whether `candidate` is an ancestor of this.
+   */
+  hasAncestor(candidate) {
+    let ancestor = this.parent;
+    while (ancestor) {
+      if (ancestor === candidate) {
+        return true;
+      }
+      ancestor = ancestor.parent;
+    }
+    return false;
   }
 
   /**
@@ -149,6 +175,7 @@ export default class TreeNode {
     }
 
     let originalNextNode = nextNode;
+    this.previousStack = null;
 
     // iterate from the last to first child of this node.
     for (let i = children.length - 1; i >= 0; i--) {
@@ -169,6 +196,7 @@ export default class TreeNode {
   initializeMetadata(depth, nextIndex) {
     this.depth = depth;
     this.nodeCount = 1;
+    this.nodeCountDelta = 0;
     this.index = nextIndex;
     nextIndex++;
 

--- a/addon/utils/tree-node.js
+++ b/addon/utils/tree-node.js
@@ -100,6 +100,10 @@ export default class TreeNode {
     }
   }
 
+  originalPrevious() {
+    return this.previousStack ? this.previousStack[0] : this.previous;
+  }
+
   /**
    * Push a new previous pointer for this node during a collapse operation.
    *

--- a/addon/utils/tree-node.js
+++ b/addon/utils/tree-node.js
@@ -84,7 +84,7 @@ export default class TreeNode {
   }
 
   /**
-   * Add a child to this node. Only use this during initial tree construction.
+   * Add a child to this node. Will not update any pointers.
    */
   addChild(child) {
     child.parent = this;

--- a/tests/dummy/app/controllers/demo.js
+++ b/tests/dummy/app/controllers/demo.js
@@ -23,13 +23,13 @@ export default Controller.extend({
   },
 
   rows: computed(function() {
-    let topRow = new TreeNode(null, this.getRow('Top Row'));
+    let topRow = new TreeNode(this.getRow('Top Row'));
     for (let i = 0; i < 10; i++) {
-      let header = new TreeNode(topRow, this.getRow(`Header ${i}`));
+      let header = new TreeNode(this.getRow(`Header ${i}`));
       for (let j = 0; j < 10; j++) {
-        let group = new TreeNode(header, this.getRow(`Group ${j}`));
+        let group = new TreeNode(this.getRow(`Group ${j}`));
         for (let k = 0; k < 10; k++) {
-          group.addChild(new TreeNode(group, this.getRow(`Leaf ${k}`)));
+          group.addChild(new TreeNode(this.getRow(`Leaf ${k}`)));
         }
 
         header.addChild(group);
@@ -38,7 +38,7 @@ export default Controller.extend({
       topRow.addChild(header);
     }
 
-    let root = new TreeNode(null, null);
+    let root = new TreeNode(null);
     root.addChild(topRow);
 
     return new LinkedListTree(root);

--- a/tests/dummy/app/pods/index/template.hbs
+++ b/tests/dummy/app/pods/index/template.hbs
@@ -3,6 +3,6 @@
 <ul>
   <li><a href="/simple">Simple table</a></li>
   <li><a href="/demo">Advanced table</a></li>
-  <li><a href="/docs">Document & Examples</a></li>
-  <li><a href="/tests">Run tests</a></li>
+  <li><a href="/docs">Document &amp; Examples</a></li>
+  <li><a target="_blank" href="/tests">Run tests (new tab)</a></li>
 </ul>

--- a/tests/dummy/app/pods/index/template.hbs
+++ b/tests/dummy/app/pods/index/template.hbs
@@ -4,4 +4,5 @@
   <li><a href="/simple">Simple table</a></li>
   <li><a href="/demo">Advanced table</a></li>
   <li><a href="/docs">Document & Examples</a></li>
+  <li><a href="/tests">Run tests</a></li>
 </ul>

--- a/tests/helpers/tree-generator.js
+++ b/tests/helpers/tree-generator.js
@@ -1,14 +1,14 @@
 import TreeNode from 'dummy/utils/tree-node';
 
 const generateBasicRoot = (childCount = 10) => {
-  let topRow = new TreeNode(null, 'Top Row');
+  let topRow = new TreeNode('Top Row');
 
   for (let i = 0; i < childCount; i++) {
-    let header = new TreeNode(topRow, `Header ${i}`);
+    let header = new TreeNode(`Header ${i}`);
     for (let j = 0; j < childCount; j++) {
-      let group = new TreeNode(header, `Group ${j}`);
+      let group = new TreeNode(`Group ${j}`);
       for (let k = 0; k < childCount; k++) {
-        group.addChild(new TreeNode(group, `Leaf ${k}`));
+        group.addChild(new TreeNode(`Leaf ${k}`));
       }
 
       header.addChild(group);
@@ -17,7 +17,7 @@ const generateBasicRoot = (childCount = 10) => {
     topRow.addChild(header);
   }
 
-  let root = new TreeNode(null, 'Root');
+  let root = new TreeNode('Root');
   root.addChild(topRow);
 
   root.updateNext(null);

--- a/tests/helpers/tree-generator.js
+++ b/tests/helpers/tree-generator.js
@@ -1,14 +1,18 @@
 import TreeNode from 'dummy/utils/tree-node';
 
-const generateBasicRoot = (childCount = 10) => {
+const generateBasicRoot = (childCount = 10, useGlobalId = false) => {
   let topRow = new TreeNode('Top Row');
 
+  let id = 0;
   for (let i = 0; i < childCount; i++) {
-    let header = new TreeNode(`Header ${i}`);
+    id = useGlobalId ? ++id : i;
+    let header = new TreeNode(`Header ${id}`);
     for (let j = 0; j < childCount; j++) {
-      let group = new TreeNode(`Group ${j}`);
+      id = useGlobalId ? ++id : j;
+      let group = new TreeNode(`Group ${id}`);
       for (let k = 0; k < childCount; k++) {
-        group.addChild(new TreeNode(`Leaf ${k}`));
+        id = useGlobalId ? ++id : k;
+        group.addChild(new TreeNode(`Leaf ${id}`));
       }
 
       header.addChild(group);

--- a/tests/helpers/tree-generator.js
+++ b/tests/helpers/tree-generator.js
@@ -20,8 +20,8 @@ const generateBasicRoot = (childCount = 10) => {
   let root = new TreeNode('Root');
   root.addChild(topRow);
 
-  root.updateNext(null);
-  root.updateNodeCountAndIndex(-1);
+  root.initializePointers(null);
+  root.initializeMetadata(-1, -1);
 
   return root;
 };

--- a/tests/unit/utils/linked-list-tree-test.js
+++ b/tests/unit/utils/linked-list-tree-test.js
@@ -29,7 +29,7 @@ test('Test expanding and collapsing rows', function(assert) {
   let tree = new LinkedListTree(generateBasicRoot());
 
   let node = tree.objectAt(24); // Group 2
-  tree.collapseNode(node);
+  tree.collapse(node);
 
   // Collapse a Group row
   assert.equal(tree.get('length'), 1101);
@@ -39,7 +39,7 @@ test('Test expanding and collapsing rows', function(assert) {
 
   // Collapse a Header row
   node = tree.objectAt(1); // Header 0
-  tree.collapseNode(node);
+  tree.collapse(node);
   assert.equal(node.value, 'Header 0');
   assert.equal(node.nodeCountDelta, -10);
   assert.equal(tree.get('length'), 1001);
@@ -61,10 +61,10 @@ test('Previous node is correct after several rows collapse & expansion.', functi
   let tree = new LinkedListTree(generateBasicRoot(3));
 
   // Collapse Top Row -> Header 0 -> Group 2
-  tree.collapseNode(tree.objectAt(10));
+  tree.collapse(tree.objectAt(10));
 
   // Collapse Top Row -> Header 0
-  tree.collapseNode(tree.objectAt(1));
+  tree.collapse(tree.objectAt(1));
 
   // Expand Top Row -> Header 0
   tree.expand(tree.objectAt(1));

--- a/tests/unit/utils/linked-list-tree-test.js
+++ b/tests/unit/utils/linked-list-tree-test.js
@@ -4,6 +4,121 @@ import { generateBasicRoot } from 'dummy/tests/helpers/tree-generator';
 
 module('Unit | Utility | linked list tree');
 
+/**
+ * the values of the node, so that you can see where in the tree something went wrong.
+ */
+function nodePathStr(node) {
+  let s = node.value;
+  while (node.parent) {
+    node = node.parent;
+    s = `${node.value} > ${s}`;
+  }
+  return s;
+}
+
+/**
+ * Ensure that the nodeCount, nodeCountDelta, and depth are correct for this node
+ * and the whole subtree.
+ *
+ * @param {String} prefix Prefix to every assert message.
+ */
+function verifyNodeMetaData(assert, prefix, node, depth) {
+  assert.equal(node.depth, depth, `${prefix}: node: ${nodePathStr(node)} has correct depth`);
+  let count = 1;
+  let delta = 0;
+  for (let child of node.children) {
+    verifyNodeMetaData(assert, prefix, child, depth + 1);
+    count += child.nodeCount;
+    delta += child.collapse ? -(child.nodeCount - 1) : child.nodeCountDelta;
+  }
+  assert.equal(
+    node.nodeCountDelta,
+    delta,
+    `${prefix}: node: ${nodePathStr(node)} has correct node delta`
+  );
+  assert.equal(node.nodeCount, count, `${prefix}: node: ${nodePathStr(node)} has correct nodeCount`);
+}
+
+/**
+ * Make sure all the counts and depths are correct.
+ */
+function verifyTreeMetadata(assert, prefix, lltree) {
+  verifyNodeMetaData(assert, prefix, lltree.root, -1);
+}
+
+/**
+ * Verify that the next, previous pointers operate in a chain.
+ * Verify that the originalNext, original previous pointers operate in a chain.
+ *
+ * @param {String} prefix Prefix to every assert message.
+ */
+function verifyTreePointers(assert, prefix, lltree) {
+  // next <-> prev
+  let length = lltree.get('length');
+  for (let i = 0; i < length - 1; i++) {
+    let first = lltree.objectAt(i);
+    let second = lltree.objectAt(i + 1);
+    assert.equal(first.next.value, second.value, `${prefix}: node ${nodePathStr(first)} has well formed links`);
+    assert.equal(first.value, second.previous.value, `${prefix}: node ${nodePathStr(first)} has well formed links`);
+  }
+
+  // original next <-> original prev
+  let originalLength = lltree.root.nodeCount - 1;
+  let count = 0;
+  lltree.resetPointer();
+  let node = lltree.pointerNode;
+  while (node.originalNext) {
+    count++;
+    assert.equal(
+      node.value,
+      node.originalNext.originalPrevious().value,
+      `${prefix}: node ${nodePathStr(node)} has well formed original links`
+    );
+    node = node.originalNext;
+  }
+  // we didn't visit the last one in the loop because the last one has no originalNext
+  count++;
+  assert.equal(count, originalLength, `${prefix}: trees nodeCount matches original (precollapse) linked list`);
+}
+
+/**
+ * Split this node and its subtrees into the hidden and visible sets.
+ */
+function divideNodes(node, hidden, visible, subtreeIsHidden) {
+  if (subtreeIsHidden) {
+    hidden.add(node);
+  } else {
+    visible.add(node);
+  }
+  subtreeIsHidden |= node.collapse;
+  for (let child of node.children) {
+    divideNodes(child, hidden, visible, subtreeIsHidden);
+  }
+}
+
+/**
+ * Make sure none of the hidden nodes get traversed.
+ */
+function verifyTreeHiding(assert, prefix, lltree) {
+  let hidden = new Set([]);
+  let visible = new Set([]);
+  divideNodes(lltree.root, hidden, visible, false);
+
+  for (let i = 0; i < lltree.get('length'); i++) {
+    let row = lltree.objectAt(i);
+    assert.ok(visible.delete(row), `${prefix}: visible node ${nodePathStr(row)} is visited once`);
+  }
+  assert.ok(visible.delete(lltree.root), `${prefix}: root node was not visited`);
+  assert.equal(visible.size, 0, `${prefix}: all visible nodes were visited`);
+  assert.equal(hidden.size, -lltree.root.nodeCountDelta, `${prefix}: hidden nodes match count`);
+}
+
+function verifyTreeWellFormed(assert, prefix, lltree) {
+  verifyTreeMetadata(assert, prefix, lltree);
+  verifyTreePointers(assert, prefix, lltree);
+  verifyTreeHiding(assert, prefix, lltree);
+}
+
 function verifyTreePath(assert, node, expectedTreePath) {
   for (let i = 0; i < expectedTreePath.length; i++) {
     assert.equal(node.value, expectedTreePath[i]);
@@ -75,4 +190,89 @@ test('Previous node is correct after several rows collapse & expansion.', functi
 
   assert.equal(tree.objectAt(0).value, 'Top Row');
   assert.equal(tree.objectAt(1).value, 'Header 0');
+});
+
+test('Tree is still well formed after removing rows', function(assert) {
+  let tree = new LinkedListTree(generateBasicRoot(3, true));
+  let originalLength = tree.get('length');
+
+  // remove a bunch of leaf nodes
+  verifyTreeWellFormed(assert, 'Initial', tree);
+  tree.remove(tree.objectAt(5));
+  tree.remove(tree.objectAt(6));
+  tree.remove(tree.objectAt(7));
+  tree.remove(tree.objectAt(8));
+  verifyTreeWellFormed(assert, 'Remove leaves', tree);
+  assert.equal(tree.get('length'), originalLength - 4, 'length is correct after removes');
+
+  // remove node with children
+  let headerNode = tree.objectAt(1);
+  assert.equal(headerNode.value.substring(0, 6), 'Header', 'object is header node');
+  tree.remove(headerNode);
+  verifyTreeWellFormed(assert, 'Remove parent', tree);
+
+  // remove node encapsulating a collapse
+  let innerNode = tree.objectAt(10);
+  let outerNode = tree.objectAt(1);
+  assert.ok(
+    innerNode.hasAncestor(outerNode),
+    'test assumption is held (node to remove is in collapse region)'
+  );
+  tree.collapse(innerNode);
+  tree.remove(outerNode);
+  verifyTreeWellFormed(assert, 'Remove node with collapse inside', tree);
+
+  // remove node encapsulated by a collapse
+  innerNode = tree.objectAt(10);
+  outerNode = tree.objectAt(1);
+  assert.ok(
+    innerNode.hasAncestor(outerNode),
+    'test assumption is held (node to remove is in collapse region)'
+  );
+  tree.collapse(outerNode);
+  tree.remove(innerNode);
+  verifyTreeWellFormed(assert, 'Remove node inside collapse', tree);
+});
+
+test('Tree is still well formed after adding rows', function(assert) {
+  let tree = new LinkedListTree(generateBasicRoot(3, true));
+  let originalLength = tree.get('length');
+
+  // add a bunch of leaf nodes
+  verifyTreeWellFormed(assert, 'Initial', tree);
+  tree.add('New Leaf 1', tree.objectAt(5));
+  tree.add('New Leaf 2', tree.objectAt(6));
+  tree.add('New Leaf 3', tree.objectAt(7));
+  tree.add('New Leaf 4', tree.objectAt(8));
+  verifyTreeWellFormed(assert, 'Add leaves', tree);
+  assert.equal(tree.get('length'), originalLength + 4, 'length is correct after adds');
+
+  // add leaf node to node with non leaf children
+  let headerNode = tree.objectAt(1);
+  assert.equal(headerNode.value.substring(0, 6), 'Header', 'object is header node');
+  let justAdded = tree.add('New Leaf 5', headerNode);
+  verifyTreeWellFormed(assert, 'Add to existing parent', tree);
+  tree.remove(justAdded);
+
+  // add node right after a collapse section
+  let toCollapse = headerNode.lastChild();
+  tree.collapse(toCollapse);
+  tree.add('New Leaf 6', headerNode); // new leaf will be appended to headerNode's children
+  verifyTreeWellFormed(assert, 'Add right after collapse section', tree);
+
+  // add node right before a collapse section
+  let header3 = tree.root.lastChild().lastChild();
+  assert.equal(header3.value.substring(0, 6), 'Header', 'object is header node');
+  let beforeCollapse = header3.previous.parent;
+  tree.collapse(header3);
+  tree.add('New Leaf 7', beforeCollapse);
+  verifyTreeWellFormed(assert, 'Add right before collapse', tree);
+
+  // add node inside collapse section
+  tree.add('New Leaf 8', header3.lastChild());
+  verifyTreeWellFormed(assert, 'Add inside collapse', tree);
+
+  // now uncollapse the container
+  tree.expand(header3);
+  verifyTreeWellFormed(assert, 'Add inside collapse, then expand', tree);
 });

--- a/tests/unit/utils/tree-node-test.js
+++ b/tests/unit/utils/tree-node-test.js
@@ -3,7 +3,6 @@ import { generateBasicRoot } from 'dummy/tests/helpers/tree-generator';
 
 module('Unit | Utility | tree node');
 
-// Replace this with your real tests.
 test('Test next and preivous nodes', function(assert) {
   let root = generateBasicRoot();
   let firstRow = root.next;


### PR DESCRIPTION
You can add or remove rows after the tree has been constructed.  The add/remove operations could be optimized, but we don't need that right now so i haven't done it.

This is on top of https://github.com/Addepar/ember-table/pull/498, so this will be a bit easier to review after the other merges.

Reviewers: @Addepar/ice 