### PR TITLE
CHORE: Change jsconfig settings so that tests are included

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,13 +1,7 @@
 {
   "compilerOptions": {
-      "target": "ES6",
-      "experimentalDecorators": true
+    "target": "ES6",
+    "experimentalDecorators": true
   },
-  "include": [
-      "addon/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp", "dist"]
 }


### PR DESCRIPTION
Both "include" and "exclude" are unnecessary together, so modify
"exclude" to exclude all relevant directories.

This makes it so that VSCode won't complain about decorator usage
in dummy/* JS files, among other things.