### PR TITLE
[bugfix] Fix fixed column behavior

### DIFF
--- a/addon/components/ember-table-base-cell.js
+++ b/addon/components/ember-table-base-cell.js
@@ -71,7 +71,7 @@ export default class EmberTableCell extends Component {
   }
 
   @computed('columnIndex', 'numFixedColumns')
-  get isFixed() {
+  get _isFixed() {
     let numFixedColumns = this.get('numFixedColumns');
     return this.get('columnIndex') === 0
       && Number.isInteger(numFixedColumns)

--- a/addon/components/ember-table-cell.js
+++ b/addon/components/ember-table-cell.js
@@ -1,5 +1,6 @@
 import EmberTableBaseCell from './ember-table-base-cell';
 
+import { alias } from '@ember-decorators/object/computed';
 import { className } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
 import { required } from '@ember-decorators/argument/validation';
@@ -11,7 +12,9 @@ import layout from '../templates/components/ember-table-cell';
 export default class EmberTableCell extends EmberTableBaseCell {
   layout = layout;
 
-  @className('', 'et-td') isFixed;
+  // Attempting to decorate the isFixed field on the super class directly
+  // overwrites the field entirely, thus the need for an alias
+  @className('', 'et-td') @alias('_isFixed') isFixed;
 
   /**
    * Whether or not the parent row is selected

--- a/addon/components/ember-table-footer.js
+++ b/addon/components/ember-table-footer.js
@@ -2,6 +2,7 @@ import EmberTableBaseCell from './ember-table-base-cell';
 import { get } from '@ember/object';
 
 import { action, computed } from '@ember-decorators/object';
+import { alias } from '@ember-decorators/object/computed';
 import { className } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
 import { type } from '@ember-decorators/argument/type';
@@ -12,7 +13,9 @@ import layout from '../templates/components/ember-table-footer';
 export default class EmberTableFooter extends EmberTableBaseCell {
   layout = layout;
 
-  @className('', 'et-tf') isFixed;
+  // Attempting to decorate the isFixed field on the super class directly
+  // overwrites the field entirely, thus the need for an alias
+  @className('', 'et-tf') @alias('_isFixed') isFixed;
 
   @argument
   @type(Action)

--- a/addon/components/ember-table-header.js
+++ b/addon/components/ember-table-header.js
@@ -2,6 +2,7 @@
 import EmberTableBaseCell from './ember-table-base-cell';
 
 import { action, computed } from '@ember-decorators/object';
+import { alias } from '@ember-decorators/object/computed';
 import { attribute, tagName, className } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
 import { required } from '@ember-decorators/argument/validation';
@@ -22,7 +23,9 @@ const COLUMN_REORDERING = 2;
 export default class EmberTableHeader extends EmberTableBaseCell {
   layout = layout;
 
-  @className('', 'et-th') isFixed;
+  // Attempting to decorate the isFixed field on the super class directly
+  // overwrites the field entirely, thus the need for an alias
+  @className('', 'et-th') @alias('_isFixed') isFixed;
 
   @argument
   @required


### PR DESCRIPTION
Even with the changes to decorators upstream there, we still can't
decorate a property without modifying the value on the prototype. In
this case it ends up manually defining an undefined value, which breaks
the prototype chain. We'll have to wait for decorators v2 transform to
see if things get fixed.