### PR TITLE
 [refactor] Use position: sticky; for fixed headers/footers/columns

### DIFF
--- a/addon/components/ember-table-base-cell.js
+++ b/addon/components/ember-table-base-cell.js
@@ -1,11 +1,9 @@
 import Component from '@ember/component';
-import { addObserver, removeObserver } from '@ember/object/observers';
 import { htmlSafe } from '@ember/string';
 import { get } from '@ember/object';
-import { scheduler, Token } from 'ember-raf-scheduler';
 
 import { action, computed } from '@ember-decorators/object';
-import { tagName, attribute } from '@ember-decorators/component';
+import { tagName, attribute, className } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
 import { type, optional } from '@ember-decorators/argument/type';
 
@@ -35,43 +33,9 @@ export default class EmberTableCell extends Component {
   @type(optional('object'))
   cell;
 
-  constructor() {
-    super(...arguments);
-
-    this.token = new Token();
-  }
-
-  willDestroy() {
-    this.token.cancel();
-  }
-
-  didInsertElement() {
-    if (this.get('isFixed')) {
-      this.scheduleSync();
-
-      // TODO: For now we are just watching rows for changes in height, but
-      // theoretically anything can change the height of a row. We need
-      // to come up with a better solution.
-      addObserver(this, 'rowValue', this, this.scheduleSync);
-    }
-  }
-
-  willDestroyElement() {
-    if (this.get('isFixed')) {
-      removeObserver(this, 'rowValue', this, this.scheduleSync);
-    }
-  }
-
-  scheduleSync() {
-    scheduler.schedule('sync', () => {
-      let { height } = this.element.getBoundingClientRect();
-
-      this.set('cellHeight', height || 0);
-    }, this.token);
-  }
-
+  @className
   @computed('columnIndex', 'numFixedColumns')
-  get _isFixed() {
+  get isFixed() {
     let numFixedColumns = this.get('numFixedColumns');
     return this.get('columnIndex') === 0
       && Number.isInteger(numFixedColumns)

--- a/addon/components/ember-table-body.js
+++ b/addon/components/ember-table-body.js
@@ -1,10 +1,12 @@
 import Component from '@ember/component';
 import layout from '../templates/components/ember-table-body';
 
+import { tagName } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
 import { required } from '@ember-decorators/argument/validation';
 import { type } from '@ember-decorators/argument/type';
 
+@tagName('')
 export default class EmberTableBody extends Component {
   layout = layout;
 

--- a/addon/components/ember-table-cell.js
+++ b/addon/components/ember-table-cell.js
@@ -1,7 +1,5 @@
 import EmberTableBaseCell from './ember-table-base-cell';
 
-import { alias } from '@ember-decorators/object/computed';
-import { className } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
 import { required } from '@ember-decorators/argument/validation';
 import { type } from '@ember-decorators/argument/type';
@@ -11,10 +9,6 @@ import layout from '../templates/components/ember-table-cell';
 
 export default class EmberTableCell extends EmberTableBaseCell {
   layout = layout;
-
-  // Attempting to decorate the isFixed field on the super class directly
-  // overwrites the field entirely, thus the need for an alias
-  @className('', 'et-td') @alias('_isFixed') isFixed;
 
   /**
    * Whether or not the parent row is selected

--- a/addon/components/ember-table-footer.js
+++ b/addon/components/ember-table-footer.js
@@ -2,8 +2,6 @@ import EmberTableBaseCell from './ember-table-base-cell';
 import { get } from '@ember/object';
 
 import { action, computed } from '@ember-decorators/object';
-import { alias } from '@ember-decorators/object/computed';
-import { className } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
 import { type } from '@ember-decorators/argument/type';
 import { Action } from '@ember-decorators/argument/types';
@@ -12,10 +10,6 @@ import layout from '../templates/components/ember-table-footer';
 
 export default class EmberTableFooter extends EmberTableBaseCell {
   layout = layout;
-
-  // Attempting to decorate the isFixed field on the super class directly
-  // overwrites the field entirely, thus the need for an alias
-  @className('', 'et-tf') @alias('_isFixed') isFixed;
 
   @argument
   @type(Action)

--- a/addon/components/ember-table-header.js
+++ b/addon/components/ember-table-header.js
@@ -2,8 +2,7 @@
 import EmberTableBaseCell from './ember-table-base-cell';
 
 import { action, computed } from '@ember-decorators/object';
-import { alias } from '@ember-decorators/object/computed';
-import { attribute, tagName, className } from '@ember-decorators/component';
+import { attribute, tagName } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
 import { required } from '@ember-decorators/argument/validation';
 import { type } from '@ember-decorators/argument/type';
@@ -22,10 +21,6 @@ const COLUMN_REORDERING = 2;
 @tagName('th')
 export default class EmberTableHeader extends EmberTableBaseCell {
   layout = layout;
-
-  // Attempting to decorate the isFixed field on the super class directly
-  // overwrites the field entirely, thus the need for an alias
-  @className('', 'et-th') @alias('_isFixed') isFixed;
 
   @argument
   @required

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,96 +1,62 @@
-.et-table {
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
-
+.ember-table {
   position: relative;
-  border-collapse: collapse;
-  width: 100%;
+  overflow: scroll;
   max-height: 100%;
   max-width: 100%;
+  box-sizing: border-box;
 
-  .et-tbody, .et-thead, .et-tfoot {
-    display: block;
-    overflow-x: hidden;
+  table {
+    border-spacing: 0;
+    table-layout: fixed;
+
+    // Hack to get table to respect the widths of columns that
+    // have been set manually
+    width: 0;
   }
 
-  .et-thead-container, .et-tfoot-container {
+  td.is-fixed, th.is-fixed {
+    position: -webkit-sticky;
+    position: sticky;
+    left: 0;
+  }
+
+  thead {
+    top: 0;
     z-index: 2;
-  }
-
-  .et-tr {
-    display: inline-flex;
-    // Fixed td elements don't have classes, so we need to make sure we override the base styles no
-    // matter what
-    .et-td, .et-th {
-      display: block;
-    }
-  }
-
-  td, th, .et-td, .et-th {
     box-sizing: border-box;
-    vertical-align: inherit;
-    padding: 0px;
-  }
 
-  .et-td, .et-th, .et-tf {
-    position: relative;
-    &.is-fixed {
-      position: absolute;
-      left: 0;
-      z-index: 1;
-    }
-  }
-
-  .et-th {
-    &.is-fixed {
+    th {
+      position: -webkit-sticky;
+      position: sticky;
       top: 0;
+
+      &:first-child {
+        z-index: 3;
+      }
     }
   }
 
-  .et-tbody-container {
-    overflow-y: scroll;
-    flex: 1;
-    position: relative;
+  tbody {
+    box-sizing: border-box;
   }
 
-  .et-horizontal-scroll-wrapper {
-    position: absolute;
+  tfoot {
+    // tfoot respects position: sticky; in Safari, but td in a tfoot does not.
+    // td in a tfoot respects position: sticky; in Chrome, but tfoot does not.
+    // Thus, we put it on both with appropriate browser prefixes and wait for
+    // Chrome/Edge to fix their implementations.
+    position: -webkit-sticky;
     bottom: 0;
-    overflow-x: scroll;
-    overflow-y: hidden;
-    height: 20px;
-    opacity: 0.7;
-    border: none 0px;
-  }
+    z-index: 2;
+    box-sizing: border-box;
 
-  .et-horizontal-scroll {
-    height: 1px;
-  }
+    td {
+      position: sticky;
+      bottom: 0;
 
-  .et-header-resize-area {
-    width: 10px;
-    height: 100%;
-    top: 0px;
-    right: 0px;
-    position: absolute;
-    cursor: col-resize;
-  }
-
-  .et-header-ghost-element {
-    position: absolute;
-  }
-
-  .et-header-align-bar {
-    position: absolute;
-  }
-
-  .et-unselectable {
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+      &:first-child {
+        z-index: 3;
+      }
+    }
   }
 }

--- a/addon/templates/components/ember-table-body.hbs
+++ b/addon/templates/components/ember-table-body.hbs
@@ -1,7 +1,7 @@
 {{#vertical-collection rows
   estimateHeight=estimateRowHeight
   staticHeight=staticHeight
-  containerSelector=".et-tbody-container"
+  containerSelector=".ember-table"
 
   as |rowValue rowIndex|
 }}

--- a/addon/templates/components/ember-table-cell.hbs
+++ b/addon/templates/components/ember-table-cell.hbs
@@ -1,13 +1,4 @@
-{{#if isFixed}}
-  <div class="et-td is-fixed" style={{fixedCellStyle}}>
-    {{#if column.hasCheckbox}}
-      {{-ember-table-private/simple-checkbox checked=rowSelected onClick="onCheckboxClicked" onChange="onChecked"}}
-    {{/if}}
-    {{yield cell}}
-  </div>
-{{else}}
-  {{#if column.hasCheckbox}}
-    {{-ember-table-private/simple-checkbox checked=rowSelected onClick="onCheckboxClicked" onChange="onChecked"}}
-  {{/if}}
-  {{yield cell}}
+{{#if column.hasCheckbox}}
+  {{-ember-table-private/simple-checkbox checked=rowSelected onClick="onCheckboxClicked" onChange="onChecked"}}
 {{/if}}
+{{yield cell}}

--- a/addon/templates/components/ember-table-footer.hbs
+++ b/addon/templates/components/ember-table-footer.hbs
@@ -1,27 +1,11 @@
-{{#if isFixed}}
-  <div class="et-tf is-fixed" style={{fixedCellStyle}}>
-    {{#if column.footerComponent}}
-      {{component column.footerComponent
-        column=column
-        rowValue=rowValue
-        rowIndex=rowIndex
-        columnIndex=columnIndex
-        onFooterEvent="sendFooterEvent"
-      }}
-    {{else}}
-      {{footerValue}}
-    {{/if}}
-  </div>
+{{#if column.footerComponent}}
+  {{component column.footerComponent
+    column=column
+    rowValue=rowValue
+    rowIndex=rowIndex
+    columnIndex=columnIndex
+    onFooterEvent="sendFooterEvent"
+  }}
 {{else}}
-  {{#if column.footerComponent}}
-    {{component column.footerComponent
-      column=column
-      rowValue=rowValue
-      rowIndex=rowIndex
-      columnIndex=columnIndex
-      onFooterEvent="sendFooterEvent"
-    }}
-  {{else}}
-    {{footerValue}}
-  {{/if}}
+  {{footerValue}}
 {{/if}}

--- a/addon/templates/components/ember-table-header.hbs
+++ b/addon/templates/components/ember-table-header.hbs
@@ -1,35 +1,15 @@
-{{#if isFixed}}
-  <div class="et-th is-fixed" style={{fixedCellStyle}}>
-    {{#if column.headerComponent}}
-      {{#component column.headerComponent
-        column=column
-        columnIndex=columnIndex
-        onHeaderEvent="sendHeaderEvent"
-      }}
-      {{/component}}
-    {{else}}
-      {{column.columnName}}
-    {{/if}}
-
-    {{#if column.isResizable}}
-      <div class="et-header-resize-area">
-      </div>
-    {{/if}}
-  </div>
+{{#if column.headerComponent}}
+  {{#component column.headerComponent
+    column=column
+    columnIndex=columnIndex
+    onHeaderEvent="sendHeaderEvent"
+  }}
+  {{/component}}
 {{else}}
-  {{#if column.headerComponent}}
-    {{#component column.headerComponent
-      column=column
-      columnIndex=columnIndex
-      onHeaderEvent="sendHeaderEvent"
-    }}
-    {{/component}}
-  {{else}}
-    {{column.columnName}}
-  {{/if}}
+  {{column.columnName}}
+{{/if}}
 
-  {{#if column.isResizable}}
-    <div class="et-header-resize-area">
-    </div>
-  {{/if}}
+{{#if column.isResizable}}
+  <div class="et-header-resize-area">
+  </div>
 {{/if}}

--- a/addon/templates/components/ember-table.hbs
+++ b/addon/templates/components/ember-table.hbs
@@ -1,6 +1,6 @@
-<div class="et-thead-container">
-  <thead class="et-thead">
-    <tr class="et-tr">
+<table>
+  <thead>
+    <tr>
       {{#each columns as |column columnIndex|}}
         {{ember-table-header
           column=column
@@ -18,7 +18,7 @@
     </tr>
 
     {{#if hasSubcolumns}}
-      <tr class="et-tr">
+      <tr>
         {{#each columns as |column columnIndex|}}
           {{#each column.subcolumns as |subcolumn subcolumnIndex|}}
             {{ember-table-header
@@ -38,10 +38,8 @@
       </tr>
     {{/if}}
   </thead>
-</div>
 
-<div class="et-tbody-container" data-test-body-container>
-  <tbody class="et-tbody">
+  <tbody>
     {{#component _bodyComponent
       api=api
       rows=rows
@@ -52,13 +50,11 @@
       {{yield row}}
     {{/component}}
   </tbody>
-</div>
 
-{{#if footerRows}}
-  <div class="et-tfoot-container">
-    <tfoot class="et-tfoot">
+  {{#if footerRows}}
+    <tfoot>
       {{#each footerRows as |footerRow footerRowIndex|}}
-        <tr class="et-tr">
+        <tr>
         {{#each bodyColumns as |column columnIndex|}}
           {{ember-table-footer
             column=column
@@ -72,10 +68,6 @@
         </tr>
       {{/each}}
     </tfoot>
-  </div>
-{{/if}}
-
-<div class="et-horizontal-scroll-wrapper" style={{horizontalScrollWrapperStyle}}>
-  <div class="et-horizontal-scroll" style={{horizontalScrollStyle}} />
-</div>
+  {{/if}}
+</table>
 

--- a/addon/templates/components/tree-table-body.hbs
+++ b/addon/templates/components/tree-table-body.hbs
@@ -1,7 +1,7 @@
 {{#vertical-collection rows
   estimateHeight=estimateRowHeight
   staticHeight=staticHeight
-  containerSelector=".et-tbody-container"
+  containerSelector=".ember-table"
 
   as |rowValue rowIndex|
 }}

--- a/addon/utils/sticky-polyfill.js
+++ b/addon/utils/sticky-polyfill.js
@@ -1,0 +1,83 @@
+/* global ResizeSensor */
+
+/**
+  These functions polyfill our usage of position: sticky; in IE11. They are not a general
+  position: sticky; polyfill, and should not be used as such.
+*/
+
+export const IS_IE = window.navigator.userAgent.match(/MSIE|Trident\/7.0/);
+
+function positionStickyElements(component) {
+  let thead = component._header;
+  let tfoot = component._footer;
+
+  let leftColumn = component.element.querySelectorAll('tr > *:first-child');
+
+  let scrollLeft = component.element.scrollLeft;
+  let scrollTop = component.element.scrollTop;
+
+  thead.style.position = 'absolute';
+  tfoot.style.position = 'absolute';
+
+  thead.style.transform = `translateY(${scrollTop}px)`;
+  tfoot.style.transform = `translateY(${scrollTop}px)`;
+
+  component._fakeHeaderRow.style.height = `${thead.offsetHeight}px`;
+  component._fakeFooterRow.style.height = `${tfoot.offsetHeight}px`;
+
+  for (let cell of leftColumn) {
+    cell.style.transform = `translateX(${scrollLeft}px)`;
+  }
+
+}
+
+export function setupStickyPolyfill(component) {
+  component._table = component.element.querySelector('table');
+  component._header = component.element.querySelector('thead');
+  component._footer = component.element.querySelector('tfoot');
+
+  if (component._header) {
+    component._fakeHeader = document.createElement('thead');
+    component._fakeHeaderRow = document.createElement('tr');
+    component._fakeHeader.insertBefore(component._fakeHeaderRow, null);
+
+    component._table.insertBefore(component._fakeHeader, component._table.firstChild);
+  }
+
+  if (component._footer) {
+    component._fakeFooter = document.createElement('tfoot');
+    component._fakeFooterRow = document.createElement('tr');
+    component._fakeFooter.insertBefore(component._fakeFooterRow, null);
+
+    component._table.insertBefore(component._fakeFooter, null);
+  }
+
+  component._repositionHandler = positionStickyElements.bind(null, component);
+
+  component.element.addEventListener('scroll', component._repositionHandler);
+
+  component._mainResizeSensor = new ResizeSensor(
+    component.element,
+    component._repositionHandler
+  );
+
+  component._headerResizeSensor = new ResizeSensor(
+    component._header,
+    component._repositionHandler
+  );
+
+  component._footerResizeSensor = new ResizeSensor(
+    component._footer,
+    component._repositionHandler
+  );
+
+  positionStickyElements(component);
+}
+
+export function teardownStickyPolyfill(component) {
+  component.element.removeEventListener('scroll', component._repositionHandler);
+
+  component._mainResizeSensor.detach(component.element);
+  component._headerResizeSensor.detach(component.element);
+  component._footerResizeSensor.detach(component.element);
+}

--- a/app/styles/ember-table/default.scss
+++ b/app/styles/ember-table/default.scss
@@ -5,37 +5,28 @@ $table-header-background-color: #f8f8f8;
 $table-border-color: #dcdcdc;
 $table-hover-color: #e5edf8;
 
-.et-table {
+.ember-table {
   border: solid 1px #ddd;
 
-  .et-thead {
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-
-  }
-
-  .et-tfoot {
-    border-top: solid 1px $table-border-color;
-  }
-
-  .et-th, .et-td, .et-tf {
+  th, td {
     white-space: nowrap;
     text-overflow: ellipsis;
     font-size: 20px;
+    padding: 4px 10px;
   }
 
-  td, .et-td {
-    border-bottom: $table-border-color 1px dotted;
-    border-right: $table-border-color 1px solid;
-    background-color: white;
-  }
-
-  .et-td {
-    &.is-fixed {
-      margin-top: -1px;
+  tbody {
+    td {
+      border-top: 0;
+      border-left: 0;
+      border-bottom: $table-border-color 1px dotted;
+      border-right: $table-border-color 1px solid;
+      background-color: white;
     }
   }
 
-  .et-th, th, .et-tf {
+
+  th, tfoot td {
     padding: 5px 0px 3px 0px;
     background-color: $table-header-background-color;
     font-family: 'Univers LT W01 65 Bold';
@@ -43,33 +34,41 @@ $table-hover-color: #e5edf8;
     font-weight: bold;
     text-align: center;
     box-sizing: border-box;
-    border-bottom: 1px solid $table-border-color;
   }
 
-  .et-th, .et-tf {
+  tfoot td {
+    border-top: 1px solid $table-border-color;
     border-right: solid 1px $table-border-color;
   }
 
-  .et-tr:hover {
-    .et-td, .et-th {
+  thead th {
+    border-bottom: 1px solid $table-border-color;
+    border-right: solid 1px $table-border-color;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+  }
+
+  tr:hover {
+    td, th {
       cursor: pointer;
       background-color: $table-hover-color;
     }
   }
 
-  .et-tr.is-selected {
-    .et-td, .et-th {
+  tr.is-selected {
+    td, th {
       background-color: #227ecb;
     }
   }
 
   .et-header-ghost-element {
+    position: absolute;
     background: #CCC;
     opacity: 0.8;
     cursor: move;
   }
 
   .et-header-align-bar {
+    position: absolute;
     background: #444;
     opacity: 0.6;
   }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ember-native-dom-helpers": "^0.6.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.16.0",
+    "ember-test-selectors": "^0.3.9",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/tests/dummy/app/controllers/demo.js
+++ b/tests/dummy/app/controllers/demo.js
@@ -24,13 +24,13 @@ export default Controller.extend({
   tree: computed(function() {
     let tree = generateRow('Top Row');
 
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 3; i++) {
       let header = generateRow(`Header ${i}`);
 
-      for (let j = 0; j < 10; j++) {
+      for (let j = 0; j < 3; j++) {
         let group = generateRow(`Group ${j}`);
 
-        for (let k = 0; k < 10; k++) {
+        for (let k = 0; k < 3; k++) {
           group.children.push(generateRow(`Leaf ${k}`));
         }
 

--- a/tests/dummy/app/styles/tables.scss
+++ b/tests/dummy/app/styles/tables.scss
@@ -9,6 +9,12 @@
   margin-right: 100px;
 }
 
+.et-table {
+  td, th {
+    background: white;
+  }
+}
+
 .red-cell {
   background: red;
 }

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -23,6 +23,8 @@ const fullTable = hbs`
       onColumnReordered="onColumnReordered"
       onColumnResized="onColumnResized"
 
+      data-test-ember-table=true
+
       as |row|
     }}
 

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -46,7 +46,7 @@ module('Integration | basic', function() {
       );
 
       // scroll all the way down
-      await scrollTo('[data-test-body-container]', 0, 10000);
+      await scrollTo('[data-test-ember-table]', 0, 10000);
 
       assert.notEqual(table.getCell(0, 0).text.trim(), '0A', 'first rendered row is not first data row');
       assert.equal(

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -5,7 +5,7 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import generateTable, { generateColumns, generateRows } from '../../helpers/generate-table';
 import { componentModule } from '../../helpers/module';
 
-import { find, scrollTo } from 'ember-native-dom-helpers';
+import { find, findAll, scrollTo } from 'ember-native-dom-helpers';
 
 import TablePage from 'ember-table/test-support/pages/ember-table';
 import { collection, hasClass } from 'ember-classy-page-object';
@@ -52,6 +52,52 @@ module('Integration | basic', function() {
       assert.equal(
         table.getCell(table.rows.length - 1, 0).text.trim(), '99A', 'correct last row rendered'
       );
+    });
+
+    test('fixed cells work', async function(assert) {
+      function validateElements(container, elements, measurement) {
+        for (let element of elements) {
+          let rect = element.getBoundingClientRect();
+
+          // Travis reports pretty wide differences for some reason, possibly
+          // their Chrome version. It does validate that the elements are moving
+          // and that should be enough to know if we messed something up majorly.
+          //
+          // TODO(sticky): Try to lower the tolerance as sticky becomes more prevalent
+          assert.ok(container[measurement] - rect[measurement] < 10);
+        }
+      }
+
+      await generateTable(this, {
+        rowCount: 100,
+        columnCount: 30,
+        footerRowCount: 1,
+        numFixedColumns: 1
+      });
+
+      let tableContainerRect = find('.ember-table').getBoundingClientRect();
+
+      validateElements(tableContainerRect, findAll('thead th'), 'top');
+      validateElements(tableContainerRect, findAll('tr > *:first-child'), 'left');
+      validateElements(tableContainerRect, findAll('tfoot td'), 'bottom');
+
+      await scrollTo('[data-test-ember-table]', 10000, 0);
+
+      validateElements(tableContainerRect, findAll('thead th'), 'top');
+      validateElements(tableContainerRect, findAll('tr > *:first-child'), 'left');
+      validateElements(tableContainerRect, findAll('tfoot td'), 'bottom');
+
+      await scrollTo('[data-test-ember-table]', 10000, 10000);
+
+      validateElements(tableContainerRect, findAll('thead th'), 'top');
+      validateElements(tableContainerRect, findAll('tr > *:first-child'), 'left');
+      validateElements(tableContainerRect, findAll('tfoot td'), 'bottom');
+
+      await scrollTo('[data-test-ember-table]', 0, 10000);
+
+      validateElements(tableContainerRect, findAll('thead th'), 'top');
+      validateElements(tableContainerRect, findAll('tr > *:first-child'), 'left');
+      validateElements(tableContainerRect, findAll('tfoot td'), 'bottom');
     });
 
     test('Accessibility test', async function(assert) {


### PR DESCRIPTION
This PR switches us to a rendering strategy using position: sticky;
in all modern browsers. This is much more performant and simpler in the
code, and maintains semantic table structure - everything we've been
after!

For IE11, the only browser we support which does not support sticky, we
use a rudimentary polyfill. The polyfill is not comprehensive, it only
solves our exact use case by using `translateX/Y` on scroll.

