### PR TITLE
[DOCS] Unconditionally enable faker for dummy app

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,6 +10,9 @@ module.exports = function(defaults) {
     babel: {
       plugins: ['transform-object-rest-spread'],
     },
+    'ember-faker': {
+      enabled: true, // Always enable for dummy app because the docs examples use faker
+    },
   });
 
   /*


### PR DESCRIPTION
The addon-docs `/docs` site uses faker to generate some of the demo data, so it must be enabled all the time. Normally `ember-faker` excludes faker from production builds, but our addon-docs deploy process builds the app in the production env, so we must enable it.