### PR TITLE
Adds prev, next,first, last computed properties to rowmeta

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -85,6 +85,37 @@ class TableRowMeta extends EmberObject {
     return parentMeta ? get(parentMeta, 'depth') + 1 : 0;
   }
 
+  @computed('_tree.length')
+  get first() {
+    if (get(this, '_tree.length') === 0) {
+      return null;
+    }
+    return get(this, '_tree').objectAt(0);
+  }
+
+  @computed('_tree.length')
+  get last() {
+    let tree = get(this, '_tree');
+    return tree.objectAt(get(tree, 'length') - 1);
+  }
+
+  @computed('_tree.length')
+  get next() {
+    let tree = get(this, '_tree');
+    if (get(this, 'index') + 1 >= get(tree, 'length')) {
+      return null;
+    }
+    return tree.objectAt(get(this, 'index') + 1);
+  }
+
+  @computed('_tree.length')
+  get prev() {
+    if (get(this, 'index') === 0) {
+      return null;
+    }
+    return get(this, '_tree').objectAt(get(this, 'index') - 1);
+  }
+
   toggleCollapse() {
     let canCollapse = get(this, 'canCollapse');
 

--- a/tests/unit/-private/collapse-tree-test.js
+++ b/tests/unit/-private/collapse-tree-test.js
@@ -73,6 +73,106 @@ module('Unit | Private | CollapseTree', function(hooks) {
     assert.equal(tree.objectAt(-1), undefined);
   });
 
+  test('rowMeta next works', function(assert) {
+    tree = CollapseTree.create({
+      rows: generateTree([0, [1, [2, 3], 4, [5, 6]]]),
+      enableTree: true,
+      rowMetaCache,
+    });
+
+    let expectedNext = [
+      {
+        children: [{ value: 2 }, { value: 3 }],
+        value: 1,
+      },
+      { value: 2 },
+      { value: 3 },
+      {
+        children: [{ value: 5 }, { value: 6 }],
+        value: 4,
+      },
+      { value: 5 },
+      { value: 6 },
+      null,
+    ];
+
+    assert.equal(get(tree, 'length'), 7);
+
+    for (let i = 0; i < 7; i++) {
+      assert.deepEqual(metaFor(tree.objectAt(i)).get('next'), expectedNext[i]);
+    }
+  });
+
+  test('rowMeta prev works', function(assert) {
+    tree = CollapseTree.create({
+      rows: generateTree([0, [1, [2, 3], 4, [5, 6]]]),
+      enableTree: true,
+      rowMetaCache,
+    });
+
+    let expectedPrev = [
+      null,
+      {
+        children: [
+          {
+            children: [{ value: 2 }, { value: 3 }],
+            value: 1,
+          },
+          {
+            children: [{ value: 5 }, { value: 6 }],
+            value: 4,
+          },
+        ],
+        value: 0,
+      },
+      {
+        children: [{ value: 2 }, { value: 3 }],
+        value: 1,
+      },
+      { value: 2 },
+      { value: 3 },
+      {
+        children: [{ value: 5 }, { value: 6 }],
+        value: 4,
+      },
+      { value: 5 },
+    ];
+
+    assert.equal(get(tree, 'length'), 7);
+
+    for (let i = 0; i < 7; i++) {
+      assert.deepEqual(metaFor(tree.objectAt(i)).get('prev'), expectedPrev[i]);
+    }
+  });
+
+  test('rowMeta first works with at least 1 row', function(assert) {
+    tree = CollapseTree.create({
+      rows: generateTree([0, 1]),
+      enableTree: true,
+      rowMetaCache,
+    });
+
+    let expectedFirst = { value: 0 };
+
+    for (let i = 0; i < 2; i++) {
+      assert.deepEqual(metaFor(tree.objectAt(i)).get('first'), expectedFirst);
+    }
+  });
+
+  test('rowMeta last works with at least 1 row', function(assert) {
+    tree = CollapseTree.create({
+      rows: generateTree([0, 1, [2, 3]]),
+      enableTree: true,
+      rowMetaCache,
+    });
+
+    let expectedLast = { value: 3 };
+
+    for (let i = 0; i < 4; i++) {
+      assert.deepEqual(metaFor(tree.objectAt(i)).get('last'), expectedLast);
+    }
+  });
+
   test('can disable tree', function(assert) {
     tree = CollapseTree.create({
       rows: generateTree([0, [1, 2]]),


### PR DESCRIPTION
Will return the corresponding row relative to the current row.

Currently has an issue when rows are deleted and/or removed.  When rows are updated, the next time the new computeds are called, there is an assertion in the console:

`Assertion Failed: Cannot modify dependent keys for 'prev' on '<Ember.Object:ember###>' after it has been destroyed.`

