### PR TITLE
[feat] Extracts the sort indicator

### DIFF
--- a/addon/components/ember-th/template.hbs
+++ b/addon/components/ember-th/template.hbs
@@ -2,14 +2,14 @@
   {{yield columnValue columnMeta}}
 {{else}}
   {{columnValue.name}}
+{{/if}}
 
-  {{#if isSorted}}
-    <span data-test-sort-indicator class="et-sort-indicator {{if isSortedAsc 'is-ascending' 'is-descending'}}">
-      {{#if isMultiSorted}}
-        {{sortIndex}}
-      {{/if}}
-    </span>
-  {{/if}}
+{{#if isSorted}}
+  <span data-test-sort-indicator class="et-sort-indicator {{if isSortedAsc 'is-ascending' 'is-descending'}}">
+    {{#if isMultiSorted}}
+      {{sortIndex}}
+    {{/if}}
+  </span>
 {{/if}}
 
 {{#if isSortable}}


### PR DESCRIPTION
Makes the sort indicator part of the default template so it is
included in custom templates with yields