### PR TITLE
Revert #623 until row meta cache handles non-unique row values

### DIFF
--- a/tests/unit/-private/collapse-tree-test.js
+++ b/tests/unit/-private/collapse-tree-test.js
@@ -173,25 +173,6 @@ module('Unit | Private | CollapseTree', function(hooks) {
     }
   });
 
-  test('rowMeta index is recomputed when row is added or removed', function(assert) {
-    let rows = generateTree([1, [2, 3, [4, 5], 6], 7]);
-    tree = CollapseTree.create({ rows, rowMetaCache, enableTree: true });
-
-    let nodes = tree.toArray();
-    nodes.forEach((node, i) => assert.equal(metaFor(node).get('index'), i));
-
-    rows.unshiftObject({ value: 0 });
-
-    let firstNode = run(() => tree.objectAt(0));
-    nodes = [firstNode].concat(nodes);
-    nodes.forEach((node, i) => assert.equal(metaFor(node).get('index'), i));
-
-    rows.pushObject({ value: 8 });
-
-    let lastNode = run(() => tree.objectAt(8));
-    nodes.concat(lastNode).forEach((node, i) => assert.equal(metaFor(node).get('index'), i));
-  });
-
   test('can disable tree', function(assert) {
     tree = CollapseTree.create({
       rows: generateTree([0, [1, 2]]),


### PR DESCRIPTION
The row meta cache is a `Map` keyed by row values. A row meta has an `index` attribute. It is the index for a given node in a flattened tree. While nodes correspond 1:1 to`<tr>`s , _their values may be 1:N_ (e.g., same value, different groups ).

The bug fix in #623 requires that row meta correspond to a node and not row value. Circular references are created from the chain of previous siblings when a row meta is shared by two nodes.

Until row meta cache implements a strategy to better handle this, **this PR reverts the #623 bug fix for the interim.**

(See https://github.com/emberjs/ember.js/issues/16975#issuecomment-457781182 for a relevant discussion to a similar problem faced by the `#each` helper.)