### PR TITLE
Added possibility to set custom container selector

### DIFF
--- a/addon/components/ember-table/component.js
+++ b/addon/components/ember-table/component.js
@@ -96,6 +96,7 @@ export default class EmberTable extends Component {
     return {
       columns: null,
       registerColumnTree: this.registerColumnTree,
+      tableId: this.elementId,
     };
   }
 

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -195,6 +195,14 @@ export default class EmberTBody extends Component {
   key = '@identity';
 
   /**
+    A selector string that will select the element from
+    which to calculate the viewable height.
+  */
+  @argument({ defaultIfUndefined: true })
+  @type('string')
+  containerSelector = '';
+
+  /**
     The map that contains row meta information for this table.
   */
   rowMetaCache = new Map();
@@ -271,6 +279,16 @@ export default class EmberTBody extends Component {
     this.collapseTree.set('rows', rows);
 
     return this.collapseTree;
+  }
+
+  /**
+    Computed property which calculates container selector for vertical collection.
+    It can be a custom selector provided directly to {{ember-tbody}}.
+    If not, it will be equal to parent {{ember-table}} `id`.
+  */
+  @computed('containerSelector', 'unwrappedApi.tableId')
+  get _containerSelector() {
+    return this.get('containerSelector') || `#${this.get('unwrappedApi.tableId')}`;
   }
 
   /**

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -1,5 +1,5 @@
 {{#vertical-collection wrappedRows
-  containerSelector=".ember-table"
+  containerSelector=_containerSelector
 
   estimateHeight=estimateRowHeight
   key=key

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -9,6 +9,7 @@ import { find, findAll, scrollTo } from 'ember-native-dom-helpers';
 
 import TablePage from 'ember-table/test-support/pages/ember-table';
 import { collection, hasClass } from 'ember-classy-page-object';
+import wait from 'ember-test-helpers/wait';
 
 let table = new TablePage({
   body: {
@@ -129,6 +130,43 @@ module('Integration | basic', function() {
 
       await a11yAudit();
       assert.ok(true, 'No accessibility error found');
+    });
+
+    test('custom container selector', async function(assert) {
+      let rowCount = 100;
+      let columnCount = 15;
+      let rowHeight = 20;
+      let containerHeight = 200;
+      let itemsCount = Math.ceil(containerHeight / rowHeight);
+      this.set('columns', generateColumns(columnCount));
+      this.set('rows', generateRows(rowCount));
+      this.set('estimateRowHeight', rowHeight);
+      this.set('containerHeight', containerHeight);
+
+      await this.render(hbs`
+        <style>
+          .ember-table {
+            max-height: initial;
+          }
+        </style>
+        <div id="container" style="height: {{containerHeight}}px; overflow: auto;">
+          {{#ember-table as |t|}}
+            {{ember-thead api=t columns=columns}}
+
+            {{ember-tbody
+              api=t
+              containerSelector="#container"
+              rows=rows
+              estimateRowHeight=estimateRowHeight
+              renderAll=false
+              bufferSize=0
+            }}
+          {{/ember-table}}
+        </div>
+      `);
+
+      await wait();
+      assert.equal(table.rows.length, itemsCount, 'renders the correct number of rows');
     });
   });
 


### PR DESCRIPTION
Added possibility to set custom container selector.
In case if we don't need fixed height of `ember-table` and scrollable height need to be taken from some outer container, we must provide`{{vertical-collection}}` by container selector property. Also we provided table id as default selector, which is more unique than `.ember-table`