### PR TITLE
allow specifying the collection key

### DIFF
--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -182,6 +182,17 @@ export default class EmberTBody extends Component {
   rows = [];
 
   /**
+    This key is the property used by the collection to determine whether an
+    array mutation is an append, prepend, or complete replacement. It is also
+    the key that is passed to the actions, and can be used to restore scroll
+    position with `idForFirstItem`. This is passed through to the
+    vertical-collection.
+  */
+  @argument({ defaultIfUndefined: true })
+  @type('string')
+  key = '@identity';
+
+  /**
     The map that contains cell meta information for this table. Is meant to be
     unique to this table, which is why it is created here. In order to prevent
     memory leaks, we need to be able to clean the cache manually when the table

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -2,6 +2,7 @@
   containerSelector=".ember-table"
 
   estimateHeight=estimateRowHeight
+  key=key
   staticHeight=staticHeight
   bufferSize=bufferSize
   renderAll=renderAll

--- a/tests/dummy/app/pods/docs/guides/body/occlusion/template.md
+++ b/tests/dummy/app/pods/docs/guides/body/occlusion/template.md
@@ -33,6 +33,10 @@ settings. The current options are:
   pass `staticHeight=true`. You are responsible for ensuring that your rows are
   styled to always be the same as `estimateRowHeight`.
 
+* `key`: This key is the property used by the vertical-collection to determine
+  whether an array mutation is an append, prepend, or complete replacement. It
+  defaults to the object identity `"@identity"`.
+
 {{#docs-demo as |demo|}}
   {{#demo.example}}
     {{! BEGIN-SNIPPET docs-example-occlusion.hbs }}
@@ -44,6 +48,7 @@ settings. The current options are:
           @rows={{rows}}
           @staticHeight={{true}}
           @estimateRowHeight={{41}}
+          @key="A"
         />
       </EmberTable>
     </div>


### PR DESCRIPTION
This helps the collection to better determine whether rows have been added, removed, or changed, and avoids unnecessary re-rendering when using non ember-data data libraries (or POJOs). You can see more info about it in the [vertical-collection docs](https://html-next.github.io/vertical-collection/#/settings):

> ```js
>   // This key is the property used by the collection
>   // to determine whether an array mutation is an
>   // append, prepend, or complete replacement. It is
>   // also the key that is passed to the actions, and
>   // can be used to restore scroll position with
>   // `idForFirstItem`.
>   //
>   // Note: `@identity` is a randomly generated value.
>   // If you want to save the id, use a unique property
>   // on your model (e.g. the `id` field on Ember Data
>   // models)
>   key: '@identity',
> ```

Since I use [ember-apollo-client](https://github.com/bgentry/ember-apollo-client) instead of ember-data, this is required in order to avoid re-rendering the entire collection every time a single item is changed.

Side note: there are probably other properties from vertical-collection that the user might want to be able to customize, so maybe they should be added too.

I couldn't figure out how this could be tested, but open to ideas if there's a way! Cheers :beers: