### PR TITLE
[CHORE] Move ember-test-selectors from deps to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ember-getowner-polyfill": "^2.2.0",
     "ember-legacy-class-shim": "^1.0.0",
     "ember-raf-scheduler": "^0.1.0",
-    "ember-test-selectors": "^0.3.9",
     "ember-useragent": "^0.6.0",
     "hammerjs": "^2.0.8"
   },
@@ -86,6 +85,7 @@
     "ember-resolver": "^5.1.1",
     "ember-source": "~3.1.0",
     "ember-source-channel-url": "^1.0.1",
+    "ember-test-selectors": "^0.3.9",
     "ember-truth-helpers": "^2.0.0",
     "ember-try": "^1.1.0",
     "eslint-plugin-ember": "^6.2.0",


### PR DESCRIPTION
ember-test-selectors does not need to be a dependency.
It was moved from devDeps to deps in #537, which appears to have been unintentional.

As an aside, the `data-test-*` attrs that ember-table uses, e.g. https://github.com/Addepar/ember-table/blob/4cbaee809bdb45874bc5e24f2d694210210866a7/addon/components/ember-table/component.js#L41
appear to leak out to consuming apps and should likely be removed.