### PR TITLE
Check for isDestroyed before calling notifyPropertyChange

### DIFF
--- a/addon/-private/utils/computed.js
+++ b/addon/-private/utils/computed.js
@@ -47,7 +47,7 @@ const ClassBasedComputedProperty = EmberObject.extend({
 
   // eslint-disable-next-line
   _contentDidChange: observer('_content', function() {
-    if (!this._isUpdating) {
+    if (!this._isUpdating && !this._context.isDestroyed) {
       this._context.notifyPropertyChange(this._key);
     }
   }),


### PR DESCRIPTION
Fixes Assertion Failed: Cannot modify dependent keys for
`cellValue` on `<Ember.Object:ember###>` after it has been destroyed.

Demonstration of issue:
(https://ember-twiddle.com/aab786f62b838562163c11f8bee3a578?fileTreeShown=false&numColumns=0)