### PR TITLE
[DOCS] Style tweaks

### DIFF
--- a/tests/dummy/app/pods/docs/guides/header/columns/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/columns/template.md
@@ -106,21 +106,19 @@ using the `enableResize` and `enableReorder` flags. You can also change the
 {{#docs-demo as |demo|}}
   {{#demo.example name="column-resize-reorder"}}
     {{! BEGIN-SNIPPET docs-example-column-resize-reorder.hbs }}
-    <div class="py-2">
-      <label>
+    <div class='demo-options'>
+      <span class='demo-option'>
         {{input type="checkbox" checked=resizeEnabled}}
         Enable Resizing
-      </label>
-
-      <label>
+      </span>
+      <span class='demo-option'>
         {{input type="checkbox" checked=reorderEnabled}}
         Enable Reordering
-      </label>
-
-      <label>
+      </span>
+      <span class='demo-option'>
         {{input type="checkbox" checked=resizeModeFluid}}
         Resize Mode Fluid
-      </label>
+      </span>
     </div>
 
     <div class="demo-container small">

--- a/tests/dummy/app/pods/docs/index/template.md
+++ b/tests/dummy/app/pods/docs/index/template.md
@@ -1,10 +1,6 @@
-<div class="docs-hero">
-  {{docs-hero
-    logo='ember'
-    slimHeading='table'
-    byline='the power table for power users'
-  }}
-</div>
+{{docs-hero
+  byline='the power table for power users'
+}}
 
 Ember Table is a power table made for users who need a full-fledged,
 fully-customizable table component for their apps. It is built to be flexible,

--- a/tests/dummy/app/styles/tables.scss
+++ b/tests/dummy/app/styles/tables.scss
@@ -25,10 +25,6 @@
   }
 }
 
-.red-cell {
-  background: #ff0000;
-}
-
 /* Custom component classes */
 .custom-component-container {
   position: relative;


### PR DESCRIPTION
Addresses #272 

  * Improve spacing of options for the resize/reorder columns demo
  * Remove some unused args passed to `{{docs-hero}}` (they were valid in an older version of addon-docs, but no longer)
  * Remove unused CSS class