### PR TITLE
[bugfix] Disable ember/new-module-imports rule for special case

### DIFF
--- a/addon/-private/utils/ember.js
+++ b/addon/-private/utils/ember.js
@@ -1,6 +1,7 @@
 /* globals Ember */
 import { gte } from 'ember-compatibility-helpers';
 
+/* eslint-disable ember/new-module-imports */
 export const notifyPropertyChange = gte('3.1.0')
   ? Ember.notifyPropertyChange
   : Ember.propertyDidChange;


### PR DESCRIPTION
Uncovered when building https://github.com/Addepar/ember-table/pull/644, which is also the cause of last [build failure on master](https://travis-ci.org/Addepar/ember-table/builds/469894604).