### PR TITLE
[DOCS] Add "Testing" section

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,0 +1,3 @@
+import TablePage from './pages/ember-table';
+
+export { TablePage };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@addepar/ember-toolbox": "^0.3.2",
-    "@addepar/eslint-config": "^4.0.0",
+    "@addepar/eslint-config": "^4.0.2",
     "@addepar/prettier-config": "^1.0.0",
     "@addepar/sass-lint-config": "^2.0.1",
     "@addepar/style-toolbox": "~0.7.0",

--- a/tests/dummy/app/pods/docs/template.hbs
+++ b/tests/dummy/app/pods/docs/template.hbs
@@ -27,6 +27,11 @@
     {{nav.item 'Rows and Trees' 'docs.guides.body.rows-and-trees'}}
     {{nav.item 'Row Selection' 'docs.guides.body.row-selection'}}
     {{nav.item 'Occlusion' 'docs.guides.body.occlusion'}}
+
+    {{nav.section 'Testing'}}
+
+    {{nav.item 'Table Test Page' 'docs.testing.test-page'}}
+
   {{/viewer.nav}}
 
   {{#viewer.main}}

--- a/tests/dummy/app/pods/docs/testing/test-page/template.md
+++ b/tests/dummy/app/pods/docs/testing/test-page/template.md
@@ -1,0 +1,29 @@
+# Testing Ember Table
+
+## Table Page Object
+
+Ember Table includes a test helper that you can import in your app's acceptance tests and use to interact with a table on the page. The Page helper is based on [`ember-classy-page-object`](https://github.com/pzuraq/ember-classy-page-object).
+
+To import it:
+
+```js
+import { TablePage } from 'ember-table/test-support';
+```
+
+Usage:
+
+```js
+// ... in an acceptance test:
+const table = new TablePage();
+
+assert.equal(table.body.rowCount, 5, 'the table has 5 body rows');
+assert.equal(table.header.rows.length, 1, 'the table has 1 row of headers');
+assert.equal(table.footer.rows.length, 1, 'the table has 1 row of footers');
+
+await table.selectRow(0); // The first body row is selected
+assert.ok(table.body.rows.objectAt(0).isSelected, 'first row is selected');
+assert.ok(!table.body.rows.objectAt(1).isSelected, 'second row is not selected');
+```
+
+To learn more about the properties that are present on the table page object, refer to [its source](https://github.com/Addepar/ember-table/blob/master/addon-test-support/pages/ember-table.js) or
+to [its usage in the ember-table tests](https://github.com/Addepar/ember-table/blob/master/tests/integration/components/basic-test.js).

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -36,6 +36,10 @@ Router.map(function() {
       });
     });
 
+    this.route('testing', function() {
+      this.route('test-page');
+    });
+
     this.route('api', function() {
       this.route('class', { path: '/:class_id' });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@
     sass-lint "^1.12.1"
     walk-sync "^0.3.2"
 
-"@addepar/eslint-config@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/@addepar/eslint-config/-/eslint-config-4.0.1.tgz#6f131ee27d894225308a7059404a877f9f4fb596"
-  integrity sha512-H8EzoOfr+TqGSgEiq7yB2T18Tw7Y0pH31/X1Qv9QK13+jdKWEUCWot1rkATk2x6ILsBU3lMUYdxke9xfGj9kbA==
+"@addepar/eslint-config@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/@addepar/eslint-config/-/eslint-config-4.0.2.tgz#312ac71dfa0123ef387342e5b71911019b878862"
+  integrity sha512-DXmIbhd7jlImQAUU++gVCplZEXUM5Hxrdeen+u3CdR8d1AncE7+P9W9OTQS7HnYkVxyZzky+YURtPk3LUaBcvg==
   dependencies:
     eslint-config-prettier "^2.9.0"
     eslint-plugin-ember "^5.0.1"


### PR DESCRIPTION
fixes #715 

Add `addon-test-support/index.js` to export the TablePage from a central
location.

Upgrade @addepar/eslint-config to ^4.0.2 so that the `index.js` is linted
correctly.

Add a "Testing" section to the addon docs that describes basic usage of the
TablePage.

The addon docs page looks like this:
![image](https://user-images.githubusercontent.com/2023/61236868-10cd2400-a707-11e9-9781-c11e7f726e0f.png)
