### PR TITLE
[bugfix] Use sticky polyfill in all browsers

### DIFF
--- a/addon/-private/sticky/table-sticky-polyfill.js
+++ b/addon/-private/sticky/table-sticky-polyfill.js
@@ -85,6 +85,7 @@ class TableStickyPolyfill {
       let height = heights[i];
 
       for (let child of row.children) {
+        child.style.position = '-webkit-sticky';
         child.style.position = 'sticky';
         child.style[this.side] = `${offset}px`;
       }

--- a/addon/components/ember-table/component.js
+++ b/addon/components/ember-table/component.js
@@ -29,7 +29,7 @@ export default class EmberTable extends Component {
 
     if (browser.isIE) {
       setupLegacyStickyPolyfill(this.element);
-    } else if (browser.isChrome || browser.isChromeHeadless || browser.isEdge) {
+    } else {
       let thead = this.element.querySelector('thead');
       let tfoot = this.element.querySelector('tfoot');
 
@@ -47,7 +47,7 @@ export default class EmberTable extends Component {
 
     if (browser.isIE) {
       teardownLegacyStickyPolyfill(this.element);
-    } else if (browser.isChrome || browser.isChromeHeadless || browser.isEdge) {
+    } else {
       let thead = this.element.querySelector('thead');
       let tfoot = this.element.querySelector('tfoot');
 

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,6 +1,6 @@
 .ember-table {
   position: relative;
-  overflow: scroll;
+  overflow: auto;
   max-height: 100%;
   max-width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
Enables the sticky polyfill for all browsers except IE. This
should ensure that every browser acts the same way in all cases.

Fixes #545