### PR TITLE
[feat] Implement Column Sorting and Actions

### DIFF
--- a/addon-test-support/pages/-private/ember-table-header.js
+++ b/addon-test-support/pages/-private/ember-table-header.js
@@ -1,5 +1,9 @@
-import PageObject, { collection, hasClass } from 'ember-classy-page-object';
+import PageObject, { alias, collection, hasClass } from 'ember-classy-page-object';
 import { findElement } from 'ember-classy-page-object/extend';
+import { click } from 'ember-native-dom-helpers';
+
+import AddeDropdownPage from '@addepar/pop-menu/test-support/pages/adde-dropdown';
+import AddeSubDropdownPage from '@addepar/pop-menu/test-support/pages/adde-sub-dropdown';
 
 import { mouseDown, mouseMove, mouseUp } from '../../helpers/mouse';
 import { getScale } from '../../helpers/element';
@@ -61,6 +65,55 @@ const Header = PageObject.extend({
     await mouseMove(header, startX, header.clientHeight / 2);
     await mouseMove(header, startX + deltaX, header.clientHeight / 2);
     await mouseUp(header, startX + deltaX, header.clientHeight / 2);
+  },
+
+  sortToggle: {
+    scope: '[data-test-sort-toggle]',
+
+    /**
+      Helper function to click with options like the meta key and ctrl key set
+
+      @param {Object} options - click event options
+    */
+    async clickWith(options) {
+      await click(findElement(this), options);
+    },
+  },
+
+  sortIndicator: {
+    scope: '[data-test-sort-indicator]',
+    isAscending: hasClass('ascending'),
+    isDescending: hasClass('descending'),
+  },
+
+  actionDropdown: {
+    scope: '[data-test-action-dropdown]',
+
+    dropdown: AddeDropdownPage.extend({
+      scope: '[data-test-action-dropdown-menu]',
+
+      content: {
+        items: collection({
+          scope: 'li > button',
+
+          subDropdown: AddeSubDropdownPage.extend({
+            scope: '[data-test-action-sub-dropdown-menu]',
+
+            content: {
+              items: collection({
+                scope: 'li > button',
+              }),
+            },
+          }),
+
+          subActions: alias('subDropdown.content.items'),
+        }),
+      },
+    }),
+
+    open: alias('dropdown.open'),
+    close: alias('dropdown.close'),
+    items: alias('dropdown.content.items'),
   },
 });
 

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -9,6 +9,7 @@ import { addObserver } from '@ember/object/observers';
 import { objectAt } from './utils/array';
 import { notifyPropertyChange } from './utils/ember';
 import { getOrCreate } from './meta-cache';
+import { mergeSort } from './utils/sort';
 
 export const SELECT_MODE = {
   SINGLE: 'single',
@@ -69,7 +70,7 @@ class TableRowMeta extends EmberObject {
     return selectedRows.includes(rowValue) || get(this, '_parentMeta.isSelected');
   }
 
-  @computed('_tree.{enableTree,enableCollapse}', 'value.children.[]')
+  @computed('_tree.{enableTree,enableCollapse}', '_rowValue.children.[]')
   get canCollapse() {
     if (!get(this, '_tree.enableTree') || !get(this, '_tree.enableCollapse')) {
       return false;
@@ -256,7 +257,7 @@ function closestLessThan(values, target) {
   Single node of a CollapseTree
 */
 class CollapseTreeNode extends EmberObject {
-  _children = null;
+  _childNodes = null;
 
   constructor() {
     super(...arguments);
@@ -288,7 +289,7 @@ class CollapseTreeNode extends EmberObject {
   destroy() {
     super.destroy(...arguments);
 
-    this.cleanChildren();
+    this.cleanChildNodes();
   }
 
   /**
@@ -296,14 +297,14 @@ class CollapseTreeNode extends EmberObject {
     node is destroyed. If children are not destroyed, they will leak memory due
     to dangling references in Ember Meta.
   */
-  cleanChildren() {
-    if (this._children) {
-      for (let child of this._children) {
+  cleanChildNodes() {
+    if (this._childNodes) {
+      for (let child of this._childNodes) {
         if (child instanceof CollapseTreeNode) {
           child.destroy();
         }
       }
-      this._children = null;
+      this._childNodes = null;
     }
   }
 
@@ -323,6 +324,23 @@ class CollapseTreeNode extends EmberObject {
     }
 
     return !get(this, 'value.children').some(child => isArray(get(child, 'children')));
+  }
+
+  @computed('value.children.[]', 'tree.{sorts.[],sortFunction,compareFunction}')
+  get sortedChildren() {
+    let valueChildren = get(this, 'value.children');
+
+    let sorts = get(this, 'tree.sorts');
+    let sortFunction = get(this, 'tree.sortFunction');
+    let compareFunction = get(this, 'tree.compareFunction');
+
+    if (sortFunction && compareFunction && sorts && get(sorts, 'length') > 0) {
+      valueChildren = mergeSort(valueChildren, (itemA, itemB) => {
+        return sortFunction(itemA, itemB, sorts, compareFunction);
+      });
+    }
+
+    return valueChildren;
   }
 
   /**
@@ -352,25 +370,25 @@ class CollapseTreeNode extends EmberObject {
 
     @type Array<Node|Array<object>>
   */
-  @computed('value.children.[]', 'isLeaf')
-  get children() {
-    this.cleanChildren();
+  @computed('sortedChildren.[]', 'isLeaf')
+  get childNodes() {
+    this.cleanChildNodes();
 
     if (get(this, 'isLeaf')) {
       return null;
     }
 
-    let valueChildren = get(this, 'value.children');
+    let sortedChildren = get(this, 'sortedChildren');
     let tree = get(this, 'tree');
     let children = [];
     let sliceStart = false;
 
-    valueChildren.forEach((child, index) => {
+    sortedChildren.forEach((child, index) => {
       let grandchildren = get(child, 'children');
 
       if (isArray(grandchildren) && get(grandchildren, 'length') > 0) {
         if (sliceStart !== false) {
-          children.push(valueChildren.slice(sliceStart, index));
+          children.push(sortedChildren.slice(sliceStart, index));
           sliceStart = false;
         }
 
@@ -381,10 +399,10 @@ class CollapseTreeNode extends EmberObject {
     });
 
     if (sliceStart !== false) {
-      children.push(valueChildren.slice(sliceStart));
+      children.push(sortedChildren.slice(sliceStart));
     }
 
-    this._children = children;
+    this._childNodes = children;
 
     return children;
   }
@@ -400,14 +418,20 @@ class CollapseTreeNode extends EmberObject {
         length of its value-children.
     3. Otherwise, the length is the sum of the lengths of its children.
   */
-  @computed('rowMeta.isCollapsed', 'value.children.[]', 'tree.enableTree', 'isLeaf')
+  @computed(
+    'childNodes.[]',
+    'sortedChildren.[]',
+    'isLeaf',
+    'rowMeta.isCollapsed',
+    'tree.enableTree'
+  )
   get length() {
     if (get(this, 'rowMeta.isCollapsed') === true) {
       return 1;
     } else if (get(this, 'isLeaf')) {
-      return 1 + get(this, 'value.children.length');
+      return 1 + get(this, 'sortedChildren.length');
     } else {
-      return 1 + get(this, 'children').reduce((sum, child) => sum + get(child, 'length'), 0);
+      return 1 + get(this, 'childNodes').reduce((sum, child) => sum + get(child, 'length'), 0);
     }
   }
 
@@ -452,7 +476,7 @@ class CollapseTreeNode extends EmberObject {
     let offset = 0;
     let offsetList = [];
 
-    for (let child of get(this, 'children')) {
+    for (let child of get(this, 'childNodes')) {
       offsetList.push(offset);
       offset += get(child, 'length');
     }
@@ -495,19 +519,19 @@ class CollapseTreeNode extends EmberObject {
     let tree = get(this, 'tree');
 
     if (get(this, 'isLeaf')) {
-      let value = objectAt(get(this, 'value.children'), normalizedIndex);
+      let value = objectAt(get(this, 'sortedChildren'), normalizedIndex);
       setupRowMeta(tree, value, get(this, 'value'));
 
       return value;
     }
 
-    let children = get(this, 'children');
+    let childNodes = get(this, 'childNodes');
     let offsetList = get(this, 'offsetList');
     let offsetIndex = closestLessThan(offsetList, normalizedIndex);
 
     normalizedIndex = normalizedIndex - offsetList[offsetIndex];
 
-    let child = children[offsetIndex];
+    let child = childNodes[offsetIndex];
 
     if (Array.isArray(child)) {
       let value = child[normalizedIndex];

--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -8,7 +8,8 @@ import { readOnly } from '@ember-decorators/object/computed';
 import { scheduler, Token } from 'ember-raf-scheduler';
 
 import { getOrCreate } from './meta-cache';
-import { move, splice, mergeSort } from './utils/array';
+import { move, splice } from './utils/array';
+import { mergeSort } from './utils/sort';
 import { getScale, getOuterClientRect, getInnerClientRect } from './utils/element';
 import { MainIndicator, DropIndicator } from './utils/reorder-indicators';
 import { notifyPropertyChange } from './utils/ember';

--- a/addon/-private/utils/array.js
+++ b/addon/-private/utils/array.js
@@ -1,4 +1,3 @@
-import { compare } from '@ember/utils';
 import { isArray } from '@ember/array';
 import { assert } from '@ember/debug';
 
@@ -38,57 +37,4 @@ export function move(items, start, end) {
 
   splice(items, start, 1);
   splice(items, end, 0, sourceItem);
-}
-
-function merge(left, right, comparator) {
-  let mergedArray = [];
-  let leftIndex = 0;
-  let rightIndex = 0;
-
-  while (leftIndex < left.length && rightIndex < right.length) {
-    let comparison = comparator(left[leftIndex], right[rightIndex]);
-
-    if (comparison <= 0) {
-      mergedArray.push(left[leftIndex]);
-      leftIndex++;
-    } else {
-      mergedArray.push(right[rightIndex]);
-      rightIndex++;
-    }
-  }
-
-  if (leftIndex < left.length) {
-    mergedArray.splice(mergedArray.length, 0, ...left.slice(leftIndex));
-  }
-
-  if (rightIndex < right.length) {
-    mergedArray.splice(mergedArray.length, 0, ...right.slice(rightIndex));
-  }
-
-  return mergedArray;
-}
-
-/**
- * An implementation of the standard merge sort algorithm.
- *
- * This is necessary because we need a stable sorting algorithm that accepts
- * a general comparator. The built in sort function and Ember's sort functions
- * are not stable, and `_.sortBy` doesn't take a general comparator. Ideally
- * lodash would add a `_.sort` function whose API would mimic this function's.
- *
- * @function
- * @param {Array} array The array to be sorted
- * @param {Comparator} comparator The comparator function to compare elements with.
- * @returns {Array} A sorted array
- */
-export function mergeSort(array, comparator = compare) {
-  if (array.length <= 1) {
-    return array;
-  }
-
-  let middleIndex = Math.floor(array.length / 2);
-  let leftArray = mergeSort(array.slice(0, middleIndex), comparator);
-  let rightArray = mergeSort(array.slice(middleIndex), comparator);
-
-  return merge(leftArray, rightArray, comparator);
 }

--- a/addon/-private/utils/sort.js
+++ b/addon/-private/utils/sort.js
@@ -1,0 +1,105 @@
+import { compare, isNone } from '@ember/utils';
+import { get } from '@ember/object';
+
+function merge(left, right, comparator) {
+  let mergedArray = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+
+  while (leftIndex < left.length && rightIndex < right.length) {
+    let comparison = comparator(left[leftIndex], right[rightIndex]);
+
+    if (comparison <= 0) {
+      mergedArray.push(left[leftIndex]);
+      leftIndex++;
+    } else {
+      mergedArray.push(right[rightIndex]);
+      rightIndex++;
+    }
+  }
+
+  if (leftIndex < left.length) {
+    mergedArray.splice(mergedArray.length, 0, ...left.slice(leftIndex));
+  }
+
+  if (rightIndex < right.length) {
+    mergedArray.splice(mergedArray.length, 0, ...right.slice(rightIndex));
+  }
+
+  return mergedArray;
+}
+
+/**
+ * An implementation of the standard merge sort algorithm.
+ *
+ * This is necessary because we need a stable sorting algorithm that accepts
+ * a general comparator. The built in sort function and Ember's sort functions
+ * are not stable, and `_.sortBy` doesn't take a general comparator. Ideally
+ * lodash would add a `_.sort` function whose API would mimic this function's.
+ *
+ * @function
+ * @param {Array} array The array to be sorted
+ * @param {Comparator} comparator The comparator function to compare elements with.
+ * @returns {Array} A sorted array
+ */
+export function mergeSort(array, comparator = compare) {
+  if (array.length <= 1) {
+    return array;
+  }
+
+  let middleIndex = Math.floor(array.length / 2);
+  let leftArray = mergeSort(array.slice(0, middleIndex), comparator);
+  let rightArray = mergeSort(array.slice(middleIndex), comparator);
+
+  return merge(leftArray, rightArray, comparator);
+}
+
+export function sortMultiple(itemA, itemB, sorts, compare) {
+  let compareValue;
+
+  for (let { valuePath, isAscending } of sorts) {
+    let valueA = get(itemA, valuePath);
+    let valueB = get(itemB, valuePath);
+
+    compareValue = isAscending ? compare(valueA, valueB) : -compare(valueA, valueB);
+
+    if (compareValue !== 0) {
+      break;
+    }
+  }
+
+  return compareValue;
+}
+
+function isExactlyNaN(value) {
+  return typeof value === 'number' && isNaN(value);
+}
+
+function isEmpty(value) {
+  return isNone(value) || isExactlyNaN(value);
+}
+
+function orderEmptyValues(itemA, itemB) {
+  let aIsEmpty = isEmpty(itemA);
+  let bIsEmpty = isEmpty(itemB);
+
+  if (aIsEmpty && !bIsEmpty) {
+    return -1;
+  } else if (bIsEmpty && !aIsEmpty) {
+    return 1;
+  } else if (isNone(itemA) && isExactlyNaN(itemB)) {
+    return -1;
+  } else if (isExactlyNaN(itemA) && isNone(itemB)) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+export function compareValues(itemA, itemB) {
+  if (isEmpty(itemA) || isEmpty(itemB)) {
+    return orderEmptyValues(itemA, itemB);
+  }
+
+  return compare(itemA, itemB);
+}

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -106,6 +106,10 @@ export default class EmberTBody extends Component {
 
     this._updateCollapseTree();
 
+    this.addObserver('api.sorts', this._updateCollapseTree);
+    this.addObserver('api.sortFunction', this._updateCollapseTree);
+    this.addObserver('api.compareFunction', this._updateCollapseTree);
+
     this.addObserver('enableCollapse', this._updateCollapseTree);
     this.addObserver('enableTree', this._updateCollapseTree);
     this.addObserver('selectedRows', this._updateCollapseTree);
@@ -120,6 +124,10 @@ export default class EmberTBody extends Component {
 
   _updateCollapseTree() {
     let onSelect = this.get('onSelect');
+
+    this.collapseTree.set('sorts', this.get('api.sorts'));
+    this.collapseTree.set('sortFunction', this.get('api.sortFunction'));
+    this.collapseTree.set('compareFunction', this.get('api.compareFunction'));
 
     this.collapseTree.set('enableCollapse', this.get('enableCollapse'));
     this.collapseTree.set('enableTree', this.get('enableTree'));

--- a/addon/components/ember-th/action-dropdown/component.js
+++ b/addon/components/ember-th/action-dropdown/component.js
@@ -1,0 +1,24 @@
+import Component from '@ember/component';
+
+import { action } from '@ember-decorators/object';
+import { tagName, classNames } from '@ember-decorators/component';
+import { argument } from '@ember-decorators/argument';
+
+import layout from './template';
+
+@tagName('button')
+@classNames('et-header-actions')
+export default class EmberThDropdown extends Component {
+  layout = layout;
+
+  @argument dropdownActions;
+
+  @argument onDropdownAction;
+
+  @action
+  sendDropdownAction(close, ...args) {
+    this.sendAction('onDropdownAction', ...args);
+
+    close();
+  }
+}

--- a/addon/components/ember-th/action-dropdown/template.hbs
+++ b/addon/components/ember-th/action-dropdown/template.hbs
@@ -1,0 +1,40 @@
++
+{{#adde-dropdown data-test-action-dropdown-menu=true as |close|}}
+  <ul class="adde-dropdown-menu">
+    {{#each dropdownActions as |dropdownAction|}}
+      {{#if dropdownAction.isDivider}}
+        <li class="list-divider" role="separator"></li>
+      {{else if dropdownAction.subActions.length}}
+        <li>
+          <button>
+            {{dropdownAction.text}}
+
+            <div class="adde-dropdown-caret right" aria-hidden="true"></div>
+
+            {{#adde-sub-dropdown data-test-action-sub-dropdown-menu=true}}
+              <ul class="adde-dropdown-menu">
+                {{#each dropdownAction.subActions as |subAction|}}
+                  {{#if subAction.isDivider}}
+                    <li class="list-divider" role="separator"></li>
+                  {{else}}
+                    <li>
+                      <button {{action "sendDropdownAction" close subAction.name subAction.args}}>
+                        {{subAction.text}}
+                      </button>
+                    </li>
+                  {{/if}}
+                {{/each}}
+              </ul>
+            {{/adde-sub-dropdown}}
+          </button>
+        </li>
+      {{else}}
+        <li>
+          <button {{action "sendDropdownAction" close dropdownAction.name dropdownAction.args}}>
+            {{dropdownAction.text}}
+          </button>
+        </li>
+      {{/if}}
+    {{/each}}
+  </ul>
+{{/adde-dropdown}}

--- a/addon/components/ember-th/component.js
+++ b/addon/components/ember-th/component.js
@@ -2,14 +2,17 @@
 import Component from '@ember/component';
 import { htmlSafe } from '@ember/string';
 
-import { computed } from '@ember-decorators/object';
-import { readOnly, equal } from '@ember-decorators/object/computed';
+import { action, computed } from '@ember-decorators/object';
+import { readOnly, equal, gt } from '@ember-decorators/object/computed';
 import { attribute, className, tagName } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
 import { required } from '@ember-decorators/argument/validation';
-import { type } from '@ember-decorators/argument/type';
+import { type, optional } from '@ember-decorators/argument/type';
+import { Action } from '@ember-decorators/argument/types';
 
 import layout from './template';
+import { get } from '@ember/object';
+import { objectAt } from '../../-private/utils/array';
 
 const COLUMN_RESIZE = 0;
 const COLUMN_REORDERING = 1;
@@ -23,20 +26,70 @@ export default class EmberTh extends Component {
   @type(Object)
   api;
 
+  /**
+    An array of header action items
+  */
+  @argument({ defaultIfUndefined: true })
+  @type(Array)
+  dropdownActions = [];
+
+  @argument
+  @type(optional(Action))
+  onDropdownAction;
+
   @readOnly('api.columnValue') columnValue;
   @readOnly('api.columnMeta') columnMeta;
 
   /**
-   * A variable used for column resizing & ordering. When user press mouse at a point that's close
-   * to column boundary (using some threshold), this variable set whether it's the left or right
-   * column.
-   */
-  _columnState = null;
+    Indicates if this column can be resized.
+  */
+  @readOnly('api.enableResize') resizeEnabled;
 
   /**
-   * An object that listens to touch/ press/ drag events.
-   */
-  _hammer = null;
+    Indicates if this column can be reordered.
+  */
+  @readOnly('api.enableReorder') reorderEnabled;
+
+  /**
+    Any sorts applied to the table.
+  */
+  @readOnly('api.sorts') sorts;
+
+  @computed('sorts.[]', 'columnValue.valuePath')
+  get sortIndex() {
+    let valuePath = this.get('columnValue.valuePath');
+    let sorts = this.get('sorts');
+
+    let sortIndex = 0;
+
+    for (let i = 0; i < get(sorts, 'length'); i++) {
+      let sorting = objectAt(sorts, i);
+
+      if (get(sorting, 'valuePath') === valuePath) {
+        sortIndex = i + 1;
+        break;
+      }
+    }
+
+    return sortIndex;
+  }
+
+  @gt('sortIndex', 0)
+  isSorted;
+
+  @gt('sorts.length', 1)
+  isMultiSorted;
+
+  @computed('sorts.[]', 'sortIndex')
+  get isSortedAsc() {
+    let sortIndex = this.get('sortIndex');
+    let sorts = this.get('sorts');
+
+    return get(objectAt(sorts, sortIndex - 1), 'isAscending');
+  }
+
+  @equal('columnMeta.index', 0)
+  isFirstColumn;
 
   @className
   @equal('columnMeta.isFixed', 'left')
@@ -45,13 +98,6 @@ export default class EmberTh extends Component {
   @className
   @equal('columnMeta.isFixed', 'right')
   isFixedRight;
-
-  /**
-   * Indicates if this column can be resized.
-   */
-  @readOnly('api.enableResize') resizeEnabled;
-
-  @readOnly('api.enableReorder') reorderEnabled;
 
   @attribute
   @computed('columnMeta.{width,offsetLeft,offsetRight}', 'isFixed')
@@ -83,6 +129,18 @@ export default class EmberTh extends Component {
   @readOnly('columnMeta.rowSpan')
   rowSpan;
 
+  /**
+    A variable used for column resizing & ordering. When user press mouse at a point that's close
+    to column boundary (using some threshold), this variable set whether it's the left or right
+    column.
+  */
+  _columnState = null;
+
+  /**
+    An object that listens to touch/ press/ drag events.
+  */
+  _hammer = null;
+
   didInsertElement() {
     super.didInsertElement(...arguments);
 
@@ -113,11 +171,34 @@ export default class EmberTh extends Component {
     super.willDestroyElement(...arguments);
   }
 
-  pressHandler = ev => {
+  @action
+  sendDropdownAction(...args) {
+    this.sendAction('onDropdownAction', ...args);
+  }
+
+  toggleSorting = event => {
+    let toggle = event.ctrlKey || event.metaKey;
+
+    let valuePath = this.get('columnValue.valuePath');
+    let sorts = this.get('sorts');
+
+    let existingSorting = sorts.find(s => get(s, 'valuePath') === valuePath);
+    let newSortings = toggle ? sorts.filter(s => get(s, 'valuePath') !== valuePath) : [];
+
+    if (!existingSorting) {
+      newSortings.push({ valuePath, isAscending: false });
+    } else if (existingSorting.isAscending === false) {
+      newSortings.push({ valuePath, isAscending: true });
+    }
+
+    this.get('api').sendUpdateSort(newSortings);
+  };
+
+  pressHandler = event => {
     let resizeEnabled = this.get('resizeEnabled');
     let reorderEnabled = this.get('reorderEnabled');
 
-    let [{ clientX, target }] = ev.pointers;
+    let [{ clientX, target }] = event.pointers;
 
     if (resizeEnabled && target.classList.contains('et-header-resize-area')) {
       this._columnState = COLUMN_RESIZE;
@@ -127,16 +208,16 @@ export default class EmberTh extends Component {
     }
   };
 
-  panStartHandler = ev => {
-    let [{ clientX }] = ev.pointers;
+  panStartHandler = event => {
+    let [{ clientX }] = event.pointers;
 
     if (this._columnState === COLUMN_REORDERING) {
       this.get('columnMeta').startReorder(clientX);
     }
   };
 
-  panMoveHandler = ev => {
-    let [{ clientX }] = ev.pointers;
+  panMoveHandler = event => {
+    let [{ clientX }] = event.pointers;
 
     if (this._columnState === COLUMN_RESIZE) {
       this.get('columnMeta').updateResize(clientX);

--- a/addon/components/ember-th/template.hbs
+++ b/addon/components/ember-th/template.hbs
@@ -1,7 +1,26 @@
 {{#if hasBlock}}
   {{yield columnValue columnMeta}}
 {{else}}
-  {{columnValue.name}}
+
+  <button data-test-sort-toggle onclick={{toggleSorting}}>
+    {{columnValue.name}}
+
+    {{#if isSorted}}
+      <div data-test-sort-indicator class="sort-indicator {{if isSortedAsc 'ascending' 'descending'}}">
+        {{#if isMultiSorted}}
+          {{sortIndex}}
+        {{/if}}
+      </div>
+    {{/if}}
+  </button>
+
+  {{#if dropdownActions.length}}
+    {{ember-th-action-dropdown
+      dropdownActions=dropdownActions
+      onDropdownAction="sendDropdownAction"
+      data-test-action-dropdown=true
+    }}
+  {{/if}}
 {{/if}}
 
 {{#if resizeEnabled}}

--- a/app/components/ember-th-action-dropdown.js
+++ b/app/components/ember-th-action-dropdown.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-table/components/ember-th/action-dropdown/component';

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@addepar/ember-toolbox": "^0.3.2",
+    "@addepar/pop-menu": "^0.3.2",
     "@ember-decorators/argument": "^0.8.15",
     "@ember-decorators/babel-transforms": "^0.1.1",
     "@html-next/vertical-collection": "1.0.0-beta.10",
@@ -40,6 +41,7 @@
     "ember-getowner-polyfill": "^2.2.0",
     "ember-legacy-class-shim": "^1.0.0",
     "ember-raf-scheduler": "^0.1.0",
+    "ember-test-selectors": "^0.3.9",
     "ember-useragent": "^0.6.0",
     "hammerjs": "^2.0.8"
   },
@@ -65,6 +67,7 @@
     "ember-cli-uglify": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
+    "ember-faker": "^1.2.1",
     "ember-load-initializers": "^1.0.0",
     "ember-math-helpers": "^2.4.1",
     "ember-maybe-import-regenerator": "^0.1.6",
@@ -73,7 +76,6 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.1.0",
     "ember-source-channel-url": "^1.0.1",
-    "ember-test-selectors": "^0.3.9",
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",

--- a/tests/dummy/app/pods/docs/examples/header/actions/controller.js
+++ b/tests/dummy/app/pods/docs/examples/header/actions/controller.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 
-import { computed } from '@ember-decorators/object';
+import { action, computed } from '@ember-decorators/object';
 import { generateRows } from '../../../../../utils/generators';
 
 export default class SimpleController extends Controller {
@@ -22,6 +22,29 @@ export default class SimpleController extends Controller {
     ];
   }
 
-  resizeCount = 0;
-  reorderCount = 0;
+  dropdownActions = [
+    {
+      name: 'foo',
+      text: 'Foo',
+    },
+    {
+      isDivider: true,
+    },
+    {
+      name: 'bar',
+      text: 'Bar',
+      subActions: [
+        {
+          name: 'baz',
+          text: 'Baz',
+        },
+      ],
+    },
+  ];
+
+  @action
+  logActionName(name) {
+    // eslint-disable-next-line
+    console.log(name);
+  }
 }

--- a/tests/dummy/app/pods/docs/examples/header/actions/template.md
+++ b/tests/dummy/app/pods/docs/examples/header/actions/template.md
@@ -1,22 +1,29 @@
 # Header Actions
 
-Headers send the `onResize` and `onReorder` actions whenever a resize or a
-reorder has occured.
+It's a common use case in tables to have dropdown menus in their headers. You
+can pass a `dropdownActions` array to the header cells directly to get a
+dropdown that contains actions.
 
 {{#docs-demo as |demo|}}
   {{#demo.example}}
     {{! BEGIN-SNIPPET docs-example-header-action.hbs }}
-    <p>Resized {{resizeCount}} times</p>
-    <p>Reorder {{reorderCount}} times</p>
-
     <div class="demo-container small">
       {{#ember-table as |t|}}
-        {{ember-thead
+        {{#ember-thead
           api=t
           columns=columns
-          onResize=(action (mut resizeCount) (add resizeCount 1))
-          onReorder=(action (mut reorderCount) (add reorderCount 1))
+
+          as |h|
         }}
+          {{#ember-tr api=h as |r|}}
+            {{ember-th
+              api=r
+
+              onDropdownAction=(action logActionName)
+              dropdownActions=dropdownActions
+            }}
+          {{/ember-tr}}
+        {{/ember-thead}}
 
         {{ember-tbody api=t rows=rows}}
       {{/ember-table}}

--- a/tests/dummy/app/pods/docs/examples/header/columns/controller.js
+++ b/tests/dummy/app/pods/docs/examples/header/columns/controller.js
@@ -59,4 +59,7 @@ export default class ColumnsController extends Controller {
   reorderEnabled = false;
   resizeModeFluid = false;
   // END-SNIPPET
+
+  resizeCount = 0;
+  reorderCount = 0;
 }

--- a/tests/dummy/app/pods/docs/examples/header/columns/template.md
+++ b/tests/dummy/app/pods/docs/examples/header/columns/template.md
@@ -144,3 +144,30 @@ using the `enableResize` and `enableReorder` flags. You can also change the
   {{demo.snippet name='docs-example-column-resize-reorder.hbs'}}
   {{demo.snippet name='docs-example-column-resize-reorder.js' label='component.js'}}
 {{/docs-demo}}
+
+Headers send the `onResize` and `onReorder` actions whenever a resize or a
+reorder has occured.
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name="resize-reorder-actions"}}
+    {{! BEGIN-SNIPPET docs-example-resize-reorder-actions.hbs }}
+    <p>Resized {{resizeCount}} times</p>
+    <p>Reorder {{reorderCount}} times</p>
+
+    <div class="demo-container small">
+      {{#ember-table as |t|}}
+        {{ember-thead
+          api=t
+          columns=columns
+          onResize=(action (mut resizeCount) (add resizeCount 1))
+          onReorder=(action (mut reorderCount) (add reorderCount 1))
+        }}
+
+        {{ember-tbody api=t rows=rows}}
+      {{/ember-table}}
+    </div>
+    {{! END-SNIPPET }}
+  {{/demo.example}}
+
+  {{demo.snippet name='docs-example-resize-reorder-actions.hbs'}}
+{{/docs-demo}}

--- a/tests/dummy/app/pods/docs/examples/header/sorting/controller.js
+++ b/tests/dummy/app/pods/docs/examples/header/sorting/controller.js
@@ -1,0 +1,83 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember-decorators/object';
+import faker from 'faker';
+
+function getRandomInt(max, min) {
+  return Math.floor(Math.max(Math.random() * Math.floor(max), min));
+}
+
+export default class SimpleController extends Controller {
+  // BEGIN-SNIPPET docs-example-sortings.js
+  @computed
+  get columns() {
+    return [
+      { name: 'Company ▸ Department ▸ Product', valuePath: 'name' },
+      { name: 'Price', valuePath: 'price' },
+      { name: 'Sold', valuePath: 'sold' },
+      { name: 'Unsold', valuePath: 'unsold' },
+      { name: 'Total Revenue', valuePath: 'totalRevenue' },
+    ];
+  }
+  // END-SNIPPET
+
+  @computed
+  get rows() {
+    let rows = [];
+
+    for (let i = 0; i < getRandomInt(5, 2); i++) {
+      let companyRow = {
+        name: faker.company.companyName(i),
+        price: 'N/A',
+        sold: 0,
+        unsold: 0,
+        totalRevenue: 0,
+        children: [],
+      };
+
+      for (let j = 0; j < getRandomInt(5, 2); j++) {
+        let departmentRow = {
+          name: faker.commerce.department(j),
+          price: 'N/A',
+          sold: 0,
+          unsold: 0,
+          totalRevenue: 0,
+          children: [],
+        };
+
+        for (let k = 0; k < getRandomInt(100, 10); k++) {
+          let sold = getRandomInt(100, 10);
+          let unsold = getRandomInt(100, 10);
+          let price = getRandomInt(50, 10);
+          let totalRevenue = price * sold;
+
+          let product = {
+            name: faker.commerce.productName(k),
+            price: `$${price}`,
+            sold,
+            unsold,
+            totalRevenue: `$${totalRevenue}`,
+          };
+
+          departmentRow.sold += sold;
+          departmentRow.unsold += unsold;
+          departmentRow.totalRevenue += totalRevenue;
+          departmentRow.children.push(product);
+        }
+
+        companyRow.sold += departmentRow.sold;
+        companyRow.unsold += departmentRow.unsold;
+        companyRow.totalRevenue += departmentRow.totalRevenue;
+
+        departmentRow.totalRevenue = `$${departmentRow.totalRevenue}`;
+
+        companyRow.children.push(departmentRow);
+      }
+
+      companyRow.totalRevenue = `$${companyRow.totalRevenue}`;
+
+      rows.push(companyRow);
+    }
+
+    return rows;
+  }
+}

--- a/tests/dummy/app/pods/docs/examples/header/sorting/template.md
+++ b/tests/dummy/app/pods/docs/examples/header/sorting/template.md
@@ -1,0 +1,59 @@
+# Sorting
+
+Ember Table ships with sorting built in to the table. Default sorting is a
+standard merge sort which does not affect the original ordering of the rows
+passed into the table. Users can sort by a column and toggle sort direction by
+clicking on its header, and can sort by multiple columns by clicking with `cmd`
+or `ctrl`:
+
+{{#docs-demo as |demo|}}
+  {{#demo.example}}
+    {{! BEGIN-SNIPPET docs-example-sortings.hbs }}
+    <div class="demo-container">
+      {{#ember-table as |t|}}
+        {{ember-thead
+          api=t
+          columns=columns
+          sorts=sorts
+
+          onUpdateSorts=(action (mut sorts))
+
+          widthConstraint='gte-container'
+          fillMode='first-column'
+        }}
+
+        {{ember-tbody api=t rows=rows}}
+      {{/ember-table}}
+    </div>
+    {{! END-SNIPPET }}
+  {{/demo.example}}
+
+  {{demo.snippet name='docs-example-sortings.hbs'}}
+  {{demo.snippet label='component.js' name='docs-example-sortings.js'}}
+{{/docs-demo}}
+
+Tables headers are passed an array of `sorts` to control the sort order. These
+sort objects should correspond to any of the `valuePaths` in the columns for the
+table. When multiple sort objects are passed, columns are sorted by each sort
+in order:
+
+```js
+let sorts = [
+  {
+    valuePath: 'name',
+    isAscending: false,
+  },
+  {
+    valuePath: 'price',
+    isAscending: true,
+  },
+]
+```
+
+Table headers can be passed a `sortFunction` and `compareFunction` as well. If
+you want to sort the content of the table asynchronously, you can unset the
+`sortFunction` and handle the async request yourself.
+
+```hbs
+{{ember-thead sortFunction=null}}
+```

--- a/tests/dummy/app/pods/docs/template.hbs
+++ b/tests/dummy/app/pods/docs/template.hbs
@@ -19,7 +19,7 @@
     {{nav.item 'Subcolumns' 'docs.examples.header.subcolumns'}}
     {{nav.item 'Fixed Columns' 'docs.examples.header.fixed-columns'}}
     {{nav.item 'Size Constraints' 'docs.examples.header.size-constraints'}}
-    {{nav.item 'Actions' 'docs.examples.header.actions'}}
+    {{nav.item 'Sorting' 'docs.examples.header.sorting'}}
 
     {{nav.section 'Body'}}
 

--- a/tests/dummy/app/pods/scenarios/performance/controller.js
+++ b/tests/dummy/app/pods/scenarios/performance/controller.js
@@ -14,8 +14,50 @@ export default class BasicController extends Controller {
     return generateColumns(20);
   }
 
+  @computed
+  get headerActions() {
+    return [
+      {
+        name: 'foo',
+        text: 'Foo',
+      },
+      {
+        name: 'bar',
+        text: 'Bar',
+      },
+      {
+        isDivider: true,
+      },
+      {
+        name: 'baz',
+        text: 'Baz',
+        subActions: [
+          {
+            name: 'sub foo',
+            text: 'Sub Foo',
+          },
+          {
+            name: 'sub bar',
+            text: 'Sub Bar',
+          },
+        ],
+      },
+    ];
+  }
+
   @action
   onSelect(selectedRows) {
     this.set('selectedRows', selectedRows);
+  }
+
+  @action
+  onUpdateSorts(sorts) {
+    this.set('sorts', sorts);
+  }
+
+  @action
+  onHeaderAction(action, args) {
+    // eslint-disable-next-line
+    console.log(action, args);
   }
 }

--- a/tests/dummy/app/pods/scenarios/performance/template.hbs
+++ b/tests/dummy/app/pods/scenarios/performance/template.hbs
@@ -3,6 +3,10 @@
     {{ember-thead
       api=t
       columns=columns
+      sorts=sorts
+      headerActions=headerActions
+      onUpdateSorts="onUpdateSorts"
+      onHeaderAction="onHeaderAction"
     }}
 
     {{ember-tbody

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -19,6 +19,7 @@ Router.map(function() {
         this.route('subcolumns');
         this.route('fixed-columns');
         this.route('size-constraints');
+        this.route('sorting');
         this.route('actions');
       });
 

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,4 +1,6 @@
 @import './tables';
+@import '@addepar/style-toolbox/variables/index';
+@import '@addepar/style-toolbox/components/index';
 
 $navy: #001f3f;
 $blue: #0074d9;

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -8,19 +8,31 @@ export { generateColumns, generateRows };
 const fullTable = hbs`
   <div style="height: 500px;">
     {{#ember-table data-test-ember-table=true as |t|}}
-      {{ember-thead
+      {{#ember-thead
         api=t
 
         columns=columns
+        sorts=sorts
         resizeMode=resizeMode
         fillMode=fillMode
         enableResize=enableResize
         enableReorder=enableReorder
         widthConstraint=widthConstraint
 
+        onUpdateSorts="onUpdateSorts"
         onReorder="onReorder"
         onResize="onResize"
+
+        as |h|
       }}
+        {{#ember-tr api=h as |r|}}
+          {{ember-th
+            api=r
+            dropdownActions=dropdownActions
+            onDropdownAction="onDropdownAction"
+          }}
+        {{/ember-tr}}
+      {{/ember-thead}}
 
       {{#ember-tbody
         api=t
@@ -79,6 +91,12 @@ const defaultActions = {
     this.set('selectedRows', newRows);
   },
 
+  onUpdateSorts(sorts) {
+    this.set('sorts', sorts);
+  },
+
+  onDropdownAction() {},
+  onColumnHeaderAction() {},
   onReorder() {},
   onResize() {},
 

--- a/tests/integration/components/headers/actions-test.js
+++ b/tests/integration/components/headers/actions-test.js
@@ -1,0 +1,106 @@
+import { module, test } from 'ember-qunit';
+import { find } from 'ember-native-dom-helpers';
+import { A as emberA } from '@ember/array';
+
+import { generateTable } from '../../../helpers/generate-table';
+import { componentModule } from '../../../helpers/module';
+
+import TablePage from 'ember-table/test-support/pages/ember-table';
+
+const table = TablePage.create();
+
+module('Integration | header | actions', function() {
+  componentModule('basic', function() {
+    test('header actions work', async function(assert) {
+      assert.expect(4);
+
+      this.on('onDropdownAction', (name, args) => {
+        assert.equal(name, 'foo');
+        assert.equal(args, 123);
+      });
+
+      await generateTable(this, {
+        dropdownActions: emberA([
+          {
+            name: 'foo',
+            text: 'Foo',
+            args: 123,
+          },
+        ]),
+      });
+
+      let firstHeader = table.headers.eq(0);
+
+      assert.ok(firstHeader.actionDropdown.isPresent);
+
+      await firstHeader.actionDropdown.open();
+
+      let firstAction = firstHeader.actionDropdown.items.eq(0);
+
+      assert.equal(firstAction.text, 'Foo');
+
+      await firstAction.click();
+    });
+
+    test('header dividers work', async function(assert) {
+      await generateTable(this, {
+        dropdownActions: emberA([
+          {
+            isDivider: true,
+          },
+        ]),
+      });
+
+      let firstHeader = table.headers.eq(0);
+
+      assert.ok(firstHeader.actionDropdown.isPresent);
+
+      await firstHeader.actionDropdown.open();
+
+      let dividerElement = find('.adde-dropdown-menu .list-divider');
+
+      assert.ok(dividerElement, 'divider exists');
+    });
+  });
+
+  test('sub actions work', async function(assert) {
+    assert.expect(5);
+
+    this.on('onDropdownAction', (name, args) => {
+      assert.equal(name, 'bar');
+      assert.equal(args, 123);
+    });
+
+    await generateTable(this, {
+      dropdownActions: emberA([
+        {
+          name: 'foo',
+          text: 'Foo',
+          subActions: emberA([
+            {
+              name: 'bar',
+              text: 'Bar',
+              args: 123,
+            },
+          ]),
+        },
+      ]),
+    });
+
+    let firstHeader = table.headers.eq(0);
+
+    assert.ok(firstHeader.actionDropdown.isPresent);
+
+    await firstHeader.actionDropdown.open();
+
+    let firstAction = firstHeader.actionDropdown.items.eq(0);
+    assert.equal(firstAction.text, 'Foo');
+
+    await firstAction.subDropdown.open();
+
+    let firstSubAction = firstAction.subActions.eq(0);
+    assert.equal(firstSubAction.text, 'Bar');
+
+    await firstSubAction.click();
+  });
+});

--- a/tests/integration/components/sort-test.js
+++ b/tests/integration/components/sort-test.js
@@ -1,0 +1,321 @@
+import { module, test } from 'ember-qunit';
+
+import { generateTable } from '../../helpers/generate-table';
+import { componentModule } from '../../helpers/module';
+
+import TablePage from 'ember-table/test-support/pages/ember-table';
+
+let table = TablePage.create();
+
+function checkRowOrder(table, expectedRowOrder) {
+  let rowOrderCorrect = true;
+
+  table.rows.forEach((r, i) => {
+    rowOrderCorrect = rowOrderCorrect && r.text === expectedRowOrder[i];
+  });
+
+  return rowOrderCorrect;
+}
+
+module('Integration | sort', function() {
+  componentModule('basic', function() {
+    test('can sort a column', async function(assert) {
+      let columns = [
+        {
+          name: 'Name',
+          valuePath: 'name',
+        },
+      ];
+
+      let rows = [{ name: 'Zoe' }, { name: 'Alex' }, { name: 'Liz' }];
+
+      await generateTable(this, { columns, rows });
+
+      let firstHeader = table.headers.eq(0);
+
+      assert.ok(checkRowOrder(table, ['Zoe', 'Alex', 'Liz']));
+
+      await firstHeader.sortToggle.click();
+      assert.ok(checkRowOrder(table, ['Zoe', 'Liz', 'Alex']));
+
+      await firstHeader.sortToggle.click();
+      assert.ok(checkRowOrder(table, ['Alex', 'Liz', 'Zoe']));
+
+      await firstHeader.sortToggle.click();
+      assert.ok(checkRowOrder(table, ['Zoe', 'Alex', 'Liz']));
+    });
+
+    test('can sort a second column', async function(assert) {
+      let columns = [
+        {
+          name: 'Name',
+          valuePath: 'name',
+        },
+        {
+          name: 'Age',
+          valuePath: 'age',
+        },
+      ];
+
+      let rows = [{ name: 'Zoe', age: 34 }, { name: 'Alex', age: 43 }, { name: 'Liz', age: 25 }];
+
+      await generateTable(this, { columns, rows });
+
+      let firstHeader = table.headers.eq(0);
+      let secondHeader = table.headers.eq(1);
+
+      assert.ok(checkRowOrder(table, ['Zoe 34', 'Alex 43', 'Liz 25']));
+
+      await firstHeader.sortToggle.click();
+      assert.ok(checkRowOrder(table, ['Zoe 34', 'Liz 25', 'Alex 43']));
+
+      await secondHeader.sortToggle.click();
+      assert.ok(checkRowOrder(table, ['Alex 43', 'Zoe 34', 'Liz 25']));
+    });
+
+    test('sends the onUpdateSorts action', async function(assert) {
+      this.on('onUpdateSorts', sorts => {
+        assert.equal(sorts.length, 1);
+        assert.equal(sorts[0].valuePath, 'name');
+        assert.equal(sorts[0].isAscending, false);
+      });
+
+      let columns = [
+        {
+          name: 'Name',
+          valuePath: 'name',
+        },
+      ];
+
+      let rows = [{ name: 'Zoe' }, { name: 'Alex' }, { name: 'Liz' }];
+
+      await generateTable(this, { columns, rows });
+
+      let firstHeader = table.headers.eq(0);
+
+      await firstHeader.sortToggle.click();
+    });
+
+    test('sort indicator works', async function(assert) {
+      await generateTable(this);
+
+      let firstHeader = table.headers.eq(0);
+
+      assert.ok(!firstHeader.sortIndicator.isPresent);
+
+      await firstHeader.sortToggle.click();
+
+      assert.ok(firstHeader.sortIndicator.isPresent);
+      assert.ok(firstHeader.sortIndicator.isDescending);
+
+      await firstHeader.sortToggle.click();
+
+      assert.ok(firstHeader.sortIndicator.isPresent);
+      assert.ok(firstHeader.sortIndicator.isAscending);
+
+      await firstHeader.sortToggle.click();
+
+      assert.ok(!firstHeader.sortIndicator.isPresent);
+    });
+
+    test('sort indicator works on second column', async function(assert) {
+      await generateTable(this);
+
+      let firstHeader = table.headers.eq(0);
+      let secondHeader = table.headers.eq(1);
+
+      assert.ok(!firstHeader.sortIndicator.isPresent);
+      assert.ok(!secondHeader.sortIndicator.isPresent);
+
+      await firstHeader.sortToggle.click();
+
+      assert.ok(firstHeader.sortIndicator.isPresent);
+      assert.ok(firstHeader.sortIndicator.isDescending);
+
+      await secondHeader.sortToggle.click();
+
+      assert.ok(!firstHeader.sortIndicator.isPresent);
+      assert.ok(secondHeader.sortIndicator.isPresent);
+      assert.ok(secondHeader.sortIndicator.isDescending);
+    });
+
+    test('can sort multiple columns', async function(assert) {
+      let columns = [
+        {
+          name: 'Name',
+          valuePath: 'name',
+        },
+        {
+          name: 'Age',
+          valuePath: 'age',
+        },
+      ];
+
+      let rows = [
+        { name: 'Zoe', age: 34 },
+        { name: 'Alex', age: 34 },
+        { name: 'Zoe', age: 25 },
+        { name: 'Zoe', age: 27 },
+      ];
+
+      await generateTable(this, { columns, rows });
+
+      let firstHeader = table.headers.eq(0);
+      let secondHeader = table.headers.eq(1);
+
+      assert.ok(
+        checkRowOrder(table, ['Zoe 34', 'Alex 34', 'Zoe 25', 'Zoe 27']),
+        'initial order is correct'
+      );
+
+      await firstHeader.sortToggle.click();
+      assert.ok(
+        checkRowOrder(table, ['Zoe 34', 'Zoe 25', 'Zoe 27', 'Alex 34']),
+        'sorting by one column is correct'
+      );
+      assert.equal(
+        firstHeader.sortIndicator.text,
+        '',
+        'sort indicators do not show number well sorted by a single column'
+      );
+
+      await secondHeader.sortToggle.clickWith({ metaKey: true });
+      assert.ok(
+        checkRowOrder(table, ['Zoe 34', 'Zoe 27', 'Zoe 25', 'Alex 34']),
+        'sorting by second column is correct'
+      );
+      assert.equal(firstHeader.sortIndicator.text, '1', 'sort indicators show correct number');
+      assert.equal(secondHeader.sortIndicator.text, '2', 'sort indicators show correct number');
+      assert.ok(firstHeader.sortIndicator.isDescending, 'sort indicators show correct direction');
+      assert.ok(secondHeader.sortIndicator.isDescending, 'sort indicators show correct direction');
+
+      await secondHeader.sortToggle.clickWith({ metaKey: true });
+      assert.ok(
+        checkRowOrder(table, ['Zoe 25', 'Zoe 27', 'Zoe 34', 'Alex 34']),
+        'can reverse the order of a secondary column'
+      );
+      assert.equal(firstHeader.sortIndicator.text, '1', 'sort indicators show correct number');
+      assert.equal(secondHeader.sortIndicator.text, '2', 'sort indicators show correct number');
+      assert.ok(firstHeader.sortIndicator.isDescending, 'sort indicators show correct direction');
+      assert.ok(secondHeader.sortIndicator.isAscending, 'sort indicators show correct direction');
+
+      await firstHeader.sortToggle.clickWith({ metaKey: true });
+      assert.ok(
+        checkRowOrder(table, ['Zoe 25', 'Zoe 27', 'Alex 34', 'Zoe 34']),
+        'can reverse the order of the inital column and push it onto the end of sorts'
+      );
+      assert.equal(firstHeader.sortIndicator.text, '2', 'sort indicators show correct number');
+      assert.equal(secondHeader.sortIndicator.text, '1', 'sort indicators show correct number');
+      assert.ok(firstHeader.sortIndicator.isAscending, 'sort indicators show correct direction');
+      assert.ok(secondHeader.sortIndicator.isAscending, 'sort indicators show correct direction');
+
+      await secondHeader.sortToggle.clickWith({ metaKey: true });
+      assert.ok(
+        checkRowOrder(table, ['Alex 34', 'Zoe 34', 'Zoe 25', 'Zoe 27']),
+        'can disable a column withot removing all sorts'
+      );
+      assert.equal(firstHeader.sortIndicator.text, '', 'no sort number shown');
+      assert.ok(!secondHeader.sortIndicator.isPresent, 'second sort indicator is gone');
+      assert.ok(firstHeader.sortIndicator.isAscending, 'sort indicators show correct direction');
+    });
+
+    test('can sort trees', async function(assert) {
+      let columns = [
+        {
+          name: 'Name',
+          valuePath: 'name',
+        },
+      ];
+
+      let rows = [
+        {
+          name: 'Zoe',
+          children: [{ name: 'Zoe' }, { name: 'Alex' }, { name: 'Liz' }],
+        },
+        {
+          name: 'Alex',
+          children: [{ name: 'Zoe' }, { name: 'Alex' }, { name: 'Liz' }],
+        },
+        {
+          name: 'Liz',
+          children: [{ name: 'Zoe' }, { name: 'Alex' }, { name: 'Liz' }],
+        },
+      ];
+
+      await generateTable(this, { columns, rows });
+
+      let firstHeader = table.headers.eq(0);
+
+      assert.ok(
+        checkRowOrder(table, [
+          'Zoe',
+          'Zoe',
+          'Alex',
+          'Liz',
+          'Alex',
+          'Zoe',
+          'Alex',
+          'Liz',
+          'Liz',
+          'Zoe',
+          'Alex',
+          'Liz',
+        ])
+      );
+
+      await firstHeader.sortToggle.click();
+      assert.ok(
+        checkRowOrder(table, [
+          'Zoe',
+          'Zoe',
+          'Liz',
+          'Alex',
+          'Liz',
+          'Zoe',
+          'Liz',
+          'Alex',
+          'Alex',
+          'Zoe',
+          'Liz',
+          'Alex',
+        ])
+      );
+
+      await firstHeader.sortToggle.click();
+      assert.ok(
+        checkRowOrder(table, [
+          'Alex',
+          'Alex',
+          'Liz',
+          'Zoe',
+          'Liz',
+          'Alex',
+          'Liz',
+          'Zoe',
+          'Zoe',
+          'Alex',
+          'Liz',
+          'Zoe',
+        ])
+      );
+
+      await firstHeader.sortToggle.click();
+      assert.ok(
+        checkRowOrder(table, [
+          'Zoe',
+          'Zoe',
+          'Alex',
+          'Liz',
+          'Alex',
+          'Zoe',
+          'Alex',
+          'Liz',
+          'Liz',
+          'Zoe',
+          'Alex',
+          'Liz',
+        ])
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR implements column sorting with a default sort implementation,
and dropdown actions, which can be passed in at the header cell level.
Dropdown actions can be used to add buttons to the dropdown menu
associated with each column.

The sorting functionality is accomplished via merge sorting each level
of the CollapseTree. This also leaves the default sort intact, so users
can return to the default state.

Dropdown actions have been tested and documented, but the docs are not
exposed via navigation yet. Unsure of the API at this point.

Styles to come in the next PR.