### PR TITLE
Ensure that table column widths are recomputed when columns change

### DIFF
--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -227,6 +227,9 @@ export default Component.extend({
   },
 
   _onColumnsChange() {
+    if (this.get('columns.length') === 0) {
+      return;
+    }
     this._updateColumnTree();
     scheduleOnce('actions', this, this.fillupHandler);
   },

--- a/tests/integration/components/headers/ember-thead-test.js
+++ b/tests/integration/components/headers/ember-thead-test.js
@@ -124,6 +124,17 @@ async function testColumnAddition(assert, table) {
   assert.equal(table.containerWidth, originalContainerWidth, 'table container width is unchanged');
 }
 
+// In Ember-1.12, the `this` context has a `context` property itself that is used to `get` or `set`.
+// This function provides Ember-1.12 compatibility for `this.get`
+function compatGet(context, propName) {
+  return context.get ? context.get(propName) : context.context.get(propName);
+}
+
+// This function provides Ember-1.12 compatibility for `this.set`
+function compatSet(context, propName, value) {
+  return context.set ? context.set(propName, value) : context.context.set(propName, value);
+}
+
 moduleForComponent('ember-thead', '[Unit] ember-thead', { integration: true });
 
 test('table resizes when columns are removed', async function(assert) {
@@ -131,7 +142,7 @@ test('table resizes when columns are removed', async function(assert) {
   this.set('rows', data.rows);
   this.set('columns', data.columns);
   this.on('removeColumn', function() {
-    this.set('columns', this.get('columns').slice(0, -1));
+    compatSet(this, 'columns', compatGet(this, 'columns').slice(0, -1));
   });
 
   await renderTable(this);
@@ -143,7 +154,7 @@ test('table resizes when columns are removed via mutation', async function(asser
   this.set('rows', data.rows);
   this.set('columns', A(data.columns));
   this.on('removeColumn', function() {
-    this.get('columns').popObject();
+    compatGet(this, 'columns').popObject();
   });
 
   await renderTable(this);
@@ -155,7 +166,7 @@ test('table resizes when columns are added', async function(assert) {
   this.set('rows', data.rows);
   this.set('columns', data.columns);
   this.on('addColumn', function() {
-    this.set('columns', [...data.columns, data.newColumn]);
+    compatSet(this, 'columns', [...data.columns, data.newColumn]);
   });
 
   await renderTable(this);
@@ -167,7 +178,7 @@ test('table resizes when columns are added via mutation', async function(assert)
   this.set('rows', data.rows);
   this.set('columns', A(data.columns));
   this.on('addColumn', function() {
-    this.get('columns').pushObject(data.newColumn);
+    compatGet(this, 'columns').pushObject(data.newColumn);
   });
 
   await renderTable(this);

--- a/tests/integration/components/headers/ember-thead-test.js
+++ b/tests/integration/components/headers/ember-thead-test.js
@@ -134,7 +134,7 @@ test('table resizes when columns are removed', async function(assert) {
   });
 
   await renderTable(this);
-  await testColumnRemovals(assert, new TablePage(), this);
+  await testColumnRemovals(assert, new TablePage());
 });
 
 test('table resizes when columns are removed via mutation', async function(assert) {
@@ -146,7 +146,7 @@ test('table resizes when columns are removed via mutation', async function(asser
   });
 
   await renderTable(this);
-  await testColumnRemovals(assert, new TablePage(), this);
+  await testColumnRemovals(assert, new TablePage());
 });
 
 test('table resizes when columns are added', async function(assert) {
@@ -158,7 +158,7 @@ test('table resizes when columns are added', async function(assert) {
   });
 
   await renderTable(this);
-  await testColumnAddition(assert, new TablePage(), this);
+  await testColumnAddition(assert, new TablePage());
 });
 
 test('table resizes when columns are added via mutation', async function(assert) {
@@ -170,5 +170,5 @@ test('table resizes when columns are added via mutation', async function(assert)
   });
 
   await renderTable(this);
-  await testColumnAddition(assert, new TablePage(), this);
+  await testColumnAddition(assert, new TablePage());
 });

--- a/tests/integration/components/headers/ember-thead-test.js
+++ b/tests/integration/components/headers/ember-thead-test.js
@@ -37,21 +37,22 @@ async function renderTable(context) {
     <button id="add-column" {{action 'addColumn'}}>Add Column</button>
     <button id="remove-column" {{action 'removeColumn'}}>Remove Column</button>
     {{#ember-table data-test-ember-table=true as |t|}}
-      {{#t.head
+      {{#ember-thead
+        api=t
         widthConstraint='eq-container'
         columns=columns as |h|}}
-        {{#h.row as |r|}}
-        {{r.cell}}
-        {{/h.row}}
-      {{/t.head}}
+        {{#ember-tr api=h as |r|}}
+          {{ember-th api=r}}
+        {{/ember-tr}}
+      {{/ember-thead}}
 
-      {{#t.body rows=rows as |b|}}
-        {{#b.row as |r|}}
-        {{#r.cell as |cellValue|}}
+      {{#ember-tbody api=t rows=rows as |b|}}
+        {{#ember-tr api=b as |r|}}
+          {{#ember-td api=r as |cellValue|}}
             {{cellValue}}
-        {{/r.cell}}
-        {{/b.row}}
-      {{/t.body}}
+          {{/ember-td}}
+        {{/ember-tr}}
+      {{/ember-tbody}}
     {{/ember-table}}
     `);
 

--- a/tests/integration/components/headers/ember-thead-test.js
+++ b/tests/integration/components/headers/ember-thead-test.js
@@ -5,6 +5,11 @@ import TablePage from 'ember-table/test-support/pages/ember-table';
 import { A } from '@ember/array';
 import RSVP from 'rsvp';
 
+// This is a "waiter"-style helper to use to ensure that
+// the interior of the ember-table has finished all of its
+// layout-related logic has finished. If we don't use this to
+// wait after `render`, the column widths will not have been
+// set yet and the tests in this module are moot.
 async function rafFinished() {
   return new RSVP.Promise(resolve => {
     requestAnimationFrame(() => requestAnimationFrame(resolve));

--- a/tests/integration/components/headers/ember-thead-test.js
+++ b/tests/integration/components/headers/ember-thead-test.js
@@ -1,0 +1,168 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import TablePage from 'ember-table/test-support/pages/ember-table';
+import { A } from '@ember/array';
+
+function tableData() {
+  return {
+    rows: [
+      { A: 'A', B: 'B', C: 'C', D: 'D', E: 'E' },
+      { A: 'A', B: 'B', C: 'C', D: 'D', E: 'E' },
+      { A: 'A', B: 'B', C: 'C', D: 'D', E: 'E' },
+    ],
+    columns: [
+      { name: 'A', valuePath: 'A', width: 180 },
+      { name: 'B', valuePath: 'B', width: 180 },
+      { name: 'C', valuePath: 'C', width: 180 },
+      { name: 'D', valuePath: 'D', width: 180 },
+    ],
+    newColumn: { name: 'E', valuePath: 'E', width: 180 },
+  };
+}
+
+function sumHeaderWidths(table) {
+  return table.headers.map(h => h.width).reduce((sum, w) => sum + w, 0);
+}
+
+async function renderTable() {
+  await render(hbs`
+    <button id="add-column" {{action 'addColumn'}}>Add Column</button>
+    <button id="remove-column" {{action 'removeColumn'}}>Remove Column</button>
+    {{#ember-table data-test-ember-table=true as |t|}}
+      {{#t.head
+        widthConstraint='eq-container'
+        columns=columns as |h|}}
+        {{#h.row as |r|}}
+        {{r.cell}}
+        {{/h.row}}
+      {{/t.head}}
+
+      {{#t.body rows=rows as |b|}}
+        {{#b.row as |r|}}
+        {{#r.cell as |cellValue|}}
+            {{cellValue}}
+        {{/r.cell}}
+        {{/b.row}}
+      {{/t.body}}
+    {{/ember-table}}
+    `);
+}
+
+async function testColumnRemovals(assert, table) {
+  let originalWidth = table.width;
+  let originalContainerWidth = table.containerWidth;
+
+  let currentColumnCount = table.headers.length;
+  assert.equal(currentColumnCount, 4, 'precond - 4 columns');
+  assert.equal(sumHeaderWidths(table), originalWidth, 'precond - headers sum to table width');
+  assert.equal(
+    originalWidth,
+    originalContainerWidth,
+    'precond - table is as wide as its container'
+  );
+
+  while (currentColumnCount > 1) {
+    await click('button#remove-column');
+    assert.equal(
+      table.headers.length,
+      currentColumnCount - 1,
+      `column count changes from ${currentColumnCount} -> ${currentColumnCount - 1}`
+    );
+    currentColumnCount -= 1;
+
+    assert.equal(
+      table.width,
+      originalWidth,
+      `table width is same after removal of column #${currentColumnCount}.`
+    );
+    assert.equal(
+      table.containerWidth,
+      originalContainerWidth,
+      `new table container is same size as original container after removal of column #${currentColumnCount}.`
+    );
+    assert.equal(
+      sumHeaderWidths(table),
+      originalWidth,
+      `headers sum to table width after removal of column #${currentColumnCount}`
+    );
+    assert.equal(
+      table.width,
+      table.containerWidth,
+      `new table width is as wide as its container after removal of column #${currentColumnCount}.`
+    );
+  }
+}
+
+async function testColumnAddition(assert, table) {
+  let originalWidth = table.width;
+  let originalContainerWidth = table.containerWidth;
+
+  let currentColumnCount = table.headers.length;
+  assert.equal(currentColumnCount, 4, 'precond - 4 columns');
+  assert.equal(sumHeaderWidths(table), originalWidth, 'precond - headers sum to table width');
+  assert.equal(
+    originalWidth,
+    originalContainerWidth,
+    'precond - table is as wide as its container'
+  );
+
+  await click('#add-column');
+  assert.equal(table.headers.length, 5, 'column is added');
+  assert.equal(sumHeaderWidths(table), originalWidth, 'headers sum to table width after adding');
+  assert.equal(table.width, originalWidth, 'table width is unchanged');
+  assert.equal(table.containerWidth, originalContainerWidth, 'table container width is unchanged');
+}
+
+module('ember-thead', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('table resizes when columns are removed', async function(assert) {
+    let data = tableData();
+    this.set('rows', data.rows);
+    this.set('columns', data.columns);
+    this.set('removeColumn', function() {
+      this.set('columns', this.get('columns').slice(0, -1));
+    });
+
+    await renderTable();
+    await testColumnRemovals(assert, new TablePage());
+  });
+
+  test('table resizes when columns are removed via mutation', async function(assert) {
+    let data = tableData();
+    this.set('rows', data.rows);
+    this.set('columns', A(data.columns));
+    this.set('removeColumn', function() {
+      this.get('columns').popObject();
+    });
+
+    await renderTable();
+    await testColumnRemovals(assert, new TablePage());
+  });
+
+  test('table resizes when columns are added', async function(assert) {
+    let data = tableData();
+    this.set('rows', data.rows);
+    this.set('columns', data.columns);
+    this.set('addColumn', function() {
+      this.set('columns', [...data.columns, data.newColumn]);
+    });
+
+    await renderTable();
+    await testColumnAddition(assert, new TablePage());
+  });
+
+  test('table resizes when columns are added via mutation', async function(assert) {
+    let data = tableData();
+    this.set('rows', data.rows);
+    this.set('columns', A(data.columns));
+    this.set('addColumn', function() {
+      this.get('columns').pushObject(data.newColumn);
+    });
+
+    await renderTable();
+    await testColumnAddition(assert, new TablePage());
+  });
+});


### PR DESCRIPTION
This fixes an issue where removing a column can leave a blank space in the
table because it doesn't recompute column widths. The table's `ResizeSensor`
is primarily responsible for noticing resizes and updating widths, but when a
column is removed, although the inner `table` element width changes, the
container `.ember-table` element does not change its width, and thus the
`ResizeSensor` never notices, and the column widths are not recomputed.

This modifies the `ember-thead` observer to have it call `fillupHandler` when
column count changes.

It also changes the observer in `ember-thead` to watch `columns.[]` instead
of just `columns`, because in the latter case, the `fillupHandler` will not
be called if a column was removed via mutation (e.g. `popObject`).

Adds tests for removal via both ways (mutation and `this.set('columns',
newColumns)`). Also adds tests that adding columns also causes column widths
to be computed.

Co-authored-by: Jonathan Jackson