### PR TITLE
DOCS: Avoid passing incorrect/unneeded args to faker.* methods

### DIFF
--- a/tests/dummy/app/pods/docs/guides/header/sorting/controller.js
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/controller.js
@@ -26,7 +26,7 @@ export default class SimpleController extends Controller {
 
     for (let i = 0; i < getRandomInt(5, 2); i++) {
       let companyRow = {
-        name: faker.company.companyName(i),
+        name: faker.company.companyName(),
         price: 'N/A',
         sold: 0,
         unsold: 0,
@@ -36,7 +36,7 @@ export default class SimpleController extends Controller {
 
       for (let j = 0; j < getRandomInt(5, 2); j++) {
         let departmentRow = {
-          name: faker.commerce.department(j),
+          name: faker.commerce.department(),
           price: 'N/A',
           sold: 0,
           unsold: 0,
@@ -51,7 +51,7 @@ export default class SimpleController extends Controller {
           let totalRevenue = price * sold;
 
           let product = {
-            name: faker.commerce.productName(k),
+            name: faker.commerce.productName(),
             price: `$${price}`,
             sold,
             unsold,

--- a/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/component.js
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/component.js
@@ -34,7 +34,7 @@ export default class EmptyValues extends Component {
       let totalRevenue = price * sold;
 
       let product = {
-        name: faker.commerce.productName(k),
+        name: faker.commerce.productName(),
         material: faker.commerce.productMaterial(),
         price: `$${price}`,
         sold,
@@ -52,7 +52,7 @@ export default class EmptyValues extends Component {
       let totalRevenue = price * sold;
 
       let product = {
-        name: faker.commerce.productName(k),
+        name: faker.commerce.productName(),
         material: '',
         price: `$${price}`,
         sold,


### PR DESCRIPTION
faker.company.companyName for its first arg expects either a format string
or an integer in the range [0,2]:
https://github.com/Marak/faker.js/blob/3a4bb358614c1e1f5d73f4df45c13a1a7aa013d7/lib/company.js#L26-L39

Passing a value greater than 2 results in a returned value of `string
parameter is required!` instead of a faked name. This wasn't obvious because
the number of generated rows is dynamic (via `getRandomInt`), so it only
shows up if the # of generated rows is enough to trigger the error, and then
you have to scroll to the bottom of the table to notice it.

Also remove the argument passed to `department` because it doesn't accept an argument:
https://github.com/Marak/faker.js/blob/3a4bb358614c1e1f5d73f4df45c13a1a7aa013d7/lib/commerce.js#L22-L24

Ditto for `productName`:
https://github.com/Marak/faker.js/blob/3a4bb358614c1e1f5d73f4df45c13a1a7aa013d7/lib/commerce.js#L31-L35

The issue can be seen at ["sorting" page](https://opensource.addepar.com/ember-table/latest/docs/guides/header/sorting) of the current published docs site. If you reload the page enough times so that the table renders more than 3 rows, the 4th row will say "string parameter is required!":
![image](https://user-images.githubusercontent.com/2023/60997875-e0ac0c80-a325-11e9-89be-ade6313dc730.png)
