### PR TITLE
collapse tree works when it is empty

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -363,7 +363,7 @@ export default class CollapseTree {
     @return {{ value: object, depth: number }}
   */
   objectAt(index) {
-    if (index >= this.get('length') || index < 0) {
+    if (index >= get(this, 'length') || index < 0) {
       return undefined;
     }
     if (this.rootIsArray) {

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -363,6 +363,9 @@ export default class CollapseTree {
     @return {{ value: object, depth: number }}
   */
   objectAt(index) {
+    if (index >= this.get('length') || index < 0) {
+      return undefined;
+    }
     if (this.rootIsArray) {
       // If the root was an array, we added a "fake" top level node. Skip this node
       // by adding one to the index, and "subtracting" one from the depth.

--- a/tests/unit/-private/collapse-tree-test.js
+++ b/tests/unit/-private/collapse-tree-test.js
@@ -33,17 +33,28 @@ function generateTree(firstNode, values) {
 
 module('Unit | Private | CollapseTree', function() {
 
+  test('empty tree works', function(assert) {
+    let tree = new CollapseTree([]);
+    assert.equal(tree.objectAt(-1), undefined);
+    assert.equal(tree.objectAt(0), undefined);
+    assert.equal(tree.objectAt(1), undefined);
+  });
+
   test('basic tree works', function(assert) {
     let tree = new CollapseTree(generateTree(0, [1, [2, 3], 4, [5, 6]]));
 
     let expectedDepth = [0, 1, 2, 2, 1, 2, 2];
+    let length = get(tree, 'length');
 
-    assert.equal(get(tree, 'length'), 7);
+    assert.equal(length, 7);
 
     for (let i = 0; i < 7; i++) {
       assert.equal(tree.objectAt(i).value.value, i);
       assert.equal(tree.objectAt(i).depth, expectedDepth[i]);
     }
+
+    assert.equal(tree.objectAt(length + 1), undefined);
+    assert.equal(tree.objectAt(-1), undefined);
   });
 
   test('works with multiroot tree', function(assert) {


### PR DESCRIPTION
Now a `CollapseTree` has behavior similar to an Ember Array: when you ask for `objectAt(outOfBounds)`, you get `undefined` back.

Reviewers: @Addepar/ice 