### PR TITLE
[bugfix] Ensures Cell Meta is unique per table instance

### DIFF
--- a/addon/components/-private/row-wrapper.js
+++ b/addon/components/-private/row-wrapper.js
@@ -31,9 +31,11 @@ class CellWrapper extends EmberObject {
     let { _cellMeta } = this;
     let row = get(this, 'rowValue');
     let valuePath = get(this, 'columnValue.valuePath');
+    let cellMetaCache = get(this, 'cellMetaCache');
 
     set(_cellMeta, 'row', row);
     set(_cellMeta, 'valuePath', valuePath);
+    set(_cellMeta, 'cellMetaCache', cellMetaCache);
 
     return _cellMeta;
   }
@@ -58,8 +60,9 @@ export default class RowWrapper extends Component {
   @argument selectRow;
   @argument toggleRowCollapse;
 
-  @argument rowMetaCache;
+  @argument cellMetaCache;
   @argument columnMetaCache;
+  @argument rowMetaCache;
 
   _cells = emberA([]);
 
@@ -89,6 +92,7 @@ export default class RowWrapper extends Component {
 
   @computed('rowValue', 'rowMeta', 'columns.[]')
   get cells() {
+    let cellMetaCache = this.get('cellMetaCache');
     let selectRow = this.get('selectRow');
     let toggleRowCollapse = this.get('toggleRowCollapse');
     let selectMode = this.get('onSelect') ? this.get('selectMode') : 'none';
@@ -104,6 +108,7 @@ export default class RowWrapper extends Component {
     if (numColumns !== _cells.length) {
       while (_cells.length < numColumns) {
         let cell = CellWrapper.create({
+          cellMetaCache,
           selectMode,
           selectRow,
           toggleRowCollapse,

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -90,6 +90,7 @@ export default class EmberTBody extends Component {
     return CollapseTree.create({ tree: rows ? rows : [] });
   }
 
+  cellMetaCache = new WeakMap();
   rowMetaCache = new WeakMap();
 
   /**

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -20,8 +20,9 @@
     selectRow=selectRow
     toggleRowCollapse=toggleRowCollapse
 
-    rowMetaCache=rowMetaCache
+    cellMetaCache=cellMetaCache
     columnMetaCache=columnMetaCache
+    rowMetaCache=rowMetaCache
 
     as |rowValue rowMeta cells|
   }}

--- a/addon/utils/cell-proxy.js
+++ b/addon/utils/cell-proxy.js
@@ -2,16 +2,15 @@
 import EmberObject, { get } from '@ember/object';
 import { addObserver } from '@ember/object/observers';
 
-const CELL_CACHE = new WeakMap();
-
 export default class CellProxy extends EmberObject {
   constructor() {
-    super();
+    super(...arguments);
 
     this._watchedProperties = [];
 
     this.row = null;
     this.valuePath = null;
+    this.cellMetaCache = null;
 
     addObserver(this, 'row', this.notifyPropertyChanges);
     addObserver(this, 'valuePath', this.notifyPropertyChanges);
@@ -40,9 +39,10 @@ export default class CellProxy extends EmberObject {
   unknownProperty(key) {
     let row = get(this, 'row');
     let valuePath = get(this, 'valuePath');
+    let cellMetaCache = get(this, 'cellMetaCache');
 
-    if (CELL_CACHE.has(row)) {
-      return CELL_CACHE.get(row)[`${valuePath}:${key}`];
+    if (cellMetaCache.has(row)) {
+      return cellMetaCache.get(row)[`${valuePath}:${key}`];
     }
 
     return undefined;
@@ -51,12 +51,13 @@ export default class CellProxy extends EmberObject {
   setUnknownProperty(key, value) {
     let row = get(this, 'row');
     let valuePath = get(this, 'valuePath');
+    let cellMetaCache = get(this, 'cellMetaCache');
 
-    if (!CELL_CACHE.has(row)) {
-      CELL_CACHE.set(row, Object.create(null));
+    if (!cellMetaCache.has(row)) {
+      cellMetaCache.set(row, Object.create(null));
     }
 
-    CELL_CACHE.get(row)[`${valuePath}:${key}`] = value;
+    cellMetaCache.get(row)[`${valuePath}:${key}`] = value;
 
     Ember.propertyDidChange(this, key);
 

--- a/tests/integration/components/meta-test.js
+++ b/tests/integration/components/meta-test.js
@@ -51,7 +51,7 @@ module('Integration | meta', function() {
               {{/ember-tr}}
             {{/ember-tbody}}
 
-            {{#ember-tfoot api=t rows=rows as |f|}}
+            {{#ember-tfoot api=t rows=footerRows as |f|}}
               {{#ember-tr api=f as |r|}}
                 {{#ember-td api=r as |value column row cellMeta columnMeta rowMeta|}}
                   {{#if columnMeta.wasClicked}}column{{/if}}
@@ -117,7 +117,7 @@ module('Integration | meta', function() {
         set(rowMeta, 'wasClicked', true);
       });
 
-      generateTableValues(this, { rowCount: 10, footerRowCount: 1 });
+      generateTableValues(this, { rowCount: 100, footerRowCount: 1 });
 
       this.render(hbs`
         <div style="height: 500px;">
@@ -147,7 +147,7 @@ module('Integration | meta', function() {
               {{/ember-tr}}
             {{/ember-tbody}}
 
-            {{#ember-tfoot api=t rows=rows as |f|}}
+            {{#ember-tfoot api=t rows=footerRows as |f|}}
               {{#ember-tr api=f as |r|}}
                 {{#ember-td api=r as |value column row cellMeta columnMeta rowMeta|}}
                   {{#if columnMeta.wasClicked}}column{{/if}}
@@ -185,7 +185,7 @@ module('Integration | meta', function() {
               {{/ember-tr}}
             {{/ember-tbody}}
 
-            {{#ember-tfoot api=t rows=rows as |f|}}
+            {{#ember-tfoot api=t rows=footerRows as |f|}}
               {{#ember-tr api=f as |r|}}
                 {{#ember-td api=r as |value column row cellMeta columnMeta rowMeta|}}
                   {{#if columnMeta.wasClicked}}column{{/if}}
@@ -199,6 +199,12 @@ module('Integration | meta', function() {
 
       await wait();
       await table.getCell(0, 0).click();
+
+      // ensure we trigger property updates by scrolling around a bit
+      await scrollTo('[data-test-other-table]', 0, 10000);
+      await scrollTo('[data-test-other-table]', 0, 1000);
+      await scrollTo('[data-test-other-table]', 0, 100);
+      await scrollTo('[data-test-other-table]', 0, 0);
 
       // Main table was affected
       assert.ok(table.getCell(0, 0).text.includes('cell'), 'meta property set correctly');


### PR DESCRIPTION
We were using a single WeakMap for cell meta globally rather than one per instance, and the tests weren't catching it since they don't actually watch the meta cache directly. This PR updates the rows by scrolling to make sure it checks the cache again, and adds a unique cell cache per table.