### PR TITLE
[PERF] Set default bufferSize to 1

### DIFF
--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -125,7 +125,7 @@ export default Component.extend({
     @argument
     @type number
   */
-  bufferSize: defaultTo(20),
+  bufferSize: defaultTo(1),
 
   /**
     A flag that tells the table to render all of its rows at once.


### PR DESCRIPTION
By default, `ember-table` was allocating a buffer of 20 rows before and after the visible ones.

This default value forces a lot of computation in the case of tables with many columns and complex cells, from syncinc more data (from rows to cells for example) and triggering more observers
(based on the number of computed properties defined per cell for example).

`vertical-collection` also does not allocate the part of the buffer that should be above the visible first row on the initial render, as there is none when loading the table. This means that the initial scroll will also lead to the creation of 20 rows in the DOM (and the underlying computation to render the content).

From a pure UI/UX point of view, we don't need more than 1 row on each side of the table,
and it's already the default for `vertical-collection`.