### PR TITLE
Fixes #656 Stop caching yarn dependencies to prevent build inconsistencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
   chrome: stable
 
 cache:
-  yarn: true
+  yarn: false
 
 global:
   # See https://git.io/vdao3 for details.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-auto-import": "^1.0.1",
     "ember-classy-page-object": "^0.5.0",
     "ember-cli": "~3.1.4",
-    "ember-cli-addon-docs": "^0.5.0",
+    "ember-cli-addon-docs": "^0.6.0",
     "ember-cli-addon-docs-esdoc": "^0.2.1",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-deploy": "^1.0.2",


### PR DESCRIPTION
This prevents Travis from caching to prevent build inconsistencies described in #656 

