### PR TITLE
Don't try to notify the cell value of a change if the context is being destroyed

### DIFF
--- a/addon/-private/utils/computed.js
+++ b/addon/-private/utils/computed.js
@@ -45,7 +45,7 @@ const ClassBasedComputedProperty = EmberObject.extend({
 
   // eslint-disable-next-line
   _contentDidChange: observer('_content', function() {
-    if (!this._isUpdating) {
+    if (!this._isUpdating && !this._context.isDestroyed && !this._context.isDestroying) {
       this._context.notifyPropertyChange(this._key);
     }
   }),


### PR DESCRIPTION
I believe the fix is correct that the cellValue notifier shouldn't fire if the context is being destroyed. 

This fixes https://github.com/Addepar/ember-table/issues/638