### PR TITLE
[feat] Adds passthrough options for vertical-collection

### DIFF
--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -1,8 +1,15 @@
 {{#vertical-collection wrappedRows
+  containerSelector=".ember-table"
+
   estimateHeight=estimateRowHeight
   staticHeight=staticHeight
-  containerSelector=".ember-table"
-  bufferSize=20
+  bufferSize=bufferSize
+  renderAll=renderAll
+
+  firstReached=firstReached
+  lastReached=lastReached
+  firstVisibleChanged=firstVisibleChanged
+  lastVisibleChanged=lastVisibleChanged
 
   as |rowValue|
 }}


### PR DESCRIPTION
Adds passthrough arguments for `vertical-collection`

Fixes #493, #539, and #457. Supercedes #459.