### PR TITLE
Update typedefs for table-head functions

### DIFF
--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -74,7 +74,7 @@ export default class EmberTHead extends Component {
     An ordered array of the sorts applied to the table
   */
   @argument({ defaultIfUndefined: true })
-  @type(Function)
+  @type(optional(Function))
   compareFunction = compareValues;
 
   /**

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -67,7 +67,7 @@ export default class EmberTHead extends Component {
     An optional sort
   */
   @argument({ defaultIfUndefined: true })
-  @type(Function)
+  @type(optional(Function))
   sortFunction = sortMultiple;
 
   /**


### PR DESCRIPTION
This PR updates the table headers `sortFunction` and `compareFunction` arguments to be optional, to line up with the docs example usage.