### PR TITLE
[FEATURE] Text alignment can be defined per column

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,2 +1,8 @@
 options:
   config-file: node_modules/@addepar/sass-lint-config/config.yml
+rules:
+  # Name Formats
+  class-name-format:
+    - 2
+    -
+      convention: strictbem

--- a/addon/components/-private/base-table-cell.js
+++ b/addon/components/-private/base-table-cell.js
@@ -1,17 +1,31 @@
 import Component from '@ember/component';
 import { equal } from '@ember/object/computed';
-import { observer } from '@ember/object';
+import { observer, computed } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
 
 export default Component.extend({
   // Provided by subclasses
   columnMeta: null,
+  columnValue: null,
 
-  classNameBindings: ['isFirstColumn', 'isFixedLeft', 'isFixedRight'],
+  classNameBindings: ['isFirstColumn', 'isFixedLeft', 'isFixedRight', 'textAlign'],
 
   isFirstColumn: equal('columnMeta.index', 0),
   isFixedLeft: equal('columnMeta.isFixed', 'left'),
   isFixedRight: equal('columnMeta.isFixed', 'right'),
+
+  /**
+   Indicates the text alignment of this cell
+  */
+  textAlign: computed('columnValue.textAlign', function() {
+    let textAlign = this.get('columnValue.textAlign');
+
+    if (['left', 'center', 'right'].includes(textAlign)) {
+      return `ember-table__text-align-${textAlign}`;
+    }
+
+    return null;
+  }),
 
   // eslint-disable-next-line
   scheduleUpdateStyles: observer(

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -22,6 +22,18 @@
       position: sticky;
       left: 0;
     }
+
+    &.ember-table__text-align-left {
+      text-align: left;
+    }
+
+    &.ember-table__text-align-center {
+      text-align: center;
+    }
+
+    &.ember-table__text-align-right {
+      text-align: right;
+    }
   }
 
   th {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@addepar/prettier-config": "^1.0.0",
     "@addepar/sass-lint-config": "^2.0.1",
     "@addepar/style-toolbox": "~0.7.0",
+    "@ember-decorators/argument": "^0.8.21",
     "@types/ember": "^2.8.22",
     "babel-eslint": "^10.0.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/tests/dummy/app/pods/docs/guides/header/columns/controller.js
+++ b/tests/dummy/app/pods/docs/guides/header/columns/controller.js
@@ -62,4 +62,16 @@ export default class ColumnsController extends Controller {
 
   resizeCount = 0;
   reorderCount = 0;
+
+  // BEGIN-SNIPPET docs-example-text-align.js
+  @computed
+  get columnsWithTextAlign() {
+    return [
+      { name: 'No alignment', valuePath: 'A' },
+      { name: 'Left alignment', valuePath: 'B', textAlign: 'left' },
+      { name: 'Center alignment', valuePath: 'C', textAlign: 'center' },
+      { name: 'Right alignment', valuePath: 'D', textAlign: 'right' },
+    ];
+  }
+  // END-SNIPPET
 }

--- a/tests/dummy/app/pods/docs/guides/header/columns/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/columns/template.md
@@ -184,3 +184,26 @@ reorder has occured.
 
   {{demo.snippet name='docs-example-resize-reorder-actions.hbs'}}
 {{/docs-demo}}
+
+## Text alignment
+
+A column can have its text aligned left, center or right by setting the `textAlign` property on the column definition.
+
+When the property is set, the cell will have the matching class (`ember-table__text-align-left`, `ember-table__text-align-center` or `ember-table__text-align-center`).
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name="text-align"}}
+    <div class="demo-container small">
+      {{! BEGIN-SNIPPET docs-example-text-align.hbs }}
+      <EmberTable as |t|>
+        <t.head @columns={{columnsWithTextAlign}} />
+
+        <t.body @rows={{rows}} />
+      </EmberTable>
+      {{! END-SNIPPET }}
+    </div>
+  {{/demo.example}}
+
+  {{demo.snippet name='docs-example-text-align.js' label='component.js'}}
+  {{demo.snippet name='docs-example-text-align.hbs'}}
+{{/docs-demo}}

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -238,6 +238,45 @@ module('Integration | basic', function() {
         );
       }
     });
+
+    test('Text can be aligned left, center or right', async function(assert) {
+      let classList;
+      let rowCount = 1;
+      let columns = generateColumns(4);
+      columns[1].textAlign = 'right';
+      columns[2].textAlign = 'center';
+      columns[3].textAlign = 'left';
+
+      await generateTable(this, { columns, columnCount: columns.length, rowCount });
+
+      for (let tagName of ['th', 'td']) {
+        classList = find(`${tagName}:nth-of-type(1)`).classList;
+        assert.notOk(
+          classList.contains('ember-table__text-align-left') ||
+            classList.contains('ember-table__text-align-center') ||
+            classList.contains('ember-table__text-align-right'),
+          `No class is applied by default on ${tagName} cells for text alignment`
+        );
+
+        classList = find(`${tagName}:nth-of-type(2)`).classList;
+        assert.ok(
+          classList.contains('ember-table__text-align-right'),
+          `${tagName} cells can be right aligned`
+        );
+
+        classList = find(`${tagName}:nth-of-type(3)`).classList;
+        assert.ok(
+          classList.contains('ember-table__text-align-center'),
+          `${tagName} cells can be centered`
+        );
+
+        classList = find(`${tagName}:nth-of-type(4)`).classList;
+        assert.ok(
+          classList.contains('ember-table__text-align-left'),
+          `${tagName} cells can be left aligned`
+        );
+      }
+    });
   });
 
   componentModule('lifecycle', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -724,6 +724,18 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@ember-decorators/argument@^0.8.21":
+  version "0.8.21"
+  resolved "https://registry.npmjs.org/@ember-decorators/argument/-/argument-0.8.21.tgz#929789f9622ee935c3fad3332b3d179e98d05b15"
+  integrity sha512-WsNQMzlEEl7puxwC3yE6VUmRvAHdIbGOQJ+tYA4DXbZOAfagjCDxhz2Gxl0JVG7Sc87e6a2YAVZQr8CLDW8zJg==
+  dependencies:
+    babel-plugin-filter-imports "^1.1.1"
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.17.0"
+    ember-cli-version-checker "^2.0.0"
+    ember-compatibility-helpers "^1.0.2"
+    ember-get-config "^0.2.3"
+
 "@ember-decorators/babel-transforms@^0.1.1":
   version "0.1.1"
   resolved "https://registry.npmjs.org/@ember-decorators/babel-transforms/-/babel-transforms-0.1.1.tgz#c2be1677192e55ccfeb806002d57e314a0e728bc"
@@ -1938,6 +1950,14 @@ babel-plugin-filter-imports@^0.3.1:
   version "0.3.1"
   resolved "https://registry.npmjs.org/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
   integrity sha1-54WbVohrF13SYWQl0neyGeIJ6os=
+
+babel-plugin-filter-imports@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/babel-plugin-filter-imports/-/babel-plugin-filter-imports-1.1.2.tgz#c6e1f2685253bbda91b1dc5a6652ce825f771264"
+  integrity sha512-BpXJV3fndKEP1D9Yhwpz4NIjM/d1FYpdx4E4KmUPnTIFUxXNj0QEAY18MXVzEyYi2EWEVhoOG2CmclDfdMj5ew==
+  dependencies:
+    babel-types "^6.26.0"
+    lodash "^4.17.10"
 
 babel-plugin-htmlbars-inline-precompile@^0.2.5:
   version "0.2.6"
@@ -5463,7 +5483,7 @@ ember-fetch@^6.4.0:
     node-fetch "^2.3.0"
     whatwg-fetch "^3.0.0"
 
-ember-get-config@^0.2.4:
+ember-get-config@^0.2.3, ember-get-config@^0.2.4:
   version "0.2.4"
   resolved "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
   integrity sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=


### PR DESCRIPTION
The `textAlign` property on a column definition accepts `left`, `center` and `right`.
When the property is set, a class is added to the cell (`ember-table__text-align-left`, `ember-table__text-align-center`, `ember-table__text-align-right`).

Also adds `ember-decorators/argument` as it's needed by the doc site.
