### PR TITLE
use window scroll position for ember-router-scroll

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -6,9 +6,6 @@ module.exports = function(environment) {
     rootURL: '/',
     locationType: 'history',
     historySupportMiddleware: true,
-    routerScroll: {
-      scrollElement: '#docs-viewer__scroll-body',
-    },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],
     },


### PR DESCRIPTION
When using the addon docs, I was getting annoyed that the documentation app did not scroll-to-top when clicking to a different docs section. This fixes that.

In the [ember-cli-addon-docs quickstart](https://ember-learn.github.io/ember-cli-addon-docs/latest/docs/quickstart#optional), they mention ember-router-scroll as an optional dependency to tackle this problem.

This installs the ember-router-scroll addon to properly remember scroll position between routes, and to reset it when the route changes. There was already a (copy-pasted?) config for this in the dummy app, but it pointed to an element that doesn't exist. Instead I just removed the config and it now uses the `window` scroll position instead, which works well.