### PR TITLE
[BUGFIX] Ensure dynamicAlias works on latest Ember

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - '8'
 
 sudo: required
 dist: trusty
@@ -34,7 +34,6 @@ matrix:
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-release
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/addon/components/-private/row-wrapper.js
+++ b/addon/components/-private/row-wrapper.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import hbs from 'htmlbars-inline-precompile';
 
-import EmberObject, { get, set } from '@ember/object';
+import EmberObject, { get, set, computed as emberComputed } from '@ember/object';
 import { A as emberA } from '@ember/array';
 
 import { tagName } from '@ember-decorators/component';
@@ -12,12 +12,10 @@ import { computed } from '@ember-decorators/object';
 import { objectAt } from '../../-private/utils/array';
 import { dynamicAlias } from '../../-private/utils/computed';
 
-class CellWrapper extends EmberObject {
-  @dynamicAlias('rowValue', 'columnValue.valuePath')
-  cellValue;
+const CellWrapper = EmberObject.extend({
+  cellValue: dynamicAlias('rowValue', 'columnValue.valuePath'),
 
-  @computed('rowMeta', 'columnValue')
-  get cellMeta() {
+  cellMeta: emberComputed('rowMeta', 'columnValue', function() {
     let rowMeta = get(this, 'rowMeta');
     let columnValue = get(this, 'columnValue');
 
@@ -26,8 +24,8 @@ class CellWrapper extends EmberObject {
     }
 
     return rowMeta._cellMetaCache.get(columnValue);
-  }
-}
+  }),
+});
 
 const layout = hbs`{{yield api}}`;
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -116,6 +116,7 @@ module.exports = function() {
             devDependencies: {
               'ember-source': null,
               'ember-angle-bracket-invocation-polyfill': null,
+              'ember-cli-addon-docs': null,
             },
           },
         },
@@ -124,6 +125,7 @@ module.exports = function() {
           npm: {
             devDependencies: {
               'ember-source': '~2.12.0',
+              'ember-cli-addon-docs': null,
             },
           },
         },
@@ -132,6 +134,7 @@ module.exports = function() {
           npm: {
             devDependencies: {
               'ember-source': '~2.16.0',
+              'ember-cli-addon-docs': null,
             },
           },
         },
@@ -140,6 +143,7 @@ module.exports = function() {
           npm: {
             devDependencies: {
               'ember-source': '~2.18.0',
+              'ember-cli-addon-docs': null,
             },
           },
         },
@@ -148,6 +152,7 @@ module.exports = function() {
           npm: {
             devDependencies: {
               'ember-source': urls[0],
+              'ember-cli-addon-docs': null,
             },
           },
         },
@@ -156,6 +161,7 @@ module.exports = function() {
           npm: {
             devDependencies: {
               'ember-source': urls[1],
+              'ember-cli-addon-docs': null,
             },
           },
         },
@@ -164,6 +170,7 @@ module.exports = function() {
           npm: {
             devDependencies: {
               'ember-source': urls[2],
+              'ember-cli-addon-docs': null,
             },
           },
         },

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,16 +1,14 @@
-/* globals define */
+/* globals define, require */
 import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 import EmberRouter from '@ember/routing/router';
 
-import { lte } from 'ember-compatibility-helpers';
-
 // Including ember-cli-addon-docs breaks certain versions of Ember when testing
 // but they also break if we remove it. This defines a stub router which should
 // prevent breakage.
-if (lte('2.5.0')) {
+if (!require.entries['ember-cli-addon-docs/router']) {
   define('ember-cli-addon-docs/router', () => {
     return EmberRouter;
   });


### PR DESCRIPTION
There were some subtle changes on the latest Ember that made aliases
and properties that include . in their name to stop working. Instead
of creating dynamic aliases, we now just access the properties directly
on _context, which should fix the issue.