### PR TITLE
[feat] Separate row/checkbox selection, fix reordering/resizing

### DIFF
--- a/addon-test-support/pages/-private/ember-table-body.js
+++ b/addon-test-support/pages/-private/ember-table-body.js
@@ -32,6 +32,16 @@ export default {
     checkbox: {
       scope: '[data-test-select-row]',
       isChecked: property('checked'),
+
+      async clickWith(options) {
+        await click(findElement(this), options);
+      },
+    },
+
+    checkboxContainer: {
+      scope: '[data-test-select-row-container]',
+
+      isHidden: hasClass('et-speech-only'),
     },
 
     toggleSelect: alias('checkbox.click'),

--- a/addon-test-support/pages/-private/ember-table-header.js
+++ b/addon-test-support/pages/-private/ember-table-header.js
@@ -8,8 +8,7 @@ import { getScale } from '../../helpers/element';
 const Header = PageObject.extend({
   get text() {
     return findElement(this)
-      .textContent.replace('Toggle Sort', '')
-      .replace(/\s+/g, ' ')
+      .innerText.replace(/\s+/g, ' ')
       .trim();
   },
 
@@ -61,9 +60,26 @@ const Header = PageObject.extend({
    */
   async reorderBy(deltaPosition) {
     let header = findElement(this);
-    let box = header.getBoundingClientRect();
-    let deltaX = deltaPosition * box.width;
-    let startX = (box.right + box.left) / 2;
+    let targetElement = header;
+
+    while (deltaPosition !== 0) {
+      if (deltaPosition < 0) {
+        deltaPosition++;
+        targetElement = targetElement.previousElementSibling
+          ? targetElement.previousElementSibling
+          : targetElement;
+      } else {
+        deltaPosition--;
+        targetElement = targetElement.nextElementSibling
+          ? targetElement.nextElementSibling
+          : targetElement;
+      }
+    }
+
+    let headerBox = header.getBoundingClientRect();
+    let targetBox = targetElement.getBoundingClientRect();
+    let deltaX = targetBox.left - headerBox.left;
+    let startX = (headerBox.right + headerBox.left) / 2;
 
     await mouseDown(header, startX - 20, header.clientHeight / 2);
     await mouseMove(header, startX, header.clientHeight / 2);

--- a/addon/-private/utils/reorder-indicators.js
+++ b/addon/-private/utils/reorder-indicators.js
@@ -47,6 +47,10 @@ class ReorderIndicator {
     this.container.removeChild(this.indicatorElement);
   }
 
+  set width(newWidth) {
+    this.indicatorElement.style.width = `${newWidth}px`;
+  }
+
   get left() {
     return this._left;
   }

--- a/addon/components/-private/row-wrapper.js
+++ b/addon/components/-private/row-wrapper.js
@@ -57,7 +57,9 @@ export default class RowWrapper extends Component {
   @argument columnMetaCache;
   @argument rowMetaCache;
 
-  @argument selectRow;
+  @argument canSelect;
+  @argument rowSelectionMode;
+  @argument checkboxSelectionMode;
 
   _cells = emberA([]);
 
@@ -67,14 +69,15 @@ export default class RowWrapper extends Component {
     super.destroy(...arguments);
   }
 
-  @computed('rowValue', 'rowMeta', 'cells', 'selectRow')
+  @computed('rowValue', 'rowMeta', 'cells', 'canSelect', 'rowSelectionMode')
   get api() {
     let rowValue = this.get('rowValue');
     let rowMeta = this.get('rowMeta');
     let cells = this.get('cells');
-    let selectRow = this.get('selectRow');
+    let canSelect = this.get('canSelect');
+    let rowSelectionMode = canSelect ? this.get('rowSelectionMode') : 'none';
 
-    return { rowValue, rowMeta, cells, selectRow };
+    return { rowValue, rowMeta, cells, rowSelectionMode };
   }
 
   @computed('rowValue')
@@ -85,7 +88,14 @@ export default class RowWrapper extends Component {
     return rowMetaCache.get(rowValue);
   }
 
-  @computed('rowValue', 'rowMeta', 'columns.[]')
+  @computed(
+    'rowValue',
+    'rowMeta',
+    'columns.[]',
+    'canSelect',
+    'checkboxSelectionMode',
+    'rowSelectionMode'
+  )
   get cells() {
     let cellMetaCache = this.get('cellMetaCache');
 
@@ -94,6 +104,9 @@ export default class RowWrapper extends Component {
 
     let rowValue = this.get('rowValue');
     let rowMeta = this.get('rowMeta');
+    let canSelect = this.get('canSelect');
+    let checkboxSelectionMode = canSelect ? this.get('checkboxSelectionMode') : 'none';
+    let rowSelectionMode = canSelect ? this.get('rowSelectionMode') : 'none';
 
     let { _cells } = this;
 
@@ -115,6 +128,9 @@ export default class RowWrapper extends Component {
     _cells.forEach((cell, i) => {
       let columnValue = objectAt(columns, i);
       let columnMeta = this.get('columnMetaCache').get(columnValue);
+
+      set(cell, 'checkboxSelectionMode', checkboxSelectionMode);
+      set(cell, 'rowSelectionMode', rowSelectionMode);
 
       set(cell, 'columnValue', columnValue);
       set(cell, 'columnMeta', columnMeta);

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 
 import { tagName } from '@ember-decorators/component';
 import { computed } from '@ember-decorators/object';
-import { readOnly } from '@ember-decorators/object/computed';
+import { bool, readOnly } from '@ember-decorators/object/computed';
 
 import { argument } from '@ember-decorators/argument';
 import { required } from '@ember-decorators/argument/validation';
@@ -38,23 +38,40 @@ export default class EmberTBody extends Component {
   */
   @argument({ defaultIfUndefined: true })
   @type('string')
-  selectMode = SELECT_MODE.MULTIPLE;
+  checkboxSelectionMode = SELECT_MODE.MULTIPLE;
+
+  /**
+
+  */
+  @argument({ defaultIfUndefined: true })
+  @type('string')
+  rowSelectionMode = SELECT_MODE.MULTIPLE;
+
+  /**
+    When true, this option causes selecting all of a node's children to also
+    select the node itself.
+  */
+  @argument({ defaultIfUndefined: true })
+  @type('boolean')
+  selectingChildrenSelectsParent = true;
 
   /**
     The currently list of currently selected rows
   */
   @argument({ defaultIfUndefined: true })
-  @type(Array)
-  selectedRows = [];
+  @type(optional('object'))
+  selection = null;
 
   /**
     An action that triggers when the row selection of the table changes
 
-    @param {Array} selectedRows - The new set of selected rows
+    @param {Array} selection - The new set of selected rows
   */
   @argument
   @type(optional(Action))
   onSelect = null;
+
+  @bool('onSelect') canSelect;
 
   /**
     Estimated height for each row. This number is used to decide how many rows will be rendered at
@@ -117,8 +134,8 @@ export default class EmberTBody extends Component {
 
     this.addObserver('enableCollapse', this._updateCollapseTree);
     this.addObserver('enableTree', this._updateCollapseTree);
-    this.addObserver('selectedRows', this._updateCollapseTree);
-    this.addObserver('selectMode', this._updateCollapseTree);
+    this.addObserver('selection', this._updateCollapseTree);
+    this.addObserver('selectingChildrenSelectsParent', this._updateCollapseTree);
     this.addObserver('onSelect', this._updateCollapseTree);
 
     assert(
@@ -128,16 +145,17 @@ export default class EmberTBody extends Component {
   }
 
   _updateCollapseTree() {
-    let onSelect = this.get('onSelect');
-
     this.collapseTree.set('sorts', this.get('unwrappedApi.sorts'));
     this.collapseTree.set('sortFunction', this.get('unwrappedApi.sortFunction'));
     this.collapseTree.set('compareFunction', this.get('unwrappedApi.compareFunction'));
 
     this.collapseTree.set('enableCollapse', this.get('enableCollapse'));
     this.collapseTree.set('enableTree', this.get('enableTree'));
-    this.collapseTree.set('selectedRows', this.get('selectedRows'));
-    this.collapseTree.set('selectMode', onSelect ? this.get('selectMode') : 'none');
+    this.collapseTree.set('selection', this.get('selection'));
+    this.collapseTree.set(
+      'selectingChildrenSelectsParent',
+      this.get('selectingChildrenSelectsParent')
+    );
   }
 
   willDestroy() {

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -14,7 +14,9 @@
     columnMetaCache=columnMetaCache
     rowMetaCache=rowMetaCache
 
-    selectRow=selectRow
+    canSelect=canSelect
+    rowSelectionMode=rowSelectionMode
+    checkboxSelectionMode=checkboxSelectionMode
 
     as |api|
   }}

--- a/addon/components/ember-td/template.hbs
+++ b/addon/components/ember-td/template.hbs
@@ -1,11 +1,14 @@
 {{#if isFirstColumn}}
   <div class="et-cell-container">
-    {{#if canMultiSelect}}
-      <span class="et-toggle-select">
+    {{#if canSelect}}
+      <span
+        class="et-toggle-select {{unless shouldShowCheckbox 'et-speech-only'}}"
+        data-test-select-row-container
+      >
         {{-ember-table-private/simple-checkbox
           data-test-select-row=true
-          checked=rowMeta.isSelected
-          onChange="onSelectionToggled"
+          checked=rowMeta.isGroupSelected
+          onClick="onSelectionToggled"
           ariaLabel="Select row"
         }}
         <span></span>

--- a/addon/components/ember-tfoot/template.hbs
+++ b/addon/components/ember-tfoot/template.hbs
@@ -7,7 +7,9 @@
     columnMetaCache=columnMetaCache
     rowMetaCache=rowMetaCache
 
-    selectRow=selectRow
+    canSelect=canSelect
+    rowSelectionMode=rowSelectionMode
+    checkboxSelectionMode=checkboxSelectionMode
 
     as |api|
   }}

--- a/addon/components/ember-th/component.js
+++ b/addon/components/ember-th/component.js
@@ -129,6 +129,7 @@ export default class EmberTh extends Component {
     hammer.add(new Hammer.Press({ time: 0 }));
 
     hammer.on('press', this.pressHandler);
+    hammer.on('pressup', this.pressUpHandler);
     hammer.on('panstart', this.panStartHandler);
     hammer.on('panmove', this.panMoveHandler);
     hammer.on('panend', this.panEndHandler);
@@ -140,6 +141,7 @@ export default class EmberTh extends Component {
     let hammer = this._hammer;
 
     hammer.off('press');
+    hammer.off('pressup');
     hammer.off('panstart');
     hammer.off('panmove');
     hammer.off('panend');
@@ -201,6 +203,12 @@ export default class EmberTh extends Component {
       this.get('columnMeta').startResize(clientX);
     } else if (reorderEnabled) {
       this._columnState = COLUMN_REORDERING;
+    }
+  };
+
+  pressUpHandler = () => {
+    if (this._columnState === COLUMN_RESIZE) {
+      this.get('columnMeta').endResize();
     }
   };
 

--- a/addon/components/ember-th/template.hbs
+++ b/addon/components/ember-th/template.hbs
@@ -12,7 +12,7 @@
   {{/if}}
 {{/if}}
 
-<button class="et-sort-toggle">Toggle Sort</button>
+<button class="et-sort-toggle et-speech-only">Toggle Sort</button>
 
 {{#if resizeEnabled}}
   <div class="et-header-resize-area">

--- a/addon/components/ember-tr/component.js
+++ b/addon/components/ember-tr/component.js
@@ -11,6 +11,7 @@ import { Action } from '@ember-decorators/argument/types';
 import { closest } from '../../-private/utils/element';
 
 import layout from './template';
+import { SELECT_MODE } from '../../-private/collapse-tree';
 
 @tagName('tr')
 @classNames('et-tr')
@@ -38,26 +39,38 @@ export default class EmberTableRow extends Component {
   @readOnly('unwrappedApi.rowValue') rowValue;
   @readOnly('unwrappedApi.rowMeta') rowMeta;
   @readOnly('unwrappedApi.cells') cells;
+  @readOnly('unwrappedApi.rowSelectionMode') rowSelectionMode;
 
   @className
   @readOnly('rowMeta.isSelected')
   isSelected;
 
   @className
-  @readOnly('rowMeta.canSelect')
-  isSelectable;
+  @readOnly('rowMeta.isGroupSelected')
+  isGroupSelected;
+
+  @className
+  @computed('rowSelectionMode')
+  get isSelectable() {
+    let rowSelectionMode = this.get('rowSelectionMode');
+
+    return rowSelectionMode === SELECT_MODE.MULTIPLE || rowSelectionMode === SELECT_MODE.SINGLE;
+  }
 
   click(event) {
+    let rowSelectionMode = this.get('rowSelectionMode');
     let inputParent = closest(event.target, 'input, button, label, a, select');
 
     if (!inputParent) {
       let rowMeta = this.get('rowMeta');
 
-      if (rowMeta) {
+      if (rowMeta && rowSelectionMode === SELECT_MODE.MULTIPLE) {
         let toggle = event.ctrlKey || event.metaKey;
         let range = event.shiftKey;
 
         rowMeta.select({ toggle, range });
+      } else if (rowMeta && rowSelectionMode === SELECT_MODE.SINGLE) {
+        rowMeta.select({ single: true });
       }
     }
 

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -81,10 +81,6 @@
     user-select: none;
   }
 
-  .et-sort-toggle {
-    display: none;
-  }
-
   .et-header-resize-area {
     cursor: col-resize;
 
@@ -95,9 +91,13 @@
     top: 0;
   }
 
+  .et-speech-only {
+    display: none !important;
+  }
+
   @media speech {
-    .et-sort-toggle {
-      display: block;
+    .et-speech-only {
+      display: block !important;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-postcss": "^4.0.0",
     "ember-cli-qunit": "^4.1.1",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",

--- a/tests/dummy/app/pods/docs/examples/body/row-selection/controller.js
+++ b/tests/dummy/app/pods/docs/examples/body/row-selection/controller.js
@@ -37,7 +37,7 @@ export default class SimpleController extends Controller {
 
     let [rowWithChildren] = this.get('rowWithChildren');
 
-    this.preselectedRows = [rowWithChildren];
+    this.preselection = [rowWithChildren];
   }
 
   @computed
@@ -60,6 +60,10 @@ export default class SimpleController extends Controller {
   // END-SNIPPET
 
   // BEGIN-SNIPPET docs-example-selection-modes.js
+  rowSelectionMode = 'multiple';
+  checkboxSelectionMode = 'multiple';
+  selectingChildrenSelectsParent = true;
+
   @computed
   get rowsWithChildren() {
     return [

--- a/tests/dummy/app/pods/docs/examples/body/row-selection/template.md
+++ b/tests/dummy/app/pods/docs/examples/body/row-selection/template.md
@@ -1,8 +1,8 @@
 # Row Selection
 
 Tables provide row selection out of the box. Adding an `onSelect` action to the
-table body will activate selection, and you can pass in `selectedRows` to
-control the selection using DDAU:
+table body will activate selection, and you can pass in the `selection` property
+to control the selection using DDAU:
 
 {{#docs-demo as |demo|}}
   {{#demo.example}}
@@ -13,8 +13,8 @@ control the selection using DDAU:
 
         {{t.body
           rows=rows
-          onSelect=(action (mut selectedRows))
-          selectedRows=selectedRows
+          onSelect=(action (mut selection))
+          selection=selection
         }}
       {{/ember-table}}
       {{! END-SNIPPET }}
@@ -27,11 +27,13 @@ control the selection using DDAU:
 
 # Selected Rows
 
-`selectedRows` is meant to be an array with the rows that are selected in it.
-In order to keep the selection state as minimal as possible, `selectedRows` will
-also deduplicate selections by removing all children when a parent node is
-selected. Ember Table can infer that because the parent node is selected, all of
-its children _must_ be selected:
+`selection` can either be a single row, or a group of rows. Selecting a row also
+marks all of its children as selected.
+
+In order to keep the selection state as minimal as possible, when `selection` is
+a group it will also deduplicate selections by removing all children when a
+parent node is selected. Ember Table can infer that because the parent node is
+selected, all of its children _must_ be selected:
 
 {{#docs-demo as |demo|}}
   {{#demo.example name="selected-rows"}}
@@ -42,8 +44,8 @@ its children _must_ be selected:
 
         {{t.body
           rows=rowWithChildren
-          onSelect=(action (mut preselectedRows))
-          selectedRows=preselectedRows
+          onSelect=(action (mut preselection))
+          selection=preselection
         }}
       {{/ember-table}}
       {{! END-SNIPPET }}
@@ -56,58 +58,105 @@ its children _must_ be selected:
 
 This can make some tasks more difficult - performing an action on all rows that
 are logically selected may mean that you have to traverse through the `children`
-in the list of `selectedRows`. It makes other tasks much easier though, like
-finding all of the groups that are selected, and selecting a group manually,
-external to the table.
+in the `selection` group. It makes other tasks much easier though, like finding
+all of the groups that are selected, and selecting a group manually, external to
+the table.
 
 # Selection Modes
 
-There are three selection modes available:
+There are three different properties you can use to control the behavior of
+row selection:
 
-1. `multiple`: The default mode, allows users to select multiple rows. `ctrl`
-  and `meta` can be used to add or toggle rows in the selection, and `shift` can
-  be used to select ranges of rows. Selecting a parent row will select all of
-  its children. However, selecting all of the children will _not_ select the
-  parent.
+1. `checkboxSelectionMode`: This controls the behavior of the checkbox which
+appears in the first cell of a row. It can be either `multiple`, `single`, or
+`none`. Checkbox selection is always a group selection - it will always pass an
+array to `onSelect`. In `multiple` mode it allows more than one checkbox to be
+checked at a time, and in the `single` mode it only allows one checkbox to be
+checked.
 
-2. `grouping`: This mode is the same as multiple, except that parent's are
-  considered groups. This means that when you select all of the children of a
-  node, the node will also be selected.
+2. `rowSelectionMode`: This controls the behavior of clicking the row itself.
+It can be either `multiple`, `single`, or `none`. If it is either `multiple` or
+`single`, then the `is-selectable` class will be applied to the row. When using
+`single` mode, clicking on a row will pass the row directly to `onSelect`. This
+marks the row as selected, but is not considered a group selection, so the
+checkbox will _not_ be checked.
 
-3. `single`: This mode only allows you to select one row at a time, and uses the
-  first item of the `selectedRows` array only. It disables the checkbox as well.
-
-You can pass one of these into the table body as the `selectMode` argument.
+3. `selectingChildrenSelectsParent`: This is a boolean flag which tells toggles
+whether or not selecting all of the children of a given row also selects the row
+itself.
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='selection-modes'}}
     {{! BEGIN-SNIPPET docs-example-selection-modes.hbs }}
-    <label class="pr-4">
-      multiple
-      {{radio-button name='select-mode' value='multiple' groupValue=selectMode}}
-    </label>
-
-    <label class="pr-4">
-      grouping
-      {{radio-button name='select-mode' value='grouping' groupValue=selectMode}}
-    </label>
-
-    <label>
-      single
-      {{radio-button name='select-mode' value='single' groupValue=selectMode}}
-    </label>
-
     <div class="demo-container small">
       {{#ember-table as |t|}}
         {{t.head columns=columns}}
 
         {{t.body
           rows=rowsWithChildren
-          selectMode=selectMode
-          onSelect=(action (mut selectedRows))
-          selectedRows=selectedRows
+
+          rowSelectionMode=rowSelectionMode
+          checkboxSelectionMode=checkboxSelectionMode
+          selectingChildrenSelectsParent=selectingChildrenSelectsParent
+
+          onSelect=(action (mut selection))
+          selection=selection
         }}
       {{/ember-table}}
+    </div>
+
+    <div class="options-container">
+      <h4 class="label">rowSelectionMode</h4>
+
+      <div class="options">
+        <label class="pr-4">
+          multiple
+          {{radio-button name='row-selection-mode' value='multiple' groupValue=rowSelectionMode}}
+        </label>
+
+        <label class="pr-4">
+          single
+          {{radio-button name='row-selection-mode' value='single' groupValue=rowSelectionMode}}
+        </label>
+
+        <label>
+          none
+          {{radio-button name='row-selection-mode' value='none' groupValue=rowSelectionMode}}
+        </label>
+      </div>
+
+      <h4 class="label">checkboxSelectionMode</h4>
+
+      <div class="options">
+        <label class="pr-4">
+          multiple
+          {{radio-button name='checkbox-selection-mode' value='multiple' groupValue=checkboxSelectionMode}}
+        </label>
+
+        <label class="pr-4">
+          single
+          {{radio-button name='checkbox-selection-mode' value='single' groupValue=checkboxSelectionMode}}
+        </label>
+
+        <label>
+          none
+          {{radio-button name='checkbox-selection-mode' value='none' groupValue=checkboxSelectionMode}}
+        </label>
+      </div>
+
+      <h4 class="label">selectingChildrenSelectsParent</h4>
+
+      <div class="options">
+        <label class="pr-4">
+          true
+          {{radio-button name='selecting-children-selects-parent' value=true groupValue=selectingChildrenSelectsParent}}
+        </label>
+
+        <label class="pr-4">
+          false
+          {{radio-button name='selecting-children-selects-parent' value=false groupValue=selectingChildrenSelectsParent}}
+        </label>
+      </div>
     </div>
     {{! END-SNIPPET }}
   {{/demo.example}}

--- a/tests/dummy/app/pods/scenarios/performance/controller.js
+++ b/tests/dummy/app/pods/scenarios/performance/controller.js
@@ -15,12 +15,16 @@ export default class BasicController extends Controller {
 
   @computed
   get columns() {
-    return generateColumns(20);
+    let columns = generateColumns(20);
+
+    columns[0].width = 300;
+
+    return columns;
   }
 
   @action
-  onSelect(selectedRows) {
-    this.set('selectedRows', selectedRows);
+  onSelect(selection) {
+    this.set('selection', selection);
   }
 
   @action

--- a/tests/dummy/app/pods/scenarios/performance/template.hbs
+++ b/tests/dummy/app/pods/scenarios/performance/template.hbs
@@ -16,9 +16,9 @@
     {{#ember-tbody
       api=t
       rows=rows
-      selectedRows=selectedRows
+
+      selection=selection
       onSelect="onSelect"
-      selectMode="grouping"
 
       as |b|
     }}

--- a/tests/dummy/app/pods/scenarios/simple/template.hbs
+++ b/tests/dummy/app/pods/scenarios/simple/template.hbs
@@ -8,7 +8,7 @@
     {{ember-tbody
       api=t
       rows=rows
-      selectedRows=selectedRows
+      selection=selection
     }}
   {{/ember-table}}
 </div>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -70,6 +70,29 @@ $silver: #dddddd;
   color: $silver;
 }
 
+.options-container {
+  display: flex;
+  flex-flow: row wrap;
+  font-size: 0.9em;
+
+  border-top: solid 1px #dae1e7;
+  margin-top: 1em;
+  padding-top: 1em;
+
+  .label {
+    flex: 0 1 40%;
+    font-weight: normal;
+    text-align: right;
+
+    padding-bottom: 1em;
+    padding-right: 1em;
+  }
+
+  .options {
+    padding-bottom: 1em;
+  }
+}
+
 .resize-container {
   resize: both;
   overflow: scroll;

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -42,8 +42,10 @@ const fullTable = hbs`
         enableTree=enableTree
 
         onSelect="onSelect"
-        selectMode=selectMode
-        selectedRows=selectedRows
+        selectingChildrenSelectsParent=selectingChildrenSelectsParent
+        checkboxSelectionMode=checkboxSelectionMode
+        rowSelectionMode=rowSelectionMode
+        selection=selection
 
         as |b|
       }}
@@ -86,7 +88,7 @@ const fullTable = hbs`
 
 const defaultActions = {
   onSelect(newRows) {
-    this.set('selectedRows', newRows);
+    this.set('selection', newRows);
   },
 
   onUpdateSorts(sorts) {

--- a/tests/integration/components/meta-test.js
+++ b/tests/integration/components/meta-test.js
@@ -76,7 +76,7 @@ module('Integration | meta', function() {
         assert.ok(row.cells.eq(0).text.includes('column'), 'column meta correct');
       });
 
-      assert.ok(table.headers.eq(0).text.includes('column'), 'header meta correct');
+      assert.ok(table.headers.eq(0).text.match(/column/i), 'header meta correct');
       assert.ok(table.footers.eq(0).text.includes('column'), 'footer meta correct');
 
       await scrollTo('[data-test-ember-table]', 0, 100000);
@@ -91,7 +91,7 @@ module('Integration | meta', function() {
         assert.ok(row.cells.eq(0).text.includes('column'), 'column meta correct');
       });
 
-      assert.ok(table.headers.eq(0).text.includes('column'), 'header meta correct');
+      assert.ok(table.headers.eq(0).text.match(/column/i), 'header meta correct');
       assert.ok(table.footers.eq(0).text.includes('column'), 'footer meta correct');
 
       await scrollTo('[data-test-ember-table]', 0, 0);
@@ -106,7 +106,7 @@ module('Integration | meta', function() {
         assert.ok(row.cells.eq(0).text.includes('column'), 'column meta correct');
       });
 
-      assert.ok(table.headers.eq(0).text.includes('column'), 'header meta correct');
+      assert.ok(table.headers.eq(0).text.match(/column/i), 'header meta correct');
       assert.ok(table.footers.eq(0).text.includes('column'), 'footer meta correct');
     });
 
@@ -217,7 +217,7 @@ module('Integration | meta', function() {
         assert.ok(row.cells.eq(0).text.includes('column'), 'column meta correct');
       });
 
-      assert.ok(table.headers.eq(0).text.includes('column'), 'header meta correct');
+      assert.ok(table.headers.eq(0).text.match(/column/i), 'header meta correct');
       assert.ok(table.footers.eq(0).text.includes('column'), 'footer meta correct');
 
       // Other table was not affected

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -22,12 +22,10 @@ let table = TablePage.extend({
 }).create();
 
 module('Integration | selection', () => {
-  for (let scenario of ['grouping', 'multiple']) {
-    let selectMode = scenario;
-
-    componentModule(scenario, function() {
+  module('rowSelectionMode', function() {
+    componentModule('multiple', function() {
       test('Can select a row by clicking on it', async function(assert) {
-        await generateTable(this, { selectMode });
+        await generateTable(this);
 
         assert.ok(table.validateSelected(), 'the row is not marked as selected on initialization');
 
@@ -37,7 +35,7 @@ module('Integration | selection', () => {
       });
 
       test('Can toggle a row with meta and control', async function(assert) {
-        await generateTable(this, { selectMode });
+        await generateTable(this);
 
         let row = table.body.rows.eq(0);
 
@@ -54,38 +52,8 @@ module('Integration | selection', () => {
         }
       });
 
-      test('Can toggle a row with checkbox', async function(assert) {
-        await generateTable(this, { selectMode });
-
-        let row = table.body.rows.eq(0);
-
-        assert.ok(table.validateSelected(), 'the row is not toggled on');
-
-        await row.checkbox.click();
-
-        assert.ok(table.validateSelected(0), 'the row is toggled on');
-
-        await row.checkbox.click();
-
-        assert.ok(table.validateSelected(), 'the row is toggled back off');
-      });
-
-      test('Checkbox state matches selection state', async function(assert) {
-        await generateTable(this, { selectMode });
-
-        let row = table.body.rows.eq(0);
-
-        assert.ok(!row.isSelected, 'the row is not selected');
-        assert.ok(!row.checkbox.isChecked, 'the row checkbox is not checked');
-
-        await row.click();
-
-        assert.ok(row.isSelected, 'the row is selected');
-        assert.ok(row.checkbox.isChecked, 'the row checkbox is checked');
-      });
-
       test('Can toggle multiple rows with meta and control', async function(assert) {
-        await generateTable(this, { selectMode });
+        await generateTable(this);
 
         let rowOne = table.rows.eq(0);
         let rowTwo = table.rows.eq(1);
@@ -105,27 +73,8 @@ module('Integration | selection', () => {
         }
       });
 
-      test('Can toggle multiple rows with checkbox', async function(assert) {
-        await generateTable(this, { selectMode });
-
-        let rowOne = table.rows.eq(0);
-        let rowTwo = table.rows.eq(1);
-
-        assert.ok(table.validateSelected(), 'the rows are not selected');
-
-        await rowOne.checkbox.click();
-        await rowTwo.checkbox.click();
-
-        assert.ok(table.validateSelected(0, 1), 'the rows are selected');
-
-        await rowOne.checkbox.click();
-        await rowTwo.checkbox.click();
-
-        assert.ok(table.validateSelected(), 'the rows are toggled back off');
-      });
-
       test('Can toggle multiple rows with checkbox and keys', async function(assert) {
-        await generateTable(this, { selectMode });
+        await generateTable(this);
 
         let rowOne = table.rows.eq(0);
         let rowTwo = table.rows.eq(1);
@@ -144,7 +93,7 @@ module('Integration | selection', () => {
       });
 
       test('Can select a range with shift', async function(assert) {
-        await generateTable(this, { selectMode });
+        await generateTable(this);
 
         assert.ok(table.validateSelected(), 'rows are not selected');
 
@@ -154,7 +103,7 @@ module('Integration | selection', () => {
       });
 
       test('Selecting a range selects based on last selection', async function(assert) {
-        await generateTable(this, { selectMode });
+        await generateTable(this);
 
         assert.ok(table.validateSelected(), 'rows are not selected');
 
@@ -164,7 +113,7 @@ module('Integration | selection', () => {
       });
 
       test('Selecting a range does not deselect previously selected rows', async function(assert) {
-        await generateTable(this, { selectMode });
+        await generateTable(this);
 
         assert.ok(table.validateSelected(), 'rows are not selected');
 
@@ -178,7 +127,7 @@ module('Integration | selection', () => {
       });
 
       test('selecting a parent selects its children', async function(assert) {
-        await generateTable(this, { selectMode, rowCount: 3, rowDepth: 2 });
+        await generateTable(this, { rowCount: 3, rowDepth: 2 });
 
         assert.ok(table.validateSelected(), 'rows are not selected');
 
@@ -188,7 +137,7 @@ module('Integration | selection', () => {
       });
 
       test('deselecting a child deselects its parents', async function(assert) {
-        await generateTable(this, { selectMode, rowCount: 3, rowDepth: 2 });
+        await generateTable(this, { rowCount: 3, rowDepth: 2 });
 
         assert.ok(table.validateSelected(), 'rows are not selected');
 
@@ -202,13 +151,13 @@ module('Integration | selection', () => {
       });
 
       test('selecting a child and then a parent dedupes selected rows correctly', async function(assert) {
-        this.on('onSelect', selectedRows => {
-          assert.equal(selectedRows.length, 1, 'correct number of rows selected');
+        this.on('onSelect', selection => {
+          assert.equal(selection.length, 1, 'correct number of rows selected');
 
-          this.set('selectedRows', selectedRows);
+          this.set('selection', selection);
         });
 
-        await generateTable(this, { selectMode, rowCount: 3, rowDepth: 2 });
+        await generateTable(this, { rowCount: 3, rowDepth: 2 });
 
         assert.ok(table.validateSelected(), 'rows are not selected');
 
@@ -220,99 +169,219 @@ module('Integration | selection', () => {
 
         assert.ok(table.validateSelected(0, 1, 2, 3), 'row and its children are selected');
       });
+    });
 
-      if (scenario === 'grouping') {
-        test('selecting all children selects the parent', async function(assert) {
-          await generateTable(this, { selectMode, rowCount: 3, rowDepth: 2 });
+    componentModule('single', function() {
+      test('Can select a row by clicking on it', async function(assert) {
+        await generateTable(this, { rowSelectionMode: 'single' });
 
-          assert.ok(table.validateSelected(), 'rows are not selected');
+        assert.ok(table.validateSelected(), 'the row is not marked as selected on initialization');
 
-          await table.selectRange(1, 3);
+        await table.selectRow(0);
 
-          assert.ok(table.validateSelected(0, 1, 2, 3), 'row and its children are selected');
+        assert.ok(table.validateSelected(0), 'the row is selected after being clicked');
+      });
+
+      test('Cannot toggle a row with meta and control', async function(assert) {
+        await generateTable(this, { rowSelectionMode: 'single' });
+
+        await table.selectRow(0);
+
+        assert.ok(table.validateSelected(0), 'the row is toggled on');
+
+        let row = table.rows.eq(0);
+
+        for (let key of ['ctrlKey', 'metaKey']) {
+          await row.clickWith({ [key]: true });
+
+          assert.ok(table.validateSelected(0), 'the row is still on');
+        }
+      });
+
+      test('Cannot toggle multiple rows with meta and control', async function(assert) {
+        await generateTable(this, { rowSelectionMode: 'single' });
+
+        assert.ok(table.validateSelected(), 'no rows are selected');
+
+        let rowOne = table.rows.eq(0);
+        let rowTwo = table.rows.eq(1);
+
+        for (let key of ['ctrlKey', 'metaKey']) {
+          await rowOne.clickWith({ [key]: true });
+
+          assert.ok(table.validateSelected(0), 'the first row is selected');
+
+          await rowTwo.clickWith({ [key]: true });
+
+          assert.ok(table.validateSelected(1), 'the second row is selected');
+        }
+      });
+
+      test('Cannot select a range with shift', async function(assert) {
+        await generateTable(this, { rowSelectionMode: 'single' });
+
+        assert.ok(table.validateSelected(), 'no rows are not selected');
+
+        await table.selectRange(0, 3);
+
+        assert.ok(table.validateSelected(3), 'last row only is selected');
+      });
+
+      test('selection is a single row', async function(assert) {
+        assert.expect(1);
+
+        this.on('onSelect', selection => {
+          assert.ok(!Array.isArray(selection), 'selection is not an array');
         });
-      } else {
-        test('selecting all children does not select the parent', async function(assert) {
-          await generateTable(this, { selectMode, rowCount: 3, rowDepth: 2 });
 
-          assert.ok(table.validateSelected(), 'rows are not selected');
+        await generateTable(this, { rowSelectionMode: 'single' });
 
-          await table.selectRange(1, 3);
-
-          assert.ok(table.validateSelected(1, 2, 3), 'only children are selected');
-        });
-      }
-    });
-  }
-
-  componentModule('single', function() {
-    test('Can select a row by clicking on it', async function(assert) {
-      await generateTable(this, { selectMode: 'single' });
-
-      assert.ok(table.validateSelected(), 'the row is not marked as selected on initialization');
-
-      await table.selectRow(0);
-
-      assert.ok(table.validateSelected(0), 'the row is selected after being clicked');
+        await table.selectRow(0);
+      });
     });
 
-    test('Cannot toggle a row with meta and control', async function(assert) {
-      await generateTable(this, { selectMode: 'single' });
+    componentModule('none', function() {
+      test('Can disable row selection', async function(assert) {
+        await generateTable(this, { rowSelectionMode: 'none' });
 
-      await table.selectRow(0);
+        assert.ok(table.validateSelected(), 'rows are not selected');
 
-      assert.ok(table.validateSelected(0), 'the row is toggled on');
+        await table.selectRow(0);
 
-      let row = table.rows.eq(0);
+        assert.ok(table.validateSelected(), 'rows are not selected');
 
-      for (let key of ['ctrlKey', 'metaKey']) {
-        await row.clickWith({ [key]: true });
+        await table.body.rows.eq(0).checkbox.click();
 
-        assert.ok(table.validateSelected(0), 'the row is still on');
-      }
-    });
-
-    test('Cannot toggle multiple rows with meta and control', async function(assert) {
-      await generateTable(this, { selectMode: 'single' });
-
-      assert.ok(table.validateSelected(), 'no rows are selected');
-
-      let rowOne = table.rows.eq(0);
-      let rowTwo = table.rows.eq(1);
-
-      for (let key of ['ctrlKey', 'metaKey']) {
-        await rowOne.clickWith({ [key]: true });
-
-        assert.ok(table.validateSelected(0), 'the first row is selected');
-
-        await rowTwo.clickWith({ [key]: true });
-
-        assert.ok(table.validateSelected(1), 'the second row is selected');
-      }
-    });
-
-    test('Cannot select a range with shift', async function(assert) {
-      await generateTable(this, { selectMode: 'single' });
-
-      assert.ok(table.validateSelected(), 'no rows are not selected');
-
-      await table.selectRange(0, 3);
-
-      assert.ok(table.validateSelected(3), 'last row only is selected');
-    });
-
-    test('selecting a parent only selects the parent', async function(assert) {
-      await generateTable(this, { selectMode: 'single', rowCount: 3, rowDepth: 2 });
-
-      assert.ok(table.validateSelected(), 'rows are not selected');
-
-      await table.selectRow(0);
-
-      assert.ok(table.validateSelected(0), 'row and its children are selected');
+        assert.ok(table.validateSelected(0), 'rows are selected');
+      });
     });
   });
 
-  componentModule('none', function() {
+  module('checkboxSelectionMode', function() {
+    componentModule('multiple', function() {
+      test('Can toggle multiple rows with checkbox', async function(assert) {
+        await generateTable(this);
+
+        let rowOne = table.rows.eq(0);
+        let rowTwo = table.rows.eq(1);
+
+        assert.ok(table.validateSelected(), 'the rows are not selected');
+
+        await rowOne.checkbox.click();
+        await rowTwo.checkbox.click();
+
+        assert.ok(table.validateSelected(0, 1), 'the rows are selected');
+
+        await rowOne.checkbox.click();
+        await rowTwo.checkbox.click();
+
+        assert.ok(table.validateSelected(), 'the rows are toggled back off');
+      });
+
+      test('Can select range by clicking on checkboxes', async function(assert) {
+        await generateTable(this);
+
+        assert.ok(table.validateSelected(), 'rows are not selected');
+
+        await table.rows.eq(3).checkbox.click();
+        await table.rows.eq(5).checkbox.clickWith({ shiftKey: true });
+
+        assert.ok(table.validateSelected(3, 4, 5), 'rows are selected');
+      });
+
+      test('Checkbox state matches selection state (rowSelectionMode multiple)', async function(assert) {
+        await generateTable(this);
+
+        let row = table.body.rows.eq(0);
+
+        assert.ok(!row.isSelected, 'the row is not selected');
+        assert.ok(!row.checkbox.isChecked, 'the row checkbox is not checked');
+
+        await row.click();
+
+        assert.ok(row.isSelected, 'the row is selected');
+        assert.ok(row.checkbox.isChecked, 'the row checkbox is checked');
+      });
+
+      test('Checkbox state does not match selection state (rowSelectionMode single)', async function(assert) {
+        await generateTable(this, { rowSelectionMode: 'single' });
+
+        let row = table.body.rows.eq(0);
+
+        assert.ok(!row.isSelected, 'the row is not selected');
+        assert.ok(!row.checkbox.isChecked, 'the row checkbox is not checked');
+
+        await row.click();
+
+        assert.ok(row.isSelected, 'the row is selected');
+        assert.ok(!row.checkbox.isChecked, 'the row checkbox is checked');
+      });
+    });
+
+    componentModule('single', function() {
+      test('Can select a row by clicking on checkbox', async function(assert) {
+        await generateTable(this, { checkboxSelectionMode: 'single' });
+
+        assert.ok(table.validateSelected(), 'the row is not marked as selected on initialization');
+
+        await table.rows.eq(0).checkbox.click();
+
+        assert.ok(table.validateSelected(0), 'the row is selected after being clicked');
+      });
+
+      test('Cannot toggle multiple rows with meta and control', async function(assert) {
+        await generateTable(this, { checkboxSelectionMode: 'single' });
+
+        assert.ok(table.validateSelected(), 'no rows are selected');
+
+        await table.rows.eq(0).checkbox.click();
+
+        assert.ok(table.validateSelected(0), 'the first row is selected');
+
+        await table.rows.eq(1).checkbox.click();
+
+        assert.ok(table.validateSelected(1), 'the second row is selected');
+      });
+
+      test('Cannot select a range with shift', async function(assert) {
+        await generateTable(this, { checkboxSelectionMode: 'single' });
+
+        assert.ok(table.validateSelected(), 'no rows are not selected');
+
+        await table.rows.eq(0).checkbox.click();
+        await table.rows.eq(3).checkbox.clickWith({ shiftKey: true });
+
+        assert.ok(table.validateSelected(3), 'last row only is selected');
+      });
+
+      test('selection is an array', async function(assert) {
+        assert.expect(1);
+
+        this.on('onSelect', selection => {
+          assert.ok(Array.isArray(selection), 'selection is not an array');
+        });
+
+        await generateTable(this, { checkboxSelectionMode: 'single' });
+
+        await table.selectRow(0);
+      });
+    });
+
+    componentModule('none', function() {
+      test('Can disable checkbox selection', async function(assert) {
+        await generateTable(this, { checkboxSelectionMode: 'none' });
+
+        assert.ok(table.validateSelected(), 'rows are not selected');
+
+        await table.selectRow(0);
+
+        assert.ok(table.validateSelected(0), 'rows are selected');
+        assert.ok(table.body.rows.eq(0).checkboxContainer.isHidden, 'checkbox is hidden');
+      });
+    });
+  });
+
+  componentModule('misc', function() {
     test('Can disable selection by not using an action', async function(assert) {
       assert.expect(3);
 
@@ -327,6 +396,34 @@ module('Integration | selection', () => {
       await table.selectRow(0);
 
       assert.ok(table.validateSelected(), 'rows are not selected');
+    });
+
+    test('selecting all children selects the parent when enabled', async function(assert) {
+      await generateTable(this, {
+        selectingChildrenSelectsParent: true,
+        rowCount: 3,
+        rowDepth: 2,
+      });
+
+      assert.ok(table.validateSelected(), 'rows are not selected');
+
+      await table.selectRange(1, 3);
+
+      assert.ok(table.validateSelected(0, 1, 2, 3), 'row and its children are selected');
+    });
+
+    test('selecting all children does not select the parent', async function(assert) {
+      await generateTable(this, {
+        selectingChildrenSelectsParent: false,
+        rowCount: 3,
+        rowDepth: 2,
+      });
+
+      assert.ok(table.validateSelected(), 'rows are not selected');
+
+      await table.selectRange(1, 3);
+
+      assert.ok(table.validateSelected(1, 2, 3), 'only children are selected');
     });
   });
 });


### PR DESCRIPTION
This PR does several things:

1. Separates row and checkbox selection settings. Users can now
independently choose the how selection works with checkboxes or by
clicking on rows. This creates a matrix of options that allows a number
of different UX patterns with tables.

2. Fixes the behavior of reordering. Before, the final drop position was
determined by the position of the middle of the resize indicator. This
was counterintuitive since the reorder indicator could be in a
completely different place than the cursor, and it actually did not work
at all in cases where the header was larger than the column that was
attempting to be reordered because headers would not travel beyond the
confines of the table. Now, the final drop position is determined by the
cursor, and the reorder indicator is always centered on the cursor.

3. Fixes the resizing. Before, users could begin a resize and end it
without removing the `is-resizing` class, locking the table into having
the resizing cursor forever.