### PR TITLE
[bugfix] Plugs Memory leaks

### DIFF
--- a/addon/-private/utils/array.js
+++ b/addon/-private/utils/array.js
@@ -1,11 +1,25 @@
 import { compare } from '@ember/utils';
+import { isArray } from '@ember/array';
+import { assert } from '@ember/debug';
 
-export function objectAt(items, index) {
-  if (typeof items.objectAt === 'function') {
-    return items.objectAt(index);
+/**
+  Genericizes `objectAt` so it can be run against a normal array or an Ember array
+
+  @param {object|Array} arr
+  @param {number} index
+  @return {any}
+*/
+export function objectAt(arr, index) {
+  assert(
+    'arr must be an instance of a Javascript Array or implement `objectAt`',
+    isArray(arr) || typeof arr.objectAt === 'function'
+  );
+
+  if (typeof arr.objectAt === 'function') {
+    return arr.objectAt(index);
   }
 
-  return items[index];
+  return arr[index];
 }
 
 export function splice(items, start, count, ...add) {

--- a/addon/components/-private/row-wrapper.js
+++ b/addon/components/-private/row-wrapper.js
@@ -66,6 +66,12 @@ export default class RowWrapper extends Component {
 
   _cells = emberA([]);
 
+  destroy() {
+    super.destroy(...arguments);
+
+    this._cells.forEach(cell => cell.destroy());
+  }
+
   @computed('rowValue', 'rowParents', 'rowIsCollapsed', 'selectedRows.[]')
   get rowMeta() {
     let rowValue = this.get('rowValue');

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -83,12 +83,7 @@ export default class EmberTBody extends Component {
   @type(optional('object'))
   tree;
 
-  @computed('rows', 'tree')
-  get wrappedRows() {
-    let rows = this.get('rows') || this.get('tree');
-
-    return CollapseTree.create({ tree: rows ? rows : [] });
-  }
+  collapseTree = CollapseTree.create();
 
   cellMetaCache = new WeakMap();
   rowMetaCache = new WeakMap();
@@ -97,6 +92,19 @@ export default class EmberTBody extends Component {
     The index of the last item that was selected, used for range selection
   */
   _lastSelectedIndex = 0;
+
+  willDestroy() {
+    this.collapseTree.destroy();
+  }
+
+  @computed('rows', 'tree')
+  get wrappedRows() {
+    let rows = this.get('rows') || this.get('tree');
+
+    this.collapseTree.set('tree', rows ? rows : []);
+
+    return this.collapseTree;
+  }
 
   selectRow = (rowIndex, { toggle, range }) => {
     let rows = this.get('wrappedRows');

--- a/addon/components/ember-th/component.js
+++ b/addon/components/ember-th/component.js
@@ -108,6 +108,8 @@ export default class EmberTh extends Component {
     hammer.off('panmove');
     hammer.off('panend');
 
+    hammer.destroy();
+
     super.willDestroyElement(...arguments);
   }
 

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -94,6 +94,32 @@ export default class EmberTHead extends Component {
 
   columnMetaCache = new WeakMap();
 
+  columnTree = ColumnTree.create({ component: this, columnMetaCache: this.columnMetaCache });
+
+  constructor() {
+    super(...arguments);
+
+    this.get('api').registerColumnTree(this.columnTree);
+  }
+
+  didInsertElement() {
+    super.didInsertElement(...arguments);
+
+    this._container = this.element.closest('.ember-table');
+
+    this.columnTree.registerContainer(this._container);
+
+    this._tableResizeSensor = new ResizeSensor(this._container, bind(this.fillupHandler));
+  }
+
+  willDestroyElement() {
+    this._tableResizeSensor.detach(this._container);
+
+    this.columnTree.destroy();
+
+    super.willDestroyElement(...arguments);
+  }
+
   @computed('columnTree.rows.[]', 'enableReorder', 'enableResize', 'fillMode')
   get wrappedRows() {
     let rows = this.get('columnTree.rows');
@@ -117,31 +143,6 @@ export default class EmberTHead extends Component {
         )
       )
     );
-  }
-
-  constructor() {
-    super(...arguments);
-
-    this.columnTree = ColumnTree.create({ component: this, columnMetaCache: this.columnMetaCache });
-    this.get('api').registerColumnTree(this.columnTree);
-  }
-
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-
-    this._container = this.element.closest('.ember-table');
-
-    this.columnTree.registerContainer(this._container);
-
-    this._tableResizeSensor = new ResizeSensor(this._container, bind(this.fillupHandler));
-  }
-
-  willDestroyElement() {
-    this._tableResizeSensor.detach(this._container);
-
-    this.columnTree.destroy();
-
-    super.willDestroyElement(...arguments);
   }
 
   fillupHandler = () => {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,6 +7,7 @@ module.exports = function() {
     getChannelURL('canary'),
   ]).then(urls => {
     return {
+      useYarn: true,
       scenarios: [
         {
           name: 'ember-1.11',


### PR DESCRIPTION
We had a number of memory leaks being caused primarily by nodes from the
ColumnTree and CollapseTree being referenced and un-garbage-collectable.
It turned out that this was due to their Ember Meta objects not being
destroyed - in certain cases, meta objects (in particular, chains) can
have dangling references.

This PR converts all objects to using EmberObject so we can clean up
their metas, and creates private caches for nodes in the trees so they
can clean up their children if they need to create a new set of nodes.

Also caught a memory leak caused by Hammer (gotta call `destroy`) and
a memory leak caused by the cell proxies in RowWrapper.

Fixes #523