### PR TITLE
[DOCS]: Add basic acceptance test for docs/ routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "ember-a11y-testing": "^0.5.0",
     "ember-ajax": "^4.0.2",
     "ember-angle-bracket-invocation-polyfill": "^1.3.1",
-    "ember-auto-import": "^1.2.20",
     "ember-classy-page-object": "^0.5.0",
     "ember-cli": "~3.1.4",
     "ember-cli-addon-docs": "^0.6.13",
@@ -77,6 +76,7 @@
     "ember-decorators": "^2.2.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
+    "ember-faker": "^1.5.0",
     "ember-fetch": "^6.4.0",
     "ember-load-initializers": "^2.0.0",
     "ember-math-helpers": "^2.10.0",
@@ -91,7 +91,6 @@
     "eslint-plugin-ember": "^6.2.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-prettier": "2.6.0",
-    "faker": "^4.1.0",
     "husky": "^1.3.1",
     "loader.js": "^4.2.3"
   },

--- a/tests/acceptance/docs-test.js
+++ b/tests/acceptance/docs-test.js
@@ -1,0 +1,36 @@
+import { module, test as qunitTest, skip as qunitSkip } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import config from 'dummy/config/environment';
+
+let skip = (msg, ...args) =>
+  qunitSkip(`Skip because ember-cli-addon-docs is not installed. ${msg}`, ...args);
+let test = config.ADDON_DOCS_INSTALLED ? qunitTest : skip;
+
+module('Acceptance | docs', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting / redirects to /docs', async function(assert) {
+    await visit('/');
+
+    assert.equal(currentURL(), '/docs');
+  });
+
+  test('pages linked to by /docs nav all render', async function(assert) {
+    await visit('/docs');
+
+    let nav = this.element.querySelector('nav');
+    assert.ok(!!nav, 'nav exists');
+
+    let links = Array.from(nav.querySelectorAll('a')).filter(link =>
+      link.getAttribute('href').startsWith('/docs')
+    );
+    assert.ok(links.length > 0, `${links.length} nav links found`);
+    for (let link of links) {
+      let href = link.getAttribute('href');
+      await visit(href);
+      assert.ok(true, `Visited ${href} successfully`);
+      await visit('/docs'); // start over
+    }
+  });
+});

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,3 +1,10 @@
+// Detect if ember-cli-addon-docs is in the project package.json.
+// This is used at test runtime to decide whether to run the docs/
+// acceptance tests.
+const ADDON_DOCS_INSTALLED = Object.keys(require('../../../package.json').devDependencies).includes(
+  'ember-cli-addon-docs'
+);
+
 module.exports = function(environment) {
   let ENV = {
     modulePrefix: 'dummy',
@@ -51,6 +58,8 @@ module.exports = function(environment) {
     ENV.rootURL = 'ADDON_DOCS_ROOT_URL';
     ENV.locationType = 'router-scroll';
   }
+
+  ENV.ADDON_DOCS_INSTALLED = ADDON_DOCS_INSTALLED;
 
   return ENV;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,7 +1905,7 @@ async@^1.5.2:
   resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.4.1, async@^2.5.0:
+async@^2.4.1:
   version "2.6.2"
   resolved "https://registry.npmjs.org/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
   integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
@@ -5131,36 +5131,6 @@ ember-auto-import@^1.2.19:
     walk-sync "^0.3.3"
     webpack "~4.28"
 
-ember-auto-import@^1.2.20:
-  version "1.2.21"
-  resolved "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-1.2.21.tgz#e02ded183844faba66c3f2af97028ef35175b837"
-  integrity sha512-coHnqO3mRnlj/JAQSQBEqzX2wL8rH5YrfEJMzk1102X9MdSX1CWeaUYBcyjvI/pG8fHUhv+4VsD6rQuhTUyZUQ==
-  dependencies:
-    "@babel/core" "^7.1.6"
-    "@babel/traverse" "^7.1.6"
-    "@babel/types" "^7.1.6"
-    babel-core "^6.26.3"
-    babel-plugin-syntax-dynamic-import "^6.18.0"
-    babel-template "^6.26.0"
-    babylon "^6.18.0"
-    broccoli-debug "^0.6.4"
-    broccoli-plugin "^1.3.0"
-    debug "^3.1.0"
-    ember-cli-babel "^6.6.0"
-    enhanced-resolve "^4.0.0"
-    fs-extra "^6.0.1"
-    fs-tree-diff "^1.0.0"
-    handlebars "~4.0.13"
-    js-string-escape "^1.0.1"
-    lodash "^4.17.10"
-    mkdirp "^0.5.1"
-    pkg-up "^2.0.0"
-    resolve "^1.7.1"
-    rimraf "^2.6.2"
-    symlink-or-copy "^1.2.0"
-    walk-sync "^0.3.3"
-    webpack "~4.28"
-
 ember-classy-page-object@^0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/ember-classy-page-object/-/ember-classy-page-object-0.5.0.tgz#42ffd395bb6045c1f3bd94d923e11f283d26d661"
@@ -5266,7 +5236,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.1, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.2:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.1, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.2:
   version "6.18.0"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -5984,6 +5954,15 @@ ember-factory-for-polyfill@^1.3.1:
   integrity sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==
   dependencies:
     ember-cli-version-checker "^2.1.0"
+
+ember-faker@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/ember-faker/-/ember-faker-1.5.0.tgz#f9454bfbc0bc81aee0fff1a151ecf57634af8ac2"
+  integrity sha512-Qpg7M/K0mbJZKWLj1FIKq5hJDnxc3RBuZ9Sn1msXhFJHiIEbpKGXsQot/tbaDJIrIrUXypV6RclF0LtFPNroMg==
+  dependencies:
+    ember-cli-babel "^6.4.1"
+    ember-cli-node-assets "^0.2.2"
+    faker "^3.0.0"
 
 ember-fetch-adapter@^0.4.3:
   version "0.4.3"
@@ -7216,10 +7195,10 @@ extsprintf@^1.2.0:
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-faker@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
-  integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
+faker@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/faker/-/faker-3.1.0.tgz#0f908faf4e6ec02524e54a57e432c5c013e08c9f"
+  integrity sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8=
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
@@ -8115,17 +8094,6 @@ handlebars@^4.0.4, handlebars@^4.0.6, handlebars@^4.1.0:
   integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
   dependencies:
     neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-handlebars@~4.0.13:
-  version "4.0.13"
-  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.0.13.tgz#89fc17bf26f46fd7f6f99d341d92efaae64f997d"
-  integrity sha512-uydY0jy4Z3wy/iGXsi64UtLD4t1fFJe16c/NFxsYE4WdQis8ZCzOXUZaPQNG0e5bgtLQV41QTfqBindhEjnpyQ==
-  dependencies:
-    async "^2.5.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
   optionalDependencies:


### PR DESCRIPTION
Supersedes #709 — it took a bit more work to get the tests passing on CI so I closed that PR and opened this one.

Adds acceptance tests that `/docs` and all of the navigation items on the `/docs` page render without error.

In order to get these tests passing I had to make a few tangential changes:

### Change: Remove ember-auto-import and faker from `devDependencies`, add `ember-faker`

Without this change, the `/docs` acceptance tests fail with a message like:

```
Global error: Uncaught Error: Assertion Failed: You attempted to define a `{{link-to "docs.guides.header.sorting"}}` but did not pass the parameters required for generating its dynamic segments. Could not find module `faker` imported from `dummy/pods/docs/guides/header/sorting/controller`
```
[Failing Travis test run](https://travis-ci.org/Addepar/ember-table/jobs/556979019).

This appears to be due to Travis's CI build failing to import `faker`, which is used for some of the docs controllers.

`ember-auto-import`'s [Usage From Addons](https://github.com/ef4/ember-auto-import#usage-from-addons) docs state:

> ember-auto-import must be in the dependencies of your addon

and

> ember-auto-import will refuse to import devDependencies of your addon

This seems to explain why `faker` was not available for the CI test runs, as at the time it and `ember-auto-import` were both in `devDependencies`. I confirmed that moving them both to `dependencies` fixes CI, but seeing as how these are both used only for this addon's tests that did not seem an appropriate fix.

So instead I've removed them and brought back `ember-faker` in `devDependencies`. Unfortunately ember-faker only brings in faker@3 (current version is 4), so we move back to an earlier version of faker, but judging from [its changelog](https://github.com/Marak/faker.js/blob/master/CHANGELOG.md#v400) there is nothing particularly important we are missing. (faker@3 already provides faked bitcoin addresses; I'm not sure what else we need \s ).

### Change: Add code to `dummy/config/environment` to detect at build-time whether `ember-cli-addon-docs` is installed

This makes it so only ember-try scenarios with the docs addon installed will run the `/docs` tests. These tests don't need to be run in every ember-try configuration, only the one that we will publish from, which will presumably always be `master` (aka `ember-default` scenario).

In #709 I had done this using an env variable, but this made the travis.yml a bit messy. The run-time detection of `ember-cli-addon-docs` seems like a cleaner approach. When it doesn't see that the addon docs are present in `package.json`, those tests are `skip`'d so they still show up in the CI build output.