### PR TITLE
[bugfix] Recompute TableRowMeta.isSelected on external selection array changes

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -52,7 +52,7 @@ export class TableRowMeta extends EmberObject {
     return isCollapsed;
   }
 
-  @computed('_tree.selection', '_parentMeta.isSelected')
+  @computed('_tree.selection.[]', '_parentMeta.isSelected')
   get isSelected() {
     let rowValue = get(this, '_rowValue');
     let selection = get(this, '_tree.selection');

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -4,6 +4,8 @@ import { componentModule } from '../../helpers/module';
 import TablePage from 'ember-table/test-support/pages/ember-table';
 
 import { generateTable } from '../../helpers/generate-table';
+import { A as emberA } from '@ember/array';
+import { run } from '@ember/runloop';
 
 let table = new TablePage({
   validateSelected(...selectedIndexes) {
@@ -198,6 +200,19 @@ module('Integration | selection', () => {
 
         await table.selectRow(1);
         assert.ok(table.validateSelected(1), 'Liz is selected after being clicked');
+      });
+
+      test('Rows are selected when selection is changed externally', async function(assert) {
+        let selection = emberA();
+        let rows = [{ name: 'Zoe', age: 34 }, { name: 'Alex', age: 43 }, { name: 'Liz', age: 25 }];
+
+        await generateTable(this, { rows, selection });
+
+        assert.ok(table.validateSelected(), 'rows are not selected');
+
+        run(() => selection.pushObject(rows[0]));
+
+        assert.ok(table.validateSelected(0), 'Zoe is selected after external change');
       });
     });
 


### PR DESCRIPTION
The ember-tbody component accepts an optional [`selection`](https://opensource.addepar.com/ember-table/latest/docs/api/components/ember-tbody#selection) argument. The `isSelected` and `isGroupSelected` CPs on TableRowMeta [both depend on this property](https://github.com/Addepar/ember-table/blob/5efba8c34d105c011d5682921beb67291bee3206/addon/-private/collapse-tree.js#L55-L77). However, the latter also tracks changes to the array (i.e., `_tree.selection.[]`).

This causes unexpected behavior when `selection` is changed externally — the class name binding for isGroupSelected is updated but isSelected is not.

A workaround, or possibly preferred usage, is requiring that `selections` array be treated as immutable, requiring the user to generate a new array when updating. However, since `isGroupSelection` behavior seems to imply that selection array mutation is acceptable, this PR changes `isSelected` to be consistent.