### PR TITLE
ember-th renders only the block when one is passed.

### DIFF
--- a/addon-test-support/pages/-private/ember-table-header.js
+++ b/addon-test-support/pages/-private/ember-table-header.js
@@ -1,9 +1,24 @@
-import PageObject, { collection, hasClass, triggerable } from 'ember-classy-page-object';
+import PageObject, { alias, collection, hasClass, triggerable } from 'ember-classy-page-object';
 import { findElement } from 'ember-classy-page-object/extend';
 import { click } from 'ember-native-dom-helpers';
 
 import { mouseDown, mouseMove, mouseUp } from '../../helpers/mouse';
 import { getScale } from '../../helpers/element';
+
+export const SortPage = PageObject.extend({
+  indicator: {
+    scope: '[data-test-sort-indicator]',
+    isAscending: hasClass('is-ascending'),
+    isDescending: hasClass('is-descending'),
+  },
+  toggle: {
+    scope: '[data-test-sort-toggle]',
+  },
+});
+
+export const ResizePage = PageObject.extend({
+  scope: '[data-test-resize-handle]',
+});
 
 const Header = PageObject.extend({
   get text() {
@@ -105,11 +120,11 @@ const Header = PageObject.extend({
 
   isSortable: hasClass('is-sortable'),
 
-  sortIndicator: {
-    scope: '[data-test-sort-indicator]',
-    isAscending: hasClass('is-ascending'),
-    isDescending: hasClass('is-descending'),
-  },
+  sort: SortPage,
+  sortIndicator: alias('sort.indicator'),
+  sortToggle: alias('sort.toggle'),
+
+  resizeHandle: ResizePage,
 });
 
 export default {

--- a/addon/components/ember-th/component.js
+++ b/addon/components/ember-th/component.js
@@ -92,18 +92,6 @@ export default class EmberTh extends BaseTableCell {
   @readOnly('columnMeta.isReorderable')
   isReorderable;
 
-  @readOnly('columnMeta.sortIndex')
-  sortIndex;
-
-  @readOnly('columnMeta.isSorted')
-  isSorted;
-
-  @readOnly('columnMeta.isMultiSorted')
-  isMultiSorted;
-
-  @readOnly('columnMeta.isSortedAsc')
-  isSortedAsc;
-
   @attribute('colspan')
   @readOnly('columnMeta.columnSpan')
   columnSpan;

--- a/addon/components/ember-th/resize-handle/component.js
+++ b/addon/components/ember-th/resize-handle/component.js
@@ -1,0 +1,44 @@
+import Component from '@ember/component';
+import layout from './template';
+
+import { argument } from '@ember-decorators/argument';
+import { required } from '@ember-decorators/argument/validation';
+import { type } from '@ember-decorators/argument/type';
+import { tagName } from '@ember-decorators/component';
+import { readOnly } from '@ember-decorators/object/computed';
+
+/**
+  The table header cell resize handle component. This component renders an area to grab to resize a column.
+
+  ```hbs
+  <EmberTable as |t|>
+    <t.head @columns={{columns}} as |h|>
+      <h.row as |r|>
+        <r.cell as |columnValue columnMeta|>
+          {{columnValue.name}}
+
+          <EmberTh::ResizeHandle @columnMeta={{columnMeta}} />
+        </r.cell>
+      </h.row>
+    </t.head>
+
+    <t.body @rows={{rows}} />
+  </EmberTable>
+  ```
+*/
+
+@tagName('')
+export default class EmberThResizeHandle extends Component {
+  layout = layout;
+
+  /**
+    The API object passed in by the table header cell
+  */
+  @argument
+  @required
+  @type('object')
+  columnMeta;
+
+  @readOnly('columnMeta.isResizable')
+  isResizable;
+}

--- a/addon/components/ember-th/resize-handle/template.hbs
+++ b/addon/components/ember-th/resize-handle/template.hbs
@@ -1,0 +1,4 @@
+  {{#if isResizable}}
+    <div data-test-resize-handle class="et-header-resize-area">
+    </div>
+  {{/if}}

--- a/addon/components/ember-th/sort-indicator/component.js
+++ b/addon/components/ember-th/sort-indicator/component.js
@@ -1,0 +1,57 @@
+import Component from '@ember/component';
+import layout from './template';
+
+import { argument } from '@ember-decorators/argument';
+import { required } from '@ember-decorators/argument/validation';
+import { type } from '@ember-decorators/argument/type';
+import { tagName } from '@ember-decorators/component';
+import { readOnly } from '@ember-decorators/object/computed';
+
+/**
+  The table header cell sort indicator component. This component renders the state of the sort on the column (ascending/descending/none).
+
+  ```hbs
+  <EmberTable as |t|>
+    <t.head @columns={{columns}} as |h|>
+      <h.row as |r|>
+        <r.cell as |columnValue columnMeta|>
+          {{columnValue.name}}
+
+          <EmberTh::SortIndicator @columnMeta={{columnMeta}} />
+        </r.cell>
+      </h.row>
+    </t.head>
+
+    <t.body @rows={{rows}} />
+  </EmberTable>
+  ```
+  @yield {object} columnMeta - The meta object associated with this column
+*/
+
+@tagName('')
+export default class EmberThSortIndicator extends Component {
+  layout = layout;
+
+  /**
+    The API object passed in by the table header cell
+  */
+  @argument
+  @required
+  @type('object')
+  columnMeta;
+
+  @readOnly('columnMeta.isSortable')
+  isSortable;
+
+  @readOnly('columnMeta.isSorted')
+  isSorted;
+
+  @readOnly('columnMeta.isSortedAsc')
+  isSortedAsc;
+
+  @readOnly('columnMeta.isMultiSorted')
+  isMultiSorted;
+
+  @readOnly('columnMeta.sortIndex')
+  sortIndex;
+}

--- a/addon/components/ember-th/sort-indicator/template.hbs
+++ b/addon/components/ember-th/sort-indicator/template.hbs
@@ -1,0 +1,15 @@
+{{#if isSorted}}
+  <span data-test-sort-indicator class="et-sort-indicator {{if isSortedAsc 'is-ascending' 'is-descending'}}">
+    {{#if hasBlock}}
+      {{yield columnMeta}}
+    {{else}}
+      {{#if isMultiSorted}}
+        {{sortIndex}}
+      {{/if}}
+    {{/if}}
+  </span>
+{{/if}}
+
+{{#if isSortable}}
+  <button data-test-sort-toggle class="et-sort-toggle et-speech-only">Toggle Sort</button>
+{{/if}}

--- a/addon/components/ember-th/template.hbs
+++ b/addon/components/ember-th/template.hbs
@@ -2,21 +2,8 @@
   {{yield columnValue columnMeta}}
 {{else}}
   {{columnValue.name}}
-{{/if}}
 
-{{#if isSorted}}
-  <span data-test-sort-indicator class="et-sort-indicator {{if isSortedAsc 'is-ascending' 'is-descending'}}">
-    {{#if isMultiSorted}}
-      {{sortIndex}}
-    {{/if}}
-  </span>
-{{/if}}
+  {{ember-th/sort-indicator columnMeta=columnMeta}}
 
-{{#if isSortable}}
-  <button class="et-sort-toggle et-speech-only">Toggle Sort</button>
-{{/if}}
-
-{{#if isResizable}}
-  <div class="et-header-resize-area">
-  </div>
+  {{ember-th/resize-handle columnMeta=columnMeta}}
 {{/if}}

--- a/app/components/ember-th/resize-handle.js
+++ b/app/components/ember-th/resize-handle.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-table/components/ember-th/resize-handle/component';

--- a/app/components/ember-th/sort-indicator.js
+++ b/app/components/ember-th/sort-indicator.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-table/components/ember-th/sort-indicator/component';

--- a/tests/dummy/app/pods/docs/guides/main/table-customization/template.md
+++ b/tests/dummy/app/pods/docs/guides/main/table-customization/template.md
@@ -42,6 +42,45 @@ lookup paths:
   {{demo.snippet name='table-customization-custom-cell-template.js' label='component.js'}}
 {{/docs-demo}}
 
+If you want to customize a header cell but still want to include the elements to sort and
+to resize a column, use the `ember-th/sort-indicator` and `ember-th/resize-handle`
+components:
+
+{{#docs-demo as |demo|}}
+  {{#demo.example}}
+    {{! BEGIN-SNIPPET docs-example-sortings.hbs }}
+    <div class="demo-container">
+      <EmberTable as |t|>
+        <t.head
+          @columns={{columns}}
+          @sorts={{sorts}}
+
+          @onUpdateSorts={{action (mut sorts)}}
+
+          @widthConstraint='gte-container'
+          @fillMode='first-column'
+        
+          as |h|
+        >
+          <h.row as |r|>
+            <r.cell as |columnValue columnMeta|>
+              <EmberTh::SortIndicator @columnMeta={{columnMeta}} />
+              Custom Header {{columnValue.name}}
+              <EmberTh::Resizehandle @columnMeta={{columnMeta}} />
+            </r.cell>
+          </h.row>
+        </t.head>
+
+        <t.body @rows={{rows}} />
+      </EmberTable>
+    </div>
+    {{! END-SNIPPET }}
+  {{/demo.example}}
+
+  {{demo.snippet name='docs-example-sortings.hbs'}}
+  {{demo.snippet label='component.js' name='docs-example-sortings.js'}}
+{{/docs-demo}}
+
 Oftentimes you'll want to provide custom components for use in table headers,
 cells, and footers. It's also pretty common to want different types of
 components used in each column. Ember Table solves this by passing the

--- a/tests/integration/components/headers/ember-th-test.js
+++ b/tests/integration/components/headers/ember-th-test.js
@@ -1,0 +1,60 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+import { generateTableValues } from '../../../helpers/generate-table';
+import TablePage from 'ember-table/test-support/pages/ember-table';
+
+let table = new TablePage();
+
+moduleForComponent('ember-th', '[Unit] ember-th', { integration: true });
+
+test('A header cell accepts a block', async function(assert) {
+  assert.expect(4);
+
+  let columns = [
+    {
+      name: 'Name',
+      valuePath: 'name',
+      isAscending: false,
+      isSortable: true,
+    },
+    {
+      name: 'Age',
+      valuePath: 'age',
+    },
+  ];
+
+  let rows = [{ name: 'Zoe', age: 34 }, { name: 'Alex', age: 43 }, { name: 'Liz', age: 25 }];
+  generateTableValues(this, { columns, rows });
+
+  let firstHeader = table.headers.objectAt(0);
+
+  await this.render(hbs`
+  {{#ember-table data-test-ember-table=true as |t|}}
+    {{#ember-thead
+      api=t
+      columns=columns
+      sorts=sorts
+
+      onUpdateSorts="onUpdateSorts"
+
+      as |h|}}
+      {{#ember-tr api=h as |r|}}
+        {{#ember-th api=r as |column|}}
+          <div data-test-block>
+            {{column.name}}
+          </div>
+        {{/ember-th}}
+      {{/ember-tr}}
+    {{/ember-thead}}
+
+    {{ember-tbody api=t rows=rows}}
+  {{/ember-table}}
+  `);
+  await firstHeader.click();
+
+  assert.equal(this.$('[data-test-block]').length, 2, 'Header cells render passed block');
+  assert.ok(!firstHeader.sortIndicator.isPresent, 'No sort indicator is rendered');
+  assert.notOk(firstHeader.sortToggle.isPresent, 'No sort toggle is rendered');
+  assert.notOk(firstHeader.resizeHandle.isPresent, 'No resize area is rendered');
+});

--- a/tests/integration/components/headers/resize-handle-test.js
+++ b/tests/integration/components/headers/resize-handle-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+import { ResizePage } from 'ember-table/test-support/pages/-private/ember-table-header';
+
+import { componentModule } from '../../../helpers/module';
+
+let resize = new ResizePage();
+
+module('Integration | Component | ember-th/resize-handle', function() {
+  componentModule('basic', function() {
+    test('it renders', async function(assert) {
+      this.set('columnMeta', {
+        isResizable: true,
+      });
+
+      await this.render(hbs`{{ember-th/resize-handle columnMeta=columnMeta}}`);
+
+      assert.ok(resize.isPresent);
+
+      this.set('columnMeta.isResizable', false);
+      assert.notOk(resize.isPresent);
+    });
+  });
+});

--- a/tests/integration/components/headers/sort-indicator-test.js
+++ b/tests/integration/components/headers/sort-indicator-test.js
@@ -1,0 +1,94 @@
+import { module, test } from 'qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+import { SortPage } from 'ember-table/test-support/pages/-private/ember-table-header';
+
+import { componentModule } from '../../../helpers/module';
+
+let sort = new SortPage();
+
+module('Integration | Component | ember-th/sort-indicator', function() {
+  componentModule('basic', function() {
+    test('it renders', async function(assert) {
+      this.set('columnMeta', {
+        isSorted: true,
+      });
+
+      await this.render(hbs`{{ember-th/sort-indicator columnMeta=columnMeta}}`);
+
+      assert.ok(sort.indicator.isPresent);
+
+      // Template block usage:
+      await this.render(hbs`
+      {{#ember-th/sort-indicator columnMeta=columnMeta}}
+        template block text
+      {{/ember-th/sort-indicator}}
+    `);
+
+      assert.equal(sort.indicator.text, 'template block text');
+    });
+
+    test('it is hidden when not sorted', async function(assert) {
+      this.set('columnMeta', {
+        isSorted: false,
+      });
+
+      await this.render(hbs`{{ember-th/sort-indicator columnMeta=columnMeta}}`);
+
+      assert.notOk(sort.indicator.isPresent);
+
+      // Template block usage:
+      await this.render(hbs`
+      {{#ember-th/sort-indicator columnMeta=columnMeta}}
+        template block text
+      {{/ember-th/sort-indicator}}
+    `);
+
+      assert.notOk(sort.indicator.isPresent);
+    });
+
+    test('it displays the sort order', async function(assert) {
+      this.set('columnMeta', {
+        isSorted: true,
+        isSortedAsc: true,
+      });
+
+      await this.render(hbs`{{ember-th/sort-indicator columnMeta=columnMeta}}`);
+      // asc sort
+      assert.ok(sort.indicator.isAscending);
+      assert.notOk(sort.indicator.isDescending);
+
+      // desc sort
+      this.set('columnMeta.isSortedAsc', false);
+      assert.notOk(sort.indicator.isAscending);
+      assert.ok(sort.indicator.isDescending);
+    });
+
+    test('it displays the sort index when using multiple sorts', async function(assert) {
+      this.set('columnMeta', {
+        isSorted: true,
+        isMultiSorted: true,
+        sortIndex: 2,
+      });
+
+      await this.render(hbs`{{ember-th/sort-indicator columnMeta=columnMeta}}`);
+
+      assert.equal(sort.indicator.text, '2');
+
+      // desc sort
+      this.set('columnMeta.isMultiSorted', false);
+      assert.equal(sort.indicator.text, '');
+    });
+
+    test('the sort option supports accessibility', async function(assert) {
+      this.set('columnMeta', {
+        isSortable: true,
+      });
+
+      await this.render(hbs`{{ember-th/sort-indicator columnMeta=columnMeta}}`);
+
+      assert.ok(sort.toggle.isPresent);
+      assert.equal(sort.toggle.text, 'Toggle Sort');
+    });
+  });
+});


### PR DESCRIPTION
It will allow to totally customize how it looks.

This will require templates to be updated if they were relying on the old behavior.
I'd also like to provide an easy way to reuse the existing html/logic to make that transition easier.