### PR TITLE
move style dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lint:files": "ember adde-lint --file-names"
   },
   "dependencies": {
-    "@addepar/ember-toolbox": "^0.3.2",
     "@ember-decorators/argument": "^0.8.16",
     "@ember-decorators/babel-transforms": "^0.1.1",
     "@html-next/vertical-collection": "1.0.0-beta.12",
@@ -43,11 +42,11 @@
     "ember-raf-scheduler": "^0.1.0",
     "ember-test-selectors": "^0.3.9",
     "ember-useragent": "^0.6.0",
-    "eslint-plugin-prettier": "2.6.0",
     "hammerjs": "^2.0.8"
   },
   "devDependencies": {
     "@addepar/eslint-config": "^4.0.0",
+    "@addepar/ember-toolbox": "^0.3.2",
     "@addepar/prettier-config": "^1.0.0",
     "@addepar/sass-lint-config": "^2.0.1",
     "@addepar/style-toolbox": "^0.5.0",
@@ -92,6 +91,7 @@
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-prettier": "2.6.0",
     "husky": "^0.14.3",
     "loader.js": "^4.2.3"
   },


### PR DESCRIPTION
Per @pzuraq, this was added as a dependency as a mistake, and causes some significant errors if your codebase is using a different version of Prettier.