### PR TITLE
Add optional containerWidthAdjustment to ember-thead component

### DIFF
--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -654,7 +654,9 @@ export default class ColumnTree extends EmberObject {
       return;
     }
 
-    let containerWidth = getInnerClientRect(this.container).width * this.scale;
+    let containerWidthAdjustment = get(this, 'containerWidthAdjustment') || 0;
+    let containerWidth =
+      getInnerClientRect(this.container).width * this.scale + containerWidthAdjustment;
     let treeWidth = get(this, 'root.width');
     let columns = get(this, 'root.subcolumnNodes');
 

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -122,6 +122,13 @@ export default class EmberTHead extends Component {
   widthConstraint = WIDTH_CONSTRAINT.NONE;
 
   /**
+    A numeric adjustment to be applied to the constraint on the table's size.
+  */
+  @argument
+  @type(optional('number'))
+  containerWidthAdjustment = null;
+
+  /**
     An action that is sent when sorts is updated
   */
   @argument
@@ -172,6 +179,7 @@ export default class EmberTHead extends Component {
     this.columnTree = ColumnTree.create({
       sendAction: this.sendAction.bind(this),
       columnMetaCache: this.columnMetaCache,
+      containerWidthAdjustment: this.containerWidthAdjustment,
     });
 
     this._updateApi();

--- a/tests/dummy/app/pods/docs/guides/header/size-constraints/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/size-constraints/template.md
@@ -19,7 +19,12 @@ override the min/max widths provided by columns.
 <aside>
   `eq-container` mode should generally be paired with `resizeMode='fluid'` to
   get a more natural resize effect. This is useful for tables that must fit
-  a constrained space, like tables in a powerpoint
+  a constrained space, like tables in a powerpoint.
+  <br><br>
+  If you need to make a small adjustment to the container width (such as to
+  account for a customized scrollbar that would cover some portion of the
+  container width), set `containerWidthAdjustment` to a numerical value equal to
+  the amount you need the measured container width to be adjusted.
 </aside>
 
 {{#docs-demo as |demo|}}

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -12,6 +12,7 @@ const fullTable = hbs`
         api=t
 
         columns=columns
+        containerWidthAdjustment=containerWidthAdjustment
         sorts=sorts
         resizeMode=resizeMode
         fillMode=fillMode

--- a/tests/integration/components/headers/main-test.js
+++ b/tests/integration/components/headers/main-test.js
@@ -46,6 +46,24 @@ module('Integration | header | main', function() {
       );
     });
 
+    test('eq-container with containerWidthAdjustment', async function(assert) {
+      let adjustmentValue = -10;
+      await generateTable(this, {
+        widthConstraint: 'eq-container',
+        containerWidthAdjustment: adjustmentValue,
+        columnCount: 2,
+      });
+
+      let containerWidth = table.containerWidth;
+      let tableWidth = table.width;
+
+      assert.equal(
+        tableWidth - containerWidth,
+        adjustmentValue,
+        'Table width is adjusted from container width by the specified amount.'
+      );
+    });
+
     test('gte-container', async function(assert) {
       await generateTable(this, {
         widthConstraint: 'gte-container',


### PR DESCRIPTION
# Problem

When using custom CSS-styled scrollbars on the `div.ember-table` element, the vertical scrollbar covers some of the container's width. In browsers such as Chrome, this causes `div.ember-table` to *also* display a horizontal scrollbar to view the `table` content that is now covered by the vertical scrollbar.

# Solution

In order to avoid this added horizontal scrollbar, @mixonic and I added here support for an optional argument to be passed to the `ember-thead` component called `containerWidthAdjustment`. This value gets passed along to the ColumnTree class to be applied to the calculated container width. This allows us to adjust the table width to account for the covering scrollbar in order to avoid a horizontal scrollbar in cases where we do not want one.

# Alternatives

As we explored this problem, we originally passed in a custom function for calculating the container width that itself performed the necessary adjustment. While using a custom function could possibly account for more complex use cases, we ultimately decided that it was overkill for our current (and the seemingly most common) need to adjust the table width by a set value.