### PR TITLE
Convert row-wrapper and simple-checkbox to classic classes

### DIFF
--- a/addon/components/-private/simple-checkbox.js
+++ b/addon/components/-private/simple-checkbox.js
@@ -1,52 +1,30 @@
 import Component from '@ember/component';
-import { tagName, attribute } from '@ember-decorators/component';
-import { argument } from '@ember-decorators/argument';
-import { type, optional } from '@ember-decorators/argument/type';
-import { Action } from '@ember-decorators/argument/types';
+import defaultTo from '../../-private/utils/default-to';
 
-@tagName('input')
-export default class SimpleCheckbox extends Component {
-  value = null;
+export default Component.extend({
+  tagName: 'input',
 
-  @attribute
-  type = 'checkbox';
+  attributeBindings: [
+    'ariaLabel:aria-label',
+    'checked',
+    'disabled',
+    'indeterminate',
+    'type',
+    'value',
+  ],
 
-  @argument({ defaultIfUndefined: true })
-  @type('boolean')
-  @attribute
-  checked = false;
-
-  @argument({ defaultIfUndefined: true })
-  @type('boolean')
-  @attribute
-  disabled = false;
-
-  @argument({ defaultIfUndefined: true })
-  @type('boolean')
-  @attribute
-  indeterminate = false;
-
-  @argument
-  @type('any')
-  @attribute
-  value = null;
-
-  @argument
-  @type(optional(Action))
-  onClick = null;
-
-  @argument
-  @type(optional(Action))
-  onChange = null;
-
-  @argument
-  @type('string')
-  @attribute('aria-label')
-  ariaLabel;
+  ariaLabel: undefined,
+  checked: defaultTo(false),
+  disabled: defaultTo(false),
+  indeterminate: defaultTo(false),
+  onChange: null,
+  onClick: null,
+  type: 'checkbox',
+  value: null,
 
   click(event) {
     this.sendAction('onClick', event);
-  }
+  },
 
   change(event) {
     let checked = this.element.checked;
@@ -59,5 +37,5 @@ export default class SimpleCheckbox extends Component {
     this.element.indeterminate = this.get('indeterminate');
 
     this.sendAction('onChange', checked, { value, indeterminate }, event);
-  }
-}
+  },
+});


### PR DESCRIPTION
There is one issue, where we are setting properties in a computed, which did not seem to be flagged by ESLint before, but is flagged when we use a classic computed. I added `// eslint-disable-next-line ember/no-side-effects, ember-best-practices/no-side-effect-cp` to get around the issue for now.

@pzuraq do we need to do something else to fix this or is disabling ESLint there okay?