### PR TITLE
Change width style handling

### DIFF
--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -490,7 +490,7 @@ class ColumnTreeNode extends EmberObject {
     }
 
     let subcolumns = get(parent, 'subcolumnNodes');
-    let offsetLeft = get(parent, 'offsetLeft');
+    let offsetLeft = get(parent, 'element.offsetLeft');
 
     for (let column of subcolumns) {
       if (column === this) {
@@ -759,9 +759,9 @@ export default class ColumnTree extends EmberObject {
     let subcolumns = get(column.parent, 'subcolumnNodes');
 
     for (let column of subcolumns) {
-      let offset = get(column, 'offsetLeft');
+      let offset = get(column, 'element.offsetLeft');
 
-      if (left < offset + get(column, 'width')) {
+      if (left < offset + get(column, 'element.offsetWidth')) {
         return column;
       }
     }
@@ -771,7 +771,7 @@ export default class ColumnTree extends EmberObject {
 
   getClosestColumnOffset(column, left, isFixed) {
     let closestColumn = this.getClosestColumn(column, left, isFixed);
-    let offsetLeft = get(closestColumn, 'offsetLeft');
+    let offsetLeft = get(closestColumn, 'element.offsetLeft');
 
     // If the column is fixed, readjust the offset so that it's correct within
     // the container
@@ -842,7 +842,7 @@ export default class ColumnTree extends EmberObject {
 
     this._reorderDropIndicator.width = get(
       this.getClosestColumn(node, this._reorderDropIndicator.left, get(node, 'isFixed')),
-      'width'
+      'element.offsetWidth'
     );
   }
 

--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -19,8 +19,6 @@ import { assert } from '@ember/debug';
 const SCROLL_THRESHOLD = 50;
 
 const DEFAULT_COLUMN_WIDTH = 100;
-const DEFAULT_MIN_WIDTH = 50;
-const DEFAULT_MAX_WIDTH = Infinity;
 
 const LOOP_COUNT_GUARD = 500;
 
@@ -66,7 +64,7 @@ function divideRounded(x, n) {
 class TableColumnMeta extends EmberObject {
   // If no width is set on the column itself, we cache a temporary width on the
   // meta object. This is set to the default width.
-  _width = DEFAULT_COLUMN_WIDTH;
+  _width = null;
 
   @readOnly('_node.isLeaf')
   isLeaf;
@@ -85,6 +83,12 @@ class TableColumnMeta extends EmberObject {
 
   @readOnly('_node.width')
   width;
+
+  @readOnly('_node.minWidth')
+  minWidth;
+
+  @readOnly('_node.maxWidth')
+  maxWidth;
 
   @readOnly('_node.offsetLeft')
   offsetLeft;
@@ -322,7 +326,7 @@ class ColumnTreeNode extends EmberObject {
     if (get(this, 'isLeaf')) {
       let columnMinWidth = get(this, 'column.minWidth');
 
-      return typeof columnMinWidth === 'number' ? columnMinWidth : DEFAULT_MIN_WIDTH;
+      return typeof columnMinWidth === 'number' ? columnMinWidth : null;
     }
 
     return get(this, 'subcolumnNodes').reduce((sum, subcolumn) => {
@@ -332,12 +336,12 @@ class ColumnTreeNode extends EmberObject {
     }, 0);
   }
 
-  @computed('column.minWidth')
+  @computed('column.maxWidth')
   get maxWidth() {
     if (get(this, 'isLeaf')) {
       let columnMaxWidth = get(this, 'column.maxWidth');
 
-      return typeof columnMaxWidth === 'number' ? columnMaxWidth : DEFAULT_MAX_WIDTH;
+      return typeof columnMaxWidth === 'number' ? columnMaxWidth : null;
     }
 
     return get(this, 'subcolumnNodes').reduce((sum, subcolumn) => {
@@ -357,7 +361,8 @@ class ColumnTreeNode extends EmberObject {
         return columnWidth;
       } else {
         let meta = get(this, 'tree.columnMetaCache').get(column);
-        return get(meta, '_width');
+        let metaWidth = get(meta, '_width');
+        return typeof metaWidth === 'number' ? metaWidth : null;
       }
     }
 

--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -18,8 +18,6 @@ import { assert } from '@ember/debug';
 
 const SCROLL_THRESHOLD = 50;
 
-const DEFAULT_COLUMN_WIDTH = 100;
-
 const LOOP_COUNT_GUARD = 500;
 
 export const RESIZE_MODE = {

--- a/addon/components/-private/base-table-cell.js
+++ b/addon/components/-private/base-table-cell.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { equal } from '@ember/object/computed';
+import { equal, bool } from '@ember/object/computed';
 import { observer } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
 
@@ -7,11 +7,21 @@ export default Component.extend({
   // Provided by subclasses
   columnMeta: null,
 
-  classNameBindings: ['isFirstColumn', 'isFixedLeft', 'isFixedRight'],
+  classNameBindings: [
+    'isFirstColumn',
+    'isFixedLeft',
+    'isFixedRight',
+    'hasWidth',
+    'hasMinWidth',
+    'hasMaxWidth',
+  ],
 
   isFirstColumn: equal('columnMeta.index', 0),
   isFixedLeft: equal('columnMeta.isFixed', 'left'),
   isFixedRight: equal('columnMeta.isFixed', 'right'),
+  hasWidth: bool('columnMeta.width'),
+  hasMinWidth: bool('columnMeta.minWidth'),
+  hasMaxWidth: bool('columnMeta.maxWidth'),
 
   // eslint-disable-next-line
   scheduleUpdateStyles: observer(
@@ -27,10 +37,12 @@ export default Component.extend({
   updateStyles() {
     if (typeof FastBoot === 'undefined' && this.element) {
       let width = `${this.get('columnMeta.width')}px`;
+      let minWidth = `${this.get('columnMeta.minWidth')}px`;
+      let maxWidth = `${this.get('columnMeta.maxWidth')}px`;
 
       this.element.style.width = width;
-      this.element.style.minWidth = width;
-      this.element.style.maxWidth = width;
+      this.element.style.minWidth = minWidth;
+      this.element.style.maxWidth = maxWidth;
 
       if (this.get('isFixedLeft')) {
         this.element.style.left = `${Math.round(this.get('columnMeta.offsetLeft'))}px`;


### PR DESCRIPTION
I had several issues with the default cell sizing. As for now, it was not possible to have the content of a cell define it's width.

This PR would allow to have bare <td> or <th> element that would respect the stylesheet sizing if no width is defined for the column.

Some classes have been added to allow stylesheet behavior based on the presence of the different width constraints