### PR TITLE
[bugfix] Fix Column Sorting

### DIFF
--- a/config/addon-docs.js
+++ b/config/addon-docs.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 'use strict';
 
+// eslint-disable-next-line
 const AddonDocsConfig = require('ember-cli-addon-docs/lib/config');
 
 module.exports = class extends AddonDocsConfig {

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -3,7 +3,7 @@
 
 module.exports = function(deployTarget) {
   let ENV = {
-    build: {}
+    build: {},
     // include other plugin configuration that applies to all deploy targets here
   };
 


### PR DESCRIPTION
It was possible for columns to get into a bad state based on the
ordering of Hammer event handlers and the click event handler. This PR
fixes it temporarily, but I think this needs further refactoring.

Testing this currently would be very difficult (it would require a lot
of intricate ordering of events) so this PR does not add tests. Locking
us into a series of events that will likely be refactored seems
ill-advised.

Fixes #553