### PR TITLE
Yield to inverse when tbody rows are empty

### DIFF
--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -9,6 +9,8 @@ import { required } from '@ember-decorators/argument/validation';
 import { type, optional } from '@ember-decorators/argument/type';
 import { Action } from '@ember-decorators/argument/types';
 
+import { SUPPORTS_INVERSE_BLOCK } from 'ember-compatibility-helpers';
+
 import CollapseTree, { SELECT_MODE } from '../../-private/collapse-tree';
 
 import layout from './template';
@@ -289,5 +291,13 @@ export default class EmberTBody extends Component {
   @computed('containerSelector', 'unwrappedApi.tableId')
   get _containerSelector() {
     return this.get('containerSelector') || `#${this.get('unwrappedApi.tableId')}`;
+  }
+
+  /**
+   * Determines if the component can yield-to-inverse based on
+   * the version compatability.
+   */
+  get shouldYieldToInverse() {
+    return SUPPORTS_INVERSE_BLOCK;
   }
 }

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -41,6 +41,6 @@
     {{/if}}
   {{/-ember-table-private/row-wrapper}}
 
-{{else}}
+{{else if shouldYieldToInverse}}
   {{yield to='inverse'}}
 {{/vertical-collection}}

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -40,4 +40,7 @@
       {{ember-tr api=api}}
     {{/if}}
   {{/-ember-table-private/row-wrapper}}
+
+{{else}}
+  {{yield to='inverse'}}
 {{/vertical-collection}}

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -7,6 +7,8 @@ import { componentModule } from '../../helpers/module';
 
 import { find, findAll, scrollTo } from 'ember-native-dom-helpers';
 
+import { SUPPORTS_INVERSE_BLOCK } from 'ember-compatibility-helpers';
+
 import TablePage from 'ember-table/test-support/pages/ember-table';
 import { collection, hasClass } from 'ember-classy-page-object';
 import wait from 'ember-test-helpers/wait';
@@ -170,25 +172,30 @@ module('Integration | basic', function() {
     });
 
     test('it yields to inverse when tbody rows are empty', async function(assert) {
-      this.set('columns', generateColumns(4));
-      this.set('rows', []);
-      this.render(hbs`
-        <div style="height: 500px;">
-          {{#ember-table as |t|}}
-            {{ember-thead api=t columns=columns}}
+      if (!SUPPORTS_INVERSE_BLOCK) {
+        assert.ok(true, 'Does not support yield-to-inverse');
+      } else {
+        this.set('columns', generateColumns(4));
+        this.set('rows', []);
+        this.render(hbs`
+          <div style="height: 500px;">
+            {{#ember-table as |t|}}
+              {{ember-thead api=t columns=columns}}
 
-            {{#ember-tbody api=t rows=rows as |b|}}
-            {{else}}
-              <div data-test-inverse-yield>inverse yield</div>
-            {{/ember-tbody}}
-          {{/ember-table}}
-        </div>
-      `);
-      await wait();
-      assert.ok(
-        find('[data-test-inverse-yield]'),
-        'expected the inverse yield content to be displayed'
-      );
+              {{#ember-tbody api=t rows=rows as |b|}}
+              {{else}}
+                <div data-test-inverse-yield>inverse yield</div>
+              {{/ember-tbody}}
+            {{/ember-table}}
+          </div>
+        `);
+
+        await wait();
+        assert.ok(
+          find('[data-test-inverse-yield]'),
+          'expected the inverse yield content to be displayed'
+        );
+      }
     });
   });
 

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -168,6 +168,28 @@ module('Integration | basic', function() {
       await wait();
       assert.equal(table.rows.length, itemsCount, 'renders the correct number of rows');
     });
+
+    test('it yields to inverse when tbody rows are empty', async function(assert) {
+      this.set('columns', generateColumns(4));
+      this.set('rows', []);
+      this.render(hbs`
+        <div style="height: 500px;">
+          {{#ember-table as |t|}}
+            {{ember-thead api=t columns=columns}}
+
+            {{#ember-tbody api=t rows=rows as |b|}}
+            {{else}}
+              <div data-test-inverse-yield>inverse yield</div>
+            {{/ember-tbody}}
+          {{/ember-table}}
+        </div>
+      `);
+      await wait();
+      assert.ok(
+        find('[data-test-inverse-yield]'),
+        'expected the inverse yield content to be displayed'
+      );
+    });
   });
 
   componentModule('lifecycle', function() {


### PR DESCRIPTION
One thing I noticed with this implementation is that since the yielded inverse content is rendered inside of the `tbody`, the content only spans the width of the first column by default. Any thoughts on the best way to solve this? Should it be wrapped in a row or something?

I'm not sure how you wanted to handle documentation either.  I could take a stab, if you want to point me in the right area where you think it makes sense (maybe under the `rows-and-trees` section? Does it deserve it's own section?).

Looks like I may need to do something for Ember 1 as well (SUPPORTS_INVERSE_BLOCK).