### PR TITLE
The `tree` attribute is correctly observed by the table

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -377,7 +377,7 @@ export default class EmberTable extends Component {
     }
   }
 
-  @computed('rows')
+  @computed('rows', 'tree')
   get wrappedRows() {
     let rows = this.get('rows') || this.get('tree');
 

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -7,6 +7,7 @@ const fullTable = hbs`
   <div style="height: 500px;">
     {{#ember-table
       columns=columns
+      tree=tree
       rows=rows
       footerRows=footerRows
       selectedRows=selectedRows
@@ -108,6 +109,7 @@ export default async function generateTable(testContext, {
   columnCount = 10,
   columnOptions,
   hasCheckbox = false,
+  useTree = false,
 
   rowComponent = 'ember-table-row',
 
@@ -133,7 +135,7 @@ export default async function generateTable(testContext, {
   columns[0].hasCheckbox = hasCheckbox;
 
   testContext.set('columns', columns);
-  testContext.set('rows', rows);
+  testContext.set(useTree ? 'tree' : 'rows', rows);
   testContext.set('footerRows', footerRows);
 
   for (let action in defaultActions) {

--- a/tests/integration/components/tree-test.js
+++ b/tests/integration/components/tree-test.js
@@ -1,0 +1,27 @@
+import { module, moduleForComponent, test } from 'ember-qunit';
+
+import TablePage from 'ember-table/test-support/pages/ember-table';
+
+import generateTable, { generateRows } from '../../helpers/generate-table';
+import wait from 'ember-test-helpers/wait';
+
+let table = TablePage.create();
+
+module('Integration | Tree', () => {
+  moduleForComponent('ember-table', 'multiple', { integration: true });
+
+  test('Tree attribute is observed', async function(assert) {
+    // render the table
+    let rowCount = 10;
+    await generateTable(this, { rowCount, useTree: true });
+    assert.equal(table.rows.length, rowCount, 'renders all rows');
+
+    // regenerate all the rows
+    let newRowCount = rowCount + 2;
+    let newRows = generateRows(newRowCount, 10);
+    this.set('tree', newRows);
+
+    await wait();
+    assert.equal(table.rows.length, newRowCount, 'renders new tree');
+  });
+});


### PR DESCRIPTION
reviewers: @Addepar/ice 

fixes #514 