### PR TITLE
failing test for selection after rows update

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -16,8 +16,16 @@ export const SELECT_MODE = {
   MULTIPLE: 'multiple',
 };
 
-class TableRowMeta extends EmberObject {
+export class TableRowMeta extends EmberObject {
   _rowValue = null;
+
+  /**
+    The map that contains cell meta information for this row. Is meant to be
+    unique to this row, which is why it is created here. In order to prevent
+    memory leaks, we need to be able to clean the cache manually when the row
+    is destroyed or updated, which is why we use a Map instead of WeakMap
+  */
+  _cellMetaCache = new Map();
   _isCollapsed = false;
 
   @computed('_rowValue.isCollapsed')
@@ -221,6 +229,12 @@ class TableRowMeta extends EmberObject {
     tree.sendAction('onSelect', selection);
 
     tree._lastSelectedIndex = rowIndex;
+  }
+
+  destroy() {
+    super.destroy();
+
+    this._cellMetaCache.clear();
   }
 }
 

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -18,7 +18,6 @@
     rowValue=rowValue
     columns=columns
 
-    cellMetaCache=cellMetaCache
     columnMetaCache=columnMetaCache
     rowMetaCache=rowMetaCache
 

--- a/addon/components/ember-tfoot/template.hbs
+++ b/addon/components/ember-tfoot/template.hbs
@@ -3,7 +3,6 @@
     rowValue=rowValue
     columns=columns
 
-    cellMetaCache=cellMetaCache
     columnMetaCache=columnMetaCache
     rowMetaCache=rowMetaCache
 

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -169,6 +169,36 @@ module('Integration | selection', () => {
 
         assert.ok(table.validateSelected(0, 1, 2, 3), 'row and its children are selected');
       });
+
+      test('selection continues to work after rows are updated', async function(assert) {
+        let columns = [
+          {
+            name: 'Name',
+            valuePath: 'name',
+          },
+          {
+            name: 'Age',
+            valuePath: 'age',
+          },
+        ];
+
+        let rows = [{ name: 'Zoe', age: 34 }, { name: 'Alex', age: 43 }, { name: 'Liz', age: 25 }];
+
+        await generateTable(this, { columns, rows });
+
+        assert.ok(table.validateSelected(), 'the row is not marked as selected on initialization');
+
+        await table.selectRow(0);
+
+        assert.ok(table.validateSelected(0), 'Zoe is selected after being clicked');
+
+        this.set('rows', rows.slice());
+
+        assert.ok(table.validateSelected(0), 'Zoe is still selected rows update');
+
+        await table.selectRow(1);
+        assert.ok(table.validateSelected(1), 'Liz is selected after being clicked');
+      });
     });
 
     componentModule('single', function() {


### PR DESCRIPTION
This is a failing test for an issue we ran into around selecting items and then the table row content changing.

For our specific case, changing the sort triggers a network request, which replaces the rows in the table. If a user had selected some items and then changed the sort, they could no longer select more items.

However, the sort changing does not appear to be core to the issue. Just changing the rows is enough to reveal the bug.

I plan to dig in and see if I can find a fix, but any guidance would be appreciated 😄.