### PR TITLE
Change pinned dependency specifier for vertical-collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@ember-decorators/babel-transforms": "^0.1.1",
-    "@html-next/vertical-collection": "html-next/vertical-collection#ca8cab8a3204f99cca1cf7661e4170ac41dc3a07",
+    "@html-next/vertical-collection": "https://github.com/html-next/vertical-collection.git#ca8cab8a3204f99cca1cf7661e4170ac41dc3a07",
     "broccoli-string-replace": "^0.1.2",
     "css-element-queries": "^0.4.0",
     "ember-assign-polyfill": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,9 +835,9 @@
   dependencies:
     "@glimmer/util" "^0.30.5"
 
-"@html-next/vertical-collection@html-next/vertical-collection#ca8cab8a3204f99cca1cf7661e4170ac41dc3a07":
+"@html-next/vertical-collection@https://github.com/html-next/vertical-collection.git#ca8cab8a3204f99cca1cf7661e4170ac41dc3a07":
   version "1.0.0-beta.13"
-  resolved "https://codeload.github.com/html-next/vertical-collection/tar.gz/ca8cab8a3204f99cca1cf7661e4170ac41dc3a07"
+  resolved "https://github.com/html-next/vertical-collection.git#ca8cab8a3204f99cca1cf7661e4170ac41dc3a07"
   dependencies:
     babel-plugin-transform-es2015-block-scoping "^6.24.1"
     babel6-plugin-strip-class-callcheck "^6.0.0"


### PR DESCRIPTION
Change from `user/repo#sha` to `https://github.com/user/repo.git#sha` form.
Yarn has a bug related to installing changed SHA versions when they are pinned in `user/repo` form,
that could cause consumers of this addon (or developers of this addon) to fail to get updated
dependency code via `yarn install`, see: https://github.com/yarnpkg/yarn/issues/4722#issuecomment-487140809

cc @cyril-sf 