### PR TITLE
[DOCS] Add 2-state sorting example

### DIFF
--- a/tests/acceptance/docs-test.js
+++ b/tests/acceptance/docs-test.js
@@ -67,4 +67,31 @@ module('Acceptance | docs', function(hooks) {
       );
     });
   });
+
+  test('sorting: 2-state sorting works as expected', async function(assert) {
+    await visit('/docs/guides/header/sorting');
+    let DemoTable = TablePage.extend({
+      scope: '[data-test-demo="docs-example-2-state-sortings"] [data-test-ember-table]',
+    });
+
+    let table = new DemoTable();
+    let header = table.headers.objectAt(0);
+
+    assert.ok(!header.sortIndicator.isPresent, 'precond - sortIndicator is not present');
+
+    await header.click();
+    assert.ok(
+      header.sortIndicator.isPresent && header.sortIndicator.isDescending,
+      'sort descending'
+    );
+
+    await header.click();
+    assert.ok(header.sortIndicator.isPresent && header.sortIndicator.isAscending, 'sort ascending');
+
+    await header.click();
+    assert.ok(
+      header.sortIndicator.isPresent && header.sortIndicator.isDescending,
+      'sort cycles back to descending'
+    );
+  });
 });

--- a/tests/dummy/app/pods/docs/guides/header/columns/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/columns/template.md
@@ -107,18 +107,18 @@ using the `enableResize` and `enableReorder` flags. You can also change the
   {{#demo.example name="column-resize-reorder"}}
     {{! BEGIN-SNIPPET docs-example-column-resize-reorder.hbs }}
     <div class='demo-options'>
-      <span class='demo-option'>
+      <label class='demo-option'>
         {{input type="checkbox" checked=resizeEnabled}}
         Enable Resizing
-      </span>
-      <span class='demo-option'>
+      </label>
+      <label class='demo-option'>
         {{input type="checkbox" checked=reorderEnabled}}
         Enable Reordering
-      </span>
-      <span class='demo-option'>
+      </label>
+      <label class='demo-option'>
         {{input type="checkbox" checked=resizeModeFluid}}
         Resize Mode Fluid
-      </span>
+      </label>
     </div>
 
     <div class="demo-container small">

--- a/tests/dummy/app/pods/docs/guides/header/sorting/controller.js
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/controller.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember-decorators/object';
+import { action, computed } from '@ember-decorators/object';
 import faker from 'faker';
 import { getRandomInt } from '../../../../../utils/generators';
 
@@ -77,4 +77,32 @@ export default class SimpleController extends Controller {
 
     return rows;
   }
+
+  // BEGIN-SNIPPET docs-example-2-state-sortings.js
+  @action
+  twoStateSorting(sorts) {
+    if (sorts.length > 1) {
+      // multi-column sort, default behavior
+      this.set('sorts', sorts);
+      return;
+    }
+
+    let hasExistingSort = this.sorts && this.sorts.length;
+    let isDefaultSort = !sorts.length;
+
+    if (hasExistingSort && isDefaultSort) {
+      // override empty sorts with reversed previous sort
+      let newSorts = [
+        {
+          valuePath: this.sorts[0].valuePath,
+          isAscending: !this.sorts[0].isAscending,
+        },
+      ];
+      this.set('sorts', newSorts);
+      return;
+    }
+
+    this.set('sorts', sorts);
+  }
+  // BEGIN-SNIPPET docs-example-2-state-sortings.js
 }

--- a/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/template.hbs
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/template.hbs
@@ -1,6 +1,12 @@
 {{#docs-demo as |demo|}}
   {{#demo.example name='sorting-empty-values'}}
     {{! BEGIN-SNIPPET docs-example-sorting-empty-values.hbs }}
+    <div class='demo-options'>
+      <label class='demo-option'>
+        {{input type="checkbox" checked=sortEmptyLast}}
+        Sort Empty Last
+      </label>
+    </div>
     <div class="demo-container">
       <EmberTable as |t|>
         <t.head

--- a/tests/dummy/app/pods/docs/guides/header/sorting/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/template.md
@@ -4,10 +4,10 @@ Ember Table ships with sorting built in to the table. Default sorting is a
 standard merge sort which does not affect the original ordering of the rows
 passed into the table. Users can sort by a column and toggle sort direction by
 clicking on its header, and can sort by multiple columns by clicking with `cmd`
-or `ctrl`:
+or `ctrl`.
 
 {{#docs-demo as |demo|}}
-  {{#demo.example}}
+  {{#demo.example name="docs-example-sortings"}}
     {{! BEGIN-SNIPPET docs-example-sortings.hbs }}
     <div class="demo-container">
       <EmberTable as |t|>
@@ -84,8 +84,49 @@ let columns = [
 ];
 ```
 
+## Sorting States
+
+By default, when a user repeatedly clicks on a column header to change sorting, ember-table
+cycles through these states:
+
+  * Unsorted (rows are in the same order as provided to the table)
+  * Sort Descending
+  * Sort Ascending
+
+You can use the `onUpdateSorts` action to change this behavior. For example, to cycle through 2 states
+(Ascending, Descending) rather than the default 3, you can modify the `onUpdateSorts` action as follows:
+  * If it is passed an empty `sorts` array, get the current sort array and toggle the `isAscending` property
+  * If it is passed anything else, set `this.sorts` to the passed-in `sorts` array (default behavior).
+
+This demo shows that in action:
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name="docs-example-2-state-sortings"}}
+    {{! BEGIN-SNIPPET docs-example-2-state-sortings.hbs }}
+    <div class="demo-container" data-test-demo="docs-example-2-state-sortings">
+      <EmberTable as |t|>
+        <t.head
+          @columns={{columns}}
+          @sorts={{sorts}}
+
+          @onUpdateSorts="twoStateSorting"
+
+          @widthConstraint='gte-container'
+          @fillMode='first-column'
+        />
+
+        <t.body @rows={{rows}} />
+      </EmberTable>
+    </div>
+    {{! END-SNIPPET }}
+  {{/demo.example}}
+
+  {{demo.snippet name='docs-example-2-state-sortings.hbs'}}
+  {{demo.snippet label='component.js' name='docs-example-2-state-sortings.js'}}
+{{/docs-demo}}
 ## Sorting empty values
 
 Empty values can be treated differently depending on the needs by using the `sortEmptyLast` option.
+To see its effect, try sorting the "Material" column in ascending order with and without "sortEmptyLast" checked.
 
 {{docs/guides/header/sorting/empty-values}}

--- a/tests/dummy/app/pods/docs/guides/main/table-customization/template.md
+++ b/tests/dummy/app/pods/docs/guides/main/table-customization/template.md
@@ -50,15 +50,15 @@ components:
   {{#demo.example}}
     {{! BEGIN-SNIPPET table-customization-example-sorting.hbs }}
     <div class='demo-options'>
-      <span class='demo-option'>
+      <label class='demo-option'>
         <input type='checkbox' checked={{showSortIndicator}} onclick={{action (mut showSortIndicator) (not showSortIndicator)}}>
         Show Sort Indicator
         <span class='small'>(Click header to sort)</span>
-      </span>
-      <span class='demo-option'>
+      </label>
+      <label class='demo-option'>
         <input type='checkbox' checked={{showResizeHandle}} onclick={{action (mut showResizeHandle) (not showResizeHandle)}}>
         Show Resize Handle <span class='small'>(Only appears on hover)</span>
-      </span>
+      </label>
     </div>
     <div class="demo-container">
       <EmberTable as |t|>


### PR DESCRIPTION
Fixes #721

Also add checkbox to configure `sortEmptyLast` on that demo.
Add test for the 2-state sorting.

Use `label` instead of `span` on all the places `demo-options` are shown.