### PR TITLE
Disable collapse support at a row level

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -75,7 +75,7 @@ export class TableRowMeta extends EmberObject {
     return selection.includes(rowValue) || get(this, '_parentMeta.isGroupSelected');
   }
 
-  @computed('_tree.{enableTree,enableCollapse}', '_rowValue.children.[]')
+  @computed('_tree.{enableTree,enableCollapse}', '_rowValue.children.[]', '_rowValue.disableCollapse')
   get canCollapse() {
     if (!get(this, '_tree.enableTree') || !get(this, '_tree.enableCollapse')) {
       return false;
@@ -83,7 +83,7 @@ export class TableRowMeta extends EmberObject {
 
     let children = get(this, '_rowValue.children');
 
-    return isArray(children) && get(children, 'length') > 0;
+    return !get(this, '_rowValue.disableCollapse') && isArray(children) && get(children, 'length') > 0;
   }
 
   @computed('_parentMeta.depth')

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -75,7 +75,7 @@ export class TableRowMeta extends EmberObject {
     return selection.includes(rowValue) || get(this, '_parentMeta.isGroupSelected');
   }
 
-  @computed('_tree.{enableTree,enableCollapse}', '_rowValue.children.[]', '_rowValue.disableCollapse')
+  @computed('_tree.{enableTree,enableCollapse}', '_rowValue.{children.[],disableCollapse}')
   get canCollapse() {
     if (!get(this, '_tree.enableTree') || !get(this, '_tree.enableCollapse')) {
       return false;
@@ -83,7 +83,9 @@ export class TableRowMeta extends EmberObject {
 
     let children = get(this, '_rowValue.children');
 
-    return !get(this, '_rowValue.disableCollapse') && isArray(children) && get(children, 'length') > 0;
+    return (
+      !get(this, '_rowValue.disableCollapse') && isArray(children) && get(children, 'length') > 0
+    );
   }
 
   @computed('_parentMeta.depth')

--- a/tests/integration/components/tree-test.js
+++ b/tests/integration/components/tree-test.js
@@ -40,7 +40,6 @@ module('Integration | Tree', () => {
       assert.equal(table.getCell(1, 0).text, '00A', 'correct cell rendered');
 
       assert.equal(table.rows.length, 6, 'renders all rows');
-      debugger;
       assert.ok(table.rows.objectAt(0).collapse.isPresent, 'collapse toggle is back');
     });
 

--- a/tests/integration/components/tree-test.js
+++ b/tests/integration/components/tree-test.js
@@ -40,6 +40,7 @@ module('Integration | Tree', () => {
       assert.equal(table.getCell(1, 0).text, '00A', 'correct cell rendered');
 
       assert.equal(table.rows.length, 6, 'renders all rows');
+      debugger;
       assert.ok(table.rows.objectAt(0).collapse.isPresent, 'collapse toggle is back');
     });
 

--- a/tests/unit/-private/collapse-tree-test.js
+++ b/tests/unit/-private/collapse-tree-test.js
@@ -320,7 +320,7 @@ module('Unit | Private | CollapseTree', function(hooks) {
 
     assert.equal(get(tree, 'length'), 7);
 
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 7; i++) {
       assert.equal(tree.objectAt(i).value, expectedValue[i]);
       assert.equal(metaFor(tree.objectAt(i)).get('depth'), expectedDepth[i]);
     }
@@ -332,6 +332,43 @@ module('Unit | Private | CollapseTree', function(hooks) {
     expectedDepth = [0, 1, 1, 2, 2];
 
     assert.equal(get(tree, 'length'), 5);
+
+    for (let i = 0; i < 5; i++) {
+      assert.equal(tree.objectAt(i).value, expectedValue[i]);
+      assert.equal(metaFor(tree.objectAt(i)).get('depth'), expectedDepth[i]);
+    }
+  });
+
+  test('can disable collapse at a row level', function(assert) {
+    let rows = generateTree([0, [1, [2, 3], 4, [5, 6]]]);
+    tree = CollapseTree.create({ rows, rowMetaCache, enableTree: true });
+    let row4Meta = metaFor(tree.objectAt(4));
+    assert.equal(
+      row4Meta.get('_rowValue.disableCollapse') === true,
+      false,
+      'collapse is not yet disabled'
+    );
+
+    let expectedValue = [0, 1, 2, 3, 4, 5, 6];
+    let expectedDepth = [0, 1, 2, 2, 1, 2, 2];
+
+    assert.equal(get(tree, 'length'), 7);
+
+    for (let i = 0; i < 7; i++) {
+      assert.equal(tree.objectAt(i).value, expectedValue[i]);
+      assert.equal(metaFor(tree.objectAt(i)).get('depth'), expectedDepth[i]);
+    }
+
+    row4Meta.set('_rowValue.disableCollapse', true);
+
+    // we can no longer collapse the tree at this row
+    assert.equal(get(row4Meta, 'canCollapse'), false);
+    // but the tree remains unchanged other than the ability to collapse
+    assert.equal(get(tree, 'length'), 7);
+    for (let i = 0; i < 7; i++) {
+      assert.equal(tree.objectAt(i).value, expectedValue[i]);
+      assert.equal(metaFor(tree.objectAt(i)).get('depth'), expectedDepth[i]);
+    }
   });
 
   test('can update nodes', function(assert) {


### PR DESCRIPTION
In this pr I hope to make it possible to disable collapsing at a row level rather than just at the total tree level.  I need this functionality to allow my tables to "hide" the children below a certain level but I thought this might be a better approach than a `maxDepth` because this is more flexible and allows more user choice about what they want to build.

I'm not married to my name `disableCollapse`, `disableTree` would probably also be fine to me. Let me know what you think of this change and whether I need to add this to any docs