### PR TITLE
DOCS: Test that subcolumns docs render cells

### DIFF
--- a/tests/acceptance/docs-test.js
+++ b/tests/acceptance/docs-test.js
@@ -2,6 +2,7 @@ import { module, test as qunitTest, skip as qunitSkip } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import config from 'dummy/config/environment';
+import TablePage from 'ember-table/test-support/pages/ember-table';
 
 let skip = (msg, ...args) =>
   qunitSkip(`Skip because ember-cli-addon-docs is not installed. ${msg}`, ...args);
@@ -32,5 +33,20 @@ module('Acceptance | docs', function(hooks) {
       assert.ok(true, `Visited ${href} successfully`);
       await visit('/docs'); // start over
     }
+  });
+
+  test('subcolumns docs renders cell content', async function(assert) {
+    let DemoTable = TablePage.extend({
+      scope: '[data-test-demo="docs-example-subcolumns"] [data-test-ember-table]',
+    });
+
+    await visit('/docs/guides/header/subcolumns');
+    let table = new DemoTable();
+    assert.equal(table.header.headers.objectAt(0).text, 'A', 'first header cell renders correctly');
+    assert.equal(
+      table.body.rows.objectAt(0).cells.objectAt(0).text,
+      'A A',
+      'first body cell renders correclty'
+    );
   });
 });

--- a/tests/dummy/app/pods/docs/guides/header/subcolumns/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/subcolumns/template.md
@@ -8,7 +8,7 @@ lowest level of subcolumns (the leaves of the column tree). This means that
 
 {{#docs-demo as |demo|}}
   {{#demo.example}}
-    <div class="demo-container small">
+    <div class="demo-container small" data-test-demo="docs-example-subcolumns">
       {{! BEGIN-SNIPPET docs-example-subcolumns.hbs }}
         <EmberTable as |t|>
           <t.head @columns={{simpleColumns}} />

--- a/tests/dummy/app/utils/generators.js
+++ b/tests/dummy/app/utils/generators.js
@@ -14,16 +14,14 @@ export class DummyRow {
   constructor(id, format = identity) {
     this.id = id;
     this.format = format;
+
+    // Set these so that they are not picked up by `unknownProperty` below
+    this.disableCollapse = null;
+    this.children = null;
   }
 
-  // this provides values for rows; but by convention in our tests, we don't use a key longer than 1
-  // so we exclude this turn off this behavior in other cases
   unknownProperty(key) {
-    if (key.length === 1) {
-      return this.format(this, key);
-    } else {
-      return undefined;
-    }
+    return this.format(this, key);
   }
 }
 


### PR DESCRIPTION
Builds on top of the acceptance tests added by ~~#709~~ #714  and should not be merged until it lands.

[Diff of changes unique to this PR](https://github.com/Addepar/ember-table/compare/bantic/docs/acceptance-tests...bantic:bantic/docs/subcolumns-render).

Fix rendering of generated dummy rows. Cells with valuePaths longer than
a single character were being skipped over in the dummy row's `unknownProperty`
hook.
Fix by removing the length check in `unknownProperty` and explicitly adding
the needed properties to the class definition so that the only accesses
that hit `unknownProperty` should be `valuePath`s for rendering.

Before:
![image](https://user-images.githubusercontent.com/2023/61004501-2374e100-a334-11e9-9437-b63406517b99.png)


After:
![image](https://user-images.githubusercontent.com/2023/61004467-148e2e80-a334-11e9-8112-0e8eb3c4d25c.png)
