### PR TITLE
Update notifyPropertyChange polyfill to work with proper versions

### DIFF
--- a/addon/-private/utils/ember.js
+++ b/addon/-private/utils/ember.js
@@ -1,6 +1,6 @@
 /* globals Ember */
 import { gte } from 'ember-compatibility-helpers';
 
-export const notifyPropertyChange = gte('3.0.0')
+export const notifyPropertyChange = gte('3.1.0')
   ? Ember.notifyPropertyChange
   : Ember.propertyDidChange;


### PR DESCRIPTION
notifyPropertyChange exists in Ember 3.1 globals, but not Ember 3.0. Update the polyfill to look for versions of
Ember gte 3.1.0, not 3.0.0