### PR TITLE
remove ember-faker

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "hammerjs": "^2.0.8"
   },
   "devDependencies": {
-    "@addepar/eslint-config": "^4.0.0",
     "@addepar/ember-toolbox": "^0.3.2",
+    "@addepar/eslint-config": "^4.0.0",
     "@addepar/prettier-config": "^1.0.0",
     "@addepar/sass-lint-config": "^2.0.1",
     "@addepar/style-toolbox": "^0.5.0",
@@ -60,6 +60,7 @@
     "ember-a11y-testing": "^0.5.0",
     "ember-ajax": "^3.0.0",
     "ember-angle-bracket-invocation-polyfill": "^1.1.4",
+    "ember-auto-import": "^1.0.1",
     "ember-classy-page-object": "^0.5.0",
     "ember-cli": "~3.1.4",
     "ember-cli-addon-docs": "^0.5.0",
@@ -77,7 +78,6 @@
     "ember-cli-uglify": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
-    "ember-faker": "^1.2.1",
     "ember-fetch": "^5.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-math-helpers": "^2.4.1",
@@ -92,6 +92,7 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prettier": "2.6.0",
+    "faker": "^4.1.0",
     "husky": "^0.14.3",
     "loader.js": "^4.2.3"
   },

--- a/tests/dummy/app/pods/docs/guides/header/sorting/controller.js
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/controller.js
@@ -3,7 +3,7 @@ import { computed } from '@ember-decorators/object';
 import faker from 'faker';
 
 function getRandomInt(max, min) {
-  return Math.floor(Math.max(Math.random() * Math.floor(max), min));
+  return faker.random.number({ min, max });
 }
 
 export default class SimpleController extends Controller {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -53,9 +53,6 @@ module.exports = function(environment) {
     // Allow ember-cli-addon-docs to update the rootURL in compiled assets
     ENV.rootURL = 'ADDON_DOCS_ROOT_URL';
     ENV.locationType = 'router-scroll';
-    ENV['ember-faker'] = {
-      enabled: true,
-    };
   }
 
   return ENV;


### PR DESCRIPTION
This PR removes ember-faker in favor of importing it from npm using ember-auto-import (since it also works in test code).
Also replaced a random number generation to use faker.