### PR TITLE
Replace `constructor` with `init`

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -311,8 +311,8 @@ function closestLessThan(values, target) {
 class CollapseTreeNode extends EmberObject {
   _childNodes = null;
 
-  constructor() {
-    super(...arguments);
+  init() {
+    super.init(...arguments);
 
     let value = get(this, 'value');
     let parentValue = get(this, 'parent.value');
@@ -652,8 +652,8 @@ class CollapseTreeNode extends EmberObject {
   order of magnitude of space and allocation costs this way.
 */
 export default class CollapseTree extends EmberObject.extend(EmberArray) {
-  constructor() {
-    super(...arguments);
+  init() {
+    super.init(...arguments);
 
     // Whenever the root node's length changes we need to propogate the change to
     // users of the tree, and since the tree is meant to work like an array we should

--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -160,8 +160,8 @@ class TableColumnMeta extends EmberObject {
 class ColumnTreeNode extends EmberObject {
   _subcolumnNodes = null;
 
-  constructor() {
-    super(...arguments);
+  init() {
+    super.init(...arguments);
 
     let tree = get(this, 'tree');
     let parent = get(this, 'parent');
@@ -530,8 +530,8 @@ class ColumnTreeNode extends EmberObject {
 }
 
 export default class ColumnTree extends EmberObject {
-  constructor() {
-    super(...arguments);
+  init() {
+    super.init(...arguments);
 
     this.token = new Token();
 

--- a/addon/components/-private/row-wrapper.js
+++ b/addon/components/-private/row-wrapper.js
@@ -33,8 +33,6 @@ const layout = hbs`{{yield api}}`;
 
 @tagName('')
 export default class RowWrapper extends Component {
-  layout = layout;
-
   @argument
   rowValue;
 
@@ -56,7 +54,12 @@ export default class RowWrapper extends Component {
   @argument
   checkboxSelectionMode;
 
-  _cells = emberA([]);
+  init() {
+    super.init(...arguments);
+
+    this.layout = layout;
+    this._cells = emberA([]);
+  }
 
   destroy() {
     this._cells.forEach(cell => cell.destroy());

--- a/addon/components/ember-table/component.js
+++ b/addon/components/ember-table/component.js
@@ -37,13 +37,17 @@ import layout from './template';
 */
 @classNames('ember-table')
 export default class EmberTable extends Component {
-  layout = layout;
-
   @service
   userAgent;
 
   @attribute('data-test-ember-table')
   dataTestEmberTable = true;
+
+  init() {
+    super.init(...arguments);
+
+    this.layout = layout;
+  }
 
   didInsertElement() {
     super.didInsertElement(...arguments);

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -232,8 +232,8 @@ export default class EmberTBody extends Component {
   @bool('onSelect')
   canSelect;
 
-  constructor() {
-    super(...arguments);
+  init() {
+    super.init(...arguments);
 
     this._updateCollapseTree();
 

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -38,8 +38,6 @@ import { assert } from '@ember/debug';
 */
 @tagName('tbody')
 export default class EmberTBody extends Component {
-  layout = layout;
-
   /**
     The API object passed in by the table
   */
@@ -212,20 +210,6 @@ export default class EmberTBody extends Component {
   containerSelector = '';
 
   /**
-    The map that contains row meta information for this table.
-  */
-  rowMetaCache = new Map();
-
-  /**
-    A data structure that the table uses wrapping the `rows` object. It flattens
-    the tree structure of the nodes and allows us to treat it as a flat list of
-    items. This is much more convenient for most table operations in general.
-  */
-  collapseTree = CollapseTree.create({
-    sendAction: this.sendAction.bind(this),
-  });
-
-  /**
     Whether or not the table can select, is true if an `onSelect` action was
     passed to the table.
   */
@@ -234,6 +218,22 @@ export default class EmberTBody extends Component {
 
   init() {
     super.init(...arguments);
+
+    this.layout = layout;
+
+    /**
+      The map that contains row meta information for this table.
+    */
+    this.rowMetaCache = new Map();
+
+    /**
+      A data structure that the table uses wrapping the `rows` object. It flattens
+      the tree structure of the nodes and allows us to treat it as a flat list of
+      items. This is much more convenient for most table operations in general.
+    */
+    this.collapseTree = CollapseTree.create({
+      sendAction: this.sendAction.bind(this),
+    });
 
     this._updateCollapseTree();
 

--- a/addon/components/ember-td/component.js
+++ b/addon/components/ember-td/component.js
@@ -39,8 +39,6 @@ import { SELECT_MODE } from '../../-private/collapse-tree';
 */
 @tagName('td')
 export default class EmberTd extends BaseTableCell {
-  layout = layout;
-
   /**
     The API object passed in by the table row
   */
@@ -93,6 +91,12 @@ export default class EmberTd extends BaseTableCell {
 
   @readOnly('rowMeta.canCollapse')
   canCollapse;
+
+  init() {
+    super.init(...arguments);
+
+    this.layout = layout;
+  }
 
   @computed('rowMeta.depth')
   get depthClass() {

--- a/addon/components/ember-tfoot/component.js
+++ b/addon/components/ember-tfoot/component.js
@@ -31,7 +31,11 @@ import layout from './template';
 */
 @tagName('tfoot')
 export default class EmberTFoot extends EmberTBody {
-  layout = layout;
+  init() {
+    super.init(...arguments);
+
+    this.layout = layout;
+  }
 
   @computed('wrappedRows.[]')
   get wrappedRowArray() {

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -38,8 +38,6 @@ import layout from './template';
 */
 @tagName('thead')
 export default class EmberTHead extends Component {
-  layout = layout;
-
   /**
     The API object passed in by the table
   */
@@ -151,28 +149,30 @@ export default class EmberTHead extends Component {
   @type(optional(Action))
   onResize = null;
 
-  /**
-   * A sensor object that sends events to this table component when table size changes. When table
-   * is resized, table width & height are updated and other computed properties depending on them
-   * also get updated.
-   */
-  _tableResizeSensor = null;
-
-  /**
-    The map that contains column meta information for this table. Is meant to be
-    unique to this table, which is why it is created here. In order to prevent
-    memory leaks, we need to be able to clean the cache manually when the table
-    is destroyed or updated, which is why we use a Map instead of WeakMap
-  */
-  columnMetaCache = new Map();
-
-  columnTree = ColumnTree.create({
-    sendAction: this.sendAction.bind(this),
-    columnMetaCache: this.columnMetaCache,
-  });
-
   init() {
     super.init(...arguments);
+
+    this.layout = layout;
+
+    /**
+     * A sensor object that sends events to this table component when table size changes. When table
+     * is resized, table width & height are updated and other computed properties depending on them
+     * also get updated.
+     */
+    this._tableResizeSensor = null;
+
+    /**
+      The map that contains column meta information for this table. Is meant to be
+      unique to this table, which is why it is created here. In order to prevent
+      memory leaks, we need to be able to clean the cache manually when the table
+      is destroyed or updated, which is why we use a Map instead of WeakMap
+    */
+    this.columnMetaCache = new Map();
+
+    this.columnTree = ColumnTree.create({
+      sendAction: this.sendAction.bind(this),
+      columnMetaCache: this.columnMetaCache,
+    });
 
     this._updateApi();
     this._updateColumnTree();

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -171,8 +171,8 @@ export default class EmberTHead extends Component {
     columnMetaCache: this.columnMetaCache,
   });
 
-  constructor() {
-    super(...arguments);
+  init() {
+    super.init(...arguments);
 
     this._updateApi();
     this._updateColumnTree();

--- a/addon/components/ember-tr/component.js
+++ b/addon/components/ember-tr/component.js
@@ -50,8 +50,6 @@ import { SELECT_MODE } from '../../-private/collapse-tree';
 @tagName('tr')
 @classNames('et-tr')
 export default class EmberTr extends Component {
-  layout = layout;
-
   /**
     The API object passed in by the table body, header, or footer
   */
@@ -96,6 +94,12 @@ export default class EmberTr extends Component {
   @className
   @readOnly('rowMeta.isGroupSelected')
   isGroupSelected;
+
+  init() {
+    super.init(...arguments);
+
+    this.layout = layout;
+  }
 
   @className
   @computed('rowSelectionMode')


### PR DESCRIPTION
As per [RFC 337](https://github.com/emberjs/rfcs/pull/337), the way
classes are initialized has changed. Namely, arguments are no longer
available in `constructor` but they are still available in `init`.

Because we used `constructor` to set properties from passed in arguments
before, we started seeing error on Travis:

```
Error: Property set failed: object in path "unwrappedApi" could not be found.
```

This change switches to using `init` where appropriate and is a
backwards compatible change.

EDIT:

An unfortunate side-effect of replacing `constructor` with `init` is
that class properties are no longer assigned properly. They used to be
assigned after `init`. So all class properties initializers that are not decorated
with `@argument` need to be moved in `init`.

thanks to @pzuraq for brain dump and explaining me differences between `init` and `constructor`.