### PR TITLE
[FEATURE] Use `sortEmptyLast` on the header to have empty values at the end of a sort result.

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -378,17 +378,18 @@ class CollapseTreeNode extends EmberObject {
     return !get(this, 'value.children').some(child => isArray(get(child, 'children')));
   }
 
-  @computed('value.children.[]', 'tree.{sorts.[],sortFunction,compareFunction}')
+  @computed('value.children.[]', 'tree.{sorts.[],sortFunction,compareFunction,sortEmptyLast}')
   get sortedChildren() {
     let valueChildren = get(this, 'value.children');
 
     let sorts = get(this, 'tree.sorts');
     let sortFunction = get(this, 'tree.sortFunction');
     let compareFunction = get(this, 'tree.compareFunction');
+    let sortEmptyLast = get(this, 'tree.sortEmptyLast');
 
     if (sortFunction && compareFunction && sorts && get(sorts, 'length') > 0) {
       valueChildren = mergeSort(valueChildren, (itemA, itemB) => {
-        return sortFunction(itemA, itemB, sorts, compareFunction);
+        return sortFunction(itemA, itemB, sorts, compareFunction, sortEmptyLast);
       });
     }
 

--- a/addon/-private/utils/sort.js
+++ b/addon/-private/utils/sort.js
@@ -54,14 +54,16 @@ export function mergeSort(array, comparator = compare) {
   return merge(leftArray, rightArray, comparator);
 }
 
-export function sortMultiple(itemA, itemB, sorts, compare) {
+export function sortMultiple(itemA, itemB, sorts, compare, sortEmptyLast) {
   let compareValue;
 
   for (let { valuePath, isAscending } of sorts) {
     let valueA = get(itemA, valuePath);
     let valueB = get(itemB, valuePath);
 
-    compareValue = isAscending ? compare(valueA, valueB) : -compare(valueA, valueB);
+    compareValue = isAscending
+      ? compare(valueA, valueB, sortEmptyLast)
+      : -compare(valueA, valueB, !sortEmptyLast);
 
     if (compareValue !== 0) {
       break;
@@ -75,30 +77,41 @@ function isExactlyNaN(value) {
   return typeof value === 'number' && isNaN(value);
 }
 
-function isEmpty(value) {
-  return isNone(value) || isExactlyNaN(value);
+function isEmptyString(value) {
+  return typeof value === 'string' && value === '';
 }
 
-function orderEmptyValues(itemA, itemB) {
+function isEmpty(value) {
+  return isNone(value) || isExactlyNaN(value) || isEmptyString(value);
+}
+
+function orderEmptyValues(itemA, itemB, sortEmptyLast) {
   let aIsEmpty = isEmpty(itemA);
   let bIsEmpty = isEmpty(itemB);
+  let less = -1;
+  let more = 1;
+
+  if (sortEmptyLast) {
+    less = 1;
+    more = -1;
+  }
 
   if (aIsEmpty && !bIsEmpty) {
-    return -1;
+    return less;
   } else if (bIsEmpty && !aIsEmpty) {
-    return 1;
+    return more;
   } else if (isNone(itemA) && isExactlyNaN(itemB)) {
-    return -1;
+    return less;
   } else if (isExactlyNaN(itemA) && isNone(itemB)) {
-    return 1;
+    return more;
   } else {
     return 0;
   }
 }
 
-export function compareValues(itemA, itemB) {
+export function compareValues(itemA, itemB, sortEmptyLast) {
   if (isEmpty(itemA) || isEmpty(itemB)) {
-    return orderEmptyValues(itemA, itemB);
+    return orderEmptyValues(itemA, itemB, sortEmptyLast);
   }
 
   return compare(itemA, itemB);

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -242,6 +242,7 @@ export default class EmberTBody extends Component {
     this.addObserver('unwrappedApi.sorts', this._updateCollapseTree);
     this.addObserver('unwrappedApi.sortFunction', this._updateCollapseTree);
     this.addObserver('unwrappedApi.compareFunction', this._updateCollapseTree);
+    this.addObserver('unwrappedApi.sortEmptyLast', this._updateCollapseTree);
 
     this.addObserver('enableCollapse', this._updateCollapseTree);
     this.addObserver('enableTree', this._updateCollapseTree);
@@ -259,6 +260,7 @@ export default class EmberTBody extends Component {
     this.collapseTree.set('sorts', this.get('unwrappedApi.sorts'));
     this.collapseTree.set('sortFunction', this.get('unwrappedApi.sortFunction'));
     this.collapseTree.set('compareFunction', this.get('unwrappedApi.compareFunction'));
+    this.collapseTree.set('sortEmptyLast', this.get('unwrappedApi.sortEmptyLast'));
 
     this.collapseTree.set('enableCollapse', this.get('enableCollapse'));
     this.collapseTree.set('enableTree', this.get('enableTree'));

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -79,6 +79,13 @@ export default class EmberTHead extends Component {
   compareFunction = compareValues;
 
   /**
+    Flag that allows to sort empty values after non empty ones
+  */
+  @argument({ defaultIfUndefined: false })
+  @type(optional('boolean'))
+  sortEmptyLast = false;
+
+  /**
     Flag that toggles reordering in the table
   */
   @argument({ defaultIfUndefined: true })
@@ -205,6 +212,7 @@ export default class EmberTHead extends Component {
     this.set('unwrappedApi.sorts', this.get('sorts'));
     this.set('unwrappedApi.sortFunction', this.get('sortFunction'));
     this.set('unwrappedApi.compareFunction', this.get('compareFunction'));
+    this.set('unwrappedApi.sortEmptyLast', this.get('sortEmptyLast'));
   }
 
   _updateColumnTree() {

--- a/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/component.js
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/component.js
@@ -1,0 +1,68 @@
+import Component from '@ember/component';
+import { computed } from '@ember-decorators/object';
+import faker from 'faker';
+
+function getRandomInt(max, min) {
+  return faker.random.number({ min, max });
+}
+
+export default class EmptyValues extends Component {
+  // BEGIN-SNIPPET docs-example-sorting-empty-values.js
+  @computed
+  get columns() {
+    return [
+      { name: 'Product', valuePath: 'name' },
+      { name: 'Material', valuePath: 'material' },
+      { name: 'Price', valuePath: 'price' },
+      { name: 'Sold', valuePath: 'sold' },
+      { name: 'Unsold', valuePath: 'unsold' },
+      { name: 'Total Revenue', valuePath: 'totalRevenue' },
+    ];
+  }
+
+  sortEmptyLast = true;
+  // END-SNIPPET
+
+  @computed
+  get rows() {
+    let rows = [];
+
+    for (let k = 0; k < 10; k++) {
+      let sold = getRandomInt(100, 10);
+      let unsold = getRandomInt(100, 10);
+      let price = getRandomInt(50, 10);
+      let totalRevenue = price * sold;
+
+      let product = {
+        name: faker.commerce.productName(k),
+        material: faker.commerce.productMaterial(),
+        price: `$${price}`,
+        sold,
+        unsold,
+        totalRevenue: `$${totalRevenue}`,
+      };
+
+      rows.push(product);
+    }
+
+    for (let k = 0; k < 5; k++) {
+      let sold = getRandomInt(100, 10);
+      let unsold = getRandomInt(100, 10);
+      let price = getRandomInt(50, 10);
+      let totalRevenue = price * sold;
+
+      let product = {
+        name: faker.commerce.productName(k),
+        material: '',
+        price: `$${price}`,
+        sold,
+        unsold,
+        totalRevenue: `$${totalRevenue}`,
+      };
+
+      rows.push(product);
+    }
+
+    return rows;
+  }
+}

--- a/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/template.hbs
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/template.hbs
@@ -1,0 +1,25 @@
+{{#docs-demo as |demo|}}
+  {{#demo.example name='sorting-empty-values'}}
+    {{! BEGIN-SNIPPET docs-example-sorting-empty-values.hbs }}
+    <div class="demo-container">
+      <EmberTable as |t|>
+        <t.head
+          @columns={{columns}}
+          @sorts={{sorts}}
+          @sortEmptyLast={{sortEmptyLast}}
+
+          @onUpdateSorts={{action (mut sorts)}}
+
+          @widthConstraint='gte-container'
+          @fillMode='first-column'
+        />
+
+        <t.body @rows={{rows}} />
+      </EmberTable>
+    </div>
+    {{! END-SNIPPET }}
+  {{/demo.example}}
+
+  {{demo.snippet name='docs-example-sorting-empty-values.hbs'}}
+  {{demo.snippet label='component.js' name='docs-example-sorting-empty-values.js'}}
+{{/docs-demo}}

--- a/tests/dummy/app/pods/docs/guides/header/sorting/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/template.md
@@ -83,3 +83,9 @@ let columns = [
   }
 ];
 ```
+
+## Sorting empty values
+
+Empty values can be treated differently depending on the needs by using the `sortEmptyLast` option.
+
+{{docs/guides/header/sorting/empty-values}}

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -14,6 +14,7 @@ const fullTable = hbs`
         columns=columns
         containerWidthAdjustment=containerWidthAdjustment
         sorts=sorts
+        sortEmptyLast=sortEmptyLast
         resizeMode=resizeMode
         fillMode=fillMode
         enableResize=enableResize

--- a/tests/integration/components/sort-test.js
+++ b/tests/integration/components/sort-test.js
@@ -76,6 +76,33 @@ module('Integration | sort', function() {
       assert.ok(checkRowOrder(table, ['Alex 43', 'Zoe 34', 'Liz 25']));
     });
 
+    test('can sort empty values last', async function(assert) {
+      let columns = [
+        {
+          name: 'Name',
+          valuePath: 'name',
+        },
+      ];
+
+      let rows = [{ name: 'Zoe' }, { name: '' }, { name: 'Alex' }];
+
+      await generateTable(this, { columns, rows, sortEmptyLast: true });
+
+      let firstHeader = table.headers.objectAt(0);
+
+      assert.ok(firstHeader.isSortable, 'sort class applied correctly');
+      assert.ok(checkRowOrder(table, ['Zoe', '', 'Alex']), 'initial render is ok');
+
+      await firstHeader.click();
+      assert.ok(checkRowOrder(table, ['Zoe', 'Alex', '']), 'descending sort works');
+
+      await firstHeader.click();
+      assert.ok(checkRowOrder(table, ['Alex', 'Zoe', '']), 'ascending sort works');
+
+      await firstHeader.click();
+      assert.ok(checkRowOrder(table, ['Zoe', '', 'Alex']), '3rd state / initial state works');
+    });
+
     test('sends the onUpdateSorts action', async function(assert) {
       this.on('onUpdateSorts', sorts => {
         assert.equal(sorts.length, 1);


### PR DESCRIPTION
```
<EmberThead @sortEmptyLast=true />
```

This is the default implementation (`sortEmptyLast=false`):

![Screen Shot 2019-03-19 at 1 56 49 PM](https://user-images.githubusercontent.com/743977/55264679-71a51f00-5232-11e9-930e-6f1a15d135ea.png)

with `sortEmptyLast=true`, the sort returns the meaningful values first

 This will allow to choose how to sort values like that:
![Screen Shot 2019-03-19 at 1 56 41 PM](https://user-images.githubusercontent.com/743977/55264674-6d790180-5232-11e9-934c-56f778b9bb40.png)


