### PR TITLE
[TEST] Add rowCount to page objects for thead, tbody and tfoot

### DIFF
--- a/addon-test-support/pages/-private/ember-table-body.js
+++ b/addon-test-support/pages/-private/ember-table-body.js
@@ -7,6 +7,13 @@ export default {
   scope: 'tbody',
 
   /**
+    Returns the number of rows in the body.
+  */
+  get rowCount() {
+    return Number(findElement(this).getAttribute('data-test-row-count'));
+  },
+
+  /**
     List of rows in table body. Each of property/function in this collections is the property/func
     of a single row selected by using calling rows.objectAt(index).
   */

--- a/addon-test-support/pages/-private/ember-table-footer.js
+++ b/addon-test-support/pages/-private/ember-table-footer.js
@@ -1,7 +1,15 @@
 import { collection } from 'ember-classy-page-object';
+import { findElement } from 'ember-classy-page-object/extend';
 
 export default {
   scope: 'tfoot',
+
+  /**
+    Returns the number of rows in the footer.
+  */
+  get rowCount() {
+    return Number(findElement(this).getAttribute('data-test-row-count'));
+  },
 
   footers: collection({
     scope: 'td',

--- a/addon-test-support/pages/-private/ember-table-header.js
+++ b/addon-test-support/pages/-private/ember-table-header.js
@@ -135,6 +135,13 @@ export default {
    */
   headers: collection('th', Header),
 
+  /**
+    Returns the number of rows in the footer.
+  */
+  get rowCount() {
+    return Number(findElement(this).getAttribute('data-test-row-count'));
+  },
+
   rows: collection({
     scope: 'tr',
   }),

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -229,6 +229,8 @@ export default Component.extend({
   */
   canSelect: bool('onSelect'),
 
+  'data-test-row-count': readOnly('wrappedRows.length'),
+
   init() {
     this._super(...arguments);
 

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -4,7 +4,7 @@ import { bind } from '@ember/runloop';
 import { A as emberA } from '@ember/array';
 import defaultTo from '../../-private/utils/default-to';
 import { computed } from '@ember/object';
-import { notEmpty, or } from '@ember/object/computed';
+import { notEmpty, or, readOnly } from '@ember/object/computed';
 
 import { closest } from '../../-private/utils/element';
 import { sortMultiple, compareValues } from '../../-private/utils/sort';
@@ -163,6 +163,8 @@ export default Component.extend({
     @type(optional(Action))
   */
   onResize: null,
+
+  'data-test-row-count': readOnly('wrappedRows.length'),
 
   init() {
     this._super(...arguments);

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -31,7 +31,22 @@ module('Integration | basic', function() {
 
       // Check column header count
       assert.equal(table.headers.length, columnCount, 'renders the correct number of columns');
+      assert.equal(
+        table.header.rowCount,
+        1,
+        'The total number of rows in the header is available through the page object'
+      );
       assert.equal(table.rows.length, rowCount, 'renders the correct number of rows');
+      assert.equal(
+        table.body.rowCount,
+        rowCount,
+        'The total number of rows in the body is available through the page object'
+      );
+      assert.equal(
+        table.footer.rowCount,
+        0,
+        'The total number of rows in the footer is available through the page object'
+      );
     });
 
     test('it renders without any valuePaths', async function(assert) {
@@ -51,6 +66,11 @@ module('Integration | basic', function() {
       await generateTable(this, { columnCount, rowCount });
 
       assert.ok(table.rows.length < rowCount, 'not all rows have been rendered');
+      assert.equal(
+        table.body.rowCount,
+        rowCount,
+        'The total number of rows in the body is available through the page object'
+      );
       assert.equal(table.getCell(0, 0).text.trim(), '0A', 'correct first row rendered');
       assert.notEqual(
         table.getCell(table.rows.length - 1, 0).text.trim(),

--- a/tests/integration/components/footer-test.js
+++ b/tests/integration/components/footer-test.js
@@ -14,6 +14,11 @@ module('Integration | footer', function() {
 
       assert.ok(table.footer.isPresent, 'Footer is present in the table');
       assert.equal(table.footer.rows.length, 3, 'correct number of footer rows rendered');
+      assert.equal(
+        table.footer.rowCount,
+        3,
+        'The total number of rows in the footer is available through the page object'
+      );
 
       this.set('footerRows', []);
 


### PR DESCRIPTION
In some tests, it is interesting to see if a row is properly inserted or removed.

Because `vertical-collection` tries to not render all the rows, we can't simply count the number of `tr`. Instead we use the `data-test-row-count` attribute to keep track of the number of available rows in a table.