### PR TITLE
[bugfix] Only clean caches on table destroy

### DIFF
--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -259,7 +259,10 @@ export default class EmberTBody extends Component {
   }
 
   willDestroy() {
-    this._cleanCaches();
+    for (let [row, meta] of this.rowMetaCache.entries()) {
+      meta.destroy();
+      this.rowMetaCache.delete(row);
+    }
 
     this.collapseTree.destroy();
   }
@@ -272,8 +275,6 @@ export default class EmberTBody extends Component {
   @computed('rows')
   get wrappedRows() {
     let rows = this.get('rows');
-
-    this._cleanCaches(rows);
 
     this.collapseTree.set('rowMetaCache', this.rowMetaCache);
     this.collapseTree.set('rows', rows);
@@ -289,30 +290,5 @@ export default class EmberTBody extends Component {
   @computed('containerSelector', 'unwrappedApi.tableId')
   get _containerSelector() {
     return this.get('containerSelector') || `#${this.get('unwrappedApi.tableId')}`;
-  }
-
-  /**
-    Helper method that is used to clear the row and cell caches whenever the
-    underlying data has changed.
-  */
-  _cleanCaches(newRows) {
-    let newRowMetaCache = new Map();
-    let meta;
-
-    if (isArray(newRows)) {
-      newRows.forEach(row => {
-        if ((meta = this.rowMetaCache.get(row))) {
-          newRowMetaCache.set(row, meta);
-          this.rowMetaCache.delete(row);
-        }
-      });
-    }
-
-    for (let [row, meta] of this.rowMetaCache.entries()) {
-      meta.destroy();
-      this.rowMetaCache.delete(row);
-    }
-
-    this.set('rowMetaCache', newRowMetaCache);
   }
 }

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -1,5 +1,4 @@
 import Component from '@ember/component';
-import { isArray } from '@ember/array';
 
 import { tagName } from '@ember-decorators/component';
 import { computed } from '@ember-decorators/object';


### PR DESCRIPTION
Currently, whenever rows change we attempt to erase the row meta values
for rows which are no longer part of the table. This is an O(n)
operation which is fairly expensive, and we were doing it wrong as we
were not traversing children rows at all.

This PR moves the cache cleaning to only occur when the table is fully
destroyed. This means that we may hold onto meta objects longer than is
ideal, but we also won't incur an expensive operation every time the
table is updated. The alternative would be to fix the cache cleaning so
that we traverse child rows as well.