### PR TITLE
[bugfix] Avoid clickable elements when toggling row selection

### DIFF
--- a/addon/-private/utils/element.js
+++ b/addon/-private/utils/element.js
@@ -1,3 +1,35 @@
+const VENDOR_MATCH_FNS = [
+  'matches',
+  'webkitMatchesSelector',
+  'mozMatchesSelector',
+  'msMatchesSelector',
+  'oMatchesSelector',
+];
+let ELEMENT_MATCH_FN;
+
+function setElementMatchFn(el) {
+  VENDOR_MATCH_FNS.forEach(fn => {
+    if (ELEMENT_MATCH_FN === undefined && typeof el[fn] === 'function') {
+      ELEMENT_MATCH_FN = fn;
+    }
+  });
+}
+
+export function closest(el, selector) {
+  if (ELEMENT_MATCH_FN === undefined) {
+    setElementMatchFn(el);
+  }
+  while (el) {
+    // TODO add explicit test
+    if (el[ELEMENT_MATCH_FN](selector)) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+
+  return null;
+}
+
 export function getScale(element) {
   let rect = element.getBoundingClientRect();
 

--- a/addon/components/ember-td/component.js
+++ b/addon/components/ember-td/component.js
@@ -89,13 +89,6 @@ export default class EmberTd extends Component {
     this.sendFullAction('onCollapse');
   }
 
-  @action
-  onCheckboxClicked(event) {
-    // Prevent the row from triggering any click events since this means that
-    // the checkbox was clicked and we want to toggle via that
-    event.stopPropagation();
-  }
-
   click(event) {
     this.sendFullAction('onClick', { event });
   }

--- a/addon/components/ember-td/template.hbs
+++ b/addon/components/ember-td/template.hbs
@@ -3,7 +3,6 @@
     {{-ember-table-private/simple-checkbox
       data-test-select-row=true
       checked=rowMeta.isSelected
-      onClick="onCheckboxClicked"
       onChange="onSelectionToggled"
       ariaLabel="Select row"
     }}
@@ -13,7 +12,6 @@
     {{-ember-table-private/simple-checkbox
       data-test-collapse-row=true
       checked=rowMeta.isCollapsed
-      onClick="onCheckboxClicked"
       onChange="onCollapseToggled"
       ariaLabel="Collapse row"
     }}

--- a/addon/components/ember-tr/component.js
+++ b/addon/components/ember-tr/component.js
@@ -7,6 +7,8 @@ import { required } from '@ember-decorators/argument/validation';
 import { type, optional } from '@ember-decorators/argument/type';
 import { Action } from '@ember-decorators/argument/types';
 
+import { closest } from '../../-private/utils/element';
+
 import layout from './template';
 
 @tagName('tr')
@@ -36,13 +38,17 @@ export default class EmberTableRow extends Component {
   isSelected;
 
   click(event) {
-    let rowMeta = this.get('rowMeta');
+    let inputParent = closest(event.target, 'input, button, label, a, select');
 
-    if (rowMeta) {
-      let toggle = event.ctrlKey || event.metaKey;
-      let range = event.shiftKey;
+    if (!inputParent) {
+      let rowMeta = this.get('rowMeta');
 
-      rowMeta.select({ toggle, range });
+      if (rowMeta) {
+        let toggle = event.ctrlKey || event.metaKey;
+        let range = event.shiftKey;
+
+        rowMeta.select({ toggle, range });
+      }
     }
 
     this.sendEventAction('onClick', event);


### PR DESCRIPTION
Currently, users will have to manually handle events in their usage of
Ember Table when clicking a button or other interactable element to
prevent row selection from toggling. This PR causes the table to ignore
any clicks that originate in a clickable element (`button`, `label`,
`input`, `a`, or `select` for nows).