### PR TITLE
adding support for context menu's

### DIFF
--- a/addon/components/ember-tr/component.js
+++ b/addon/components/ember-tr/component.js
@@ -72,6 +72,10 @@ export default class EmberTr extends Component {
   @type(optional(Action))
   onDoubleClick;
 
+  @argument
+  @type(optional(Action))
+  onContextMenu;
+
   @readOnly('api.rowValue')
   rowValue;
 
@@ -131,6 +135,10 @@ export default class EmberTr extends Component {
 
   doubleClick(event) {
     this.sendEventAction('onDoubleClick', event);
+  }
+
+  contextMenu(event) {
+    this.sendEventAction('onContextMenu', event);
   }
 
   sendEventAction(action, event) {


### PR DESCRIPTION
It's a common pattern to offer a right click menu for rows in a table - this extends ember table to add support for contextMenu's (right click on a row)