### PR TITLE
[DOCS] Change styling for row-selection demo options

### DIFF
--- a/tests/dummy/app/pods/docs/guides/body/row-selection/template.md
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/template.md
@@ -5,7 +5,7 @@ table body will activate selection, and you can pass in the `selection` property
 to control the selection using DDAU:
 
 {{#docs-demo as |demo|}}
-  {{#demo.example}}
+  {{#demo.example name="docs-example-row-selection"}}
     <div class="demo-container small">
       {{! BEGIN-SNIPPET docs-example-row-selection.hbs }}
       <EmberTable as |t|>
@@ -104,60 +104,23 @@ itself.
         />
       </EmberTable>
     </div>
-
-    <div class="options-container">
-      <h4 class="label">rowSelectionMode</h4>
-
-      <div class="options">
-        <label class="pr-4">
-          multiple
-          <RadioButton @name='row-selection-mode' @value='multiple' @groupValue={{rowSelectionMode}} />
-        </label>
-
-        <label class="pr-4">
-          single
-          <RadioButton @name='row-selection-mode' @value='single' @groupValue={{rowSelectionMode}} />
-        </label>
-
-        <label>
-          none
-          <RadioButton @name='row-selection-mode' @value='none' @groupValue={{rowSelectionMode}} />
-        </label>
-      </div>
-
-      <h4 class="label">checkboxSelectionMode</h4>
-
-      <div class="options">
-        <label class="pr-4">
-          multiple
-          <RadioButton @name='checkbox-selection-mode' @value='multiple' @groupValue={{checkboxSelectionMode}} />
-        </label>
-
-        <label class="pr-4">
-          single
-          <RadioButton @name='checkbox-selection-mode' @value='single' @groupValue={{checkboxSelectionMode}} />
-        </label>
-
-        <label>
-          none
-          <RadioButton @name='checkbox-selection-mode' @value='none' @groupValue={{checkboxSelectionMode}} />
-        </label>
-      </div>
-
-      <h4 class="label">selectingChildrenSelectsParent</h4>
-
-      <div class="options">
-        <label class="pr-4">
-          true
-          <RadioButton @name='selecting-children-selects-parent' @value={{true}} @groupValue={{selectingChildrenSelectsParent}} />
-        </label>
-
-        <label class="pr-4">
-          false
-          <RadioButton @name='selecting-children-selects-parent' @value={{false}} @groupValue={{selectingChildrenSelectsParent}} />
-        </label>
-      </div>
+    <div class="demo-options-group">
+      <h4>rowSelectionMode</h4>
+      <label> <RadioButton @name='row-selection-mode' @value='multiple' @groupValue={{rowSelectionMode}} /> multiple </label>
+      <label> <RadioButton @name='row-selection-mode' @value='single' @groupValue={{rowSelectionMode}} /> single </label>
+      <label> <RadioButton @name='row-selection-mode' @value='none' @groupValue={{rowSelectionMode}} /> none </label>
     </div>
+    <div class="demo-options-group">
+      <h4>checkboxSelectionMode</h4>
+      <label> <RadioButton @name='checkbox-selection-mode' @value='multiple' @groupValue={{checkboxSelectionMode}} /> multiple </label>
+      <label> <RadioButton @name='checkbox-selection-mode' @value='single' @groupValue={{checkboxSelectionMode}} /> single </label>
+      <label> <RadioButton @name='checkbox-selection-mode' @value='none' @groupValue={{checkboxSelectionMode}} /> none </label>
+    </div>
+    <div class="demo-options-group">
+      <h4>selectingChildrenSelectsParent</h4>
+      <label> {{input type="checkbox" checked=selectingChildrenSelectsParent}} </label>
+    </div>
+
     {{! END-SNIPPET }}
   {{/demo.example}}
 

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -42,29 +42,6 @@ $colors: (
   }
 }
 
-.options-container {
-  display: flex;
-  flex-flow: row wrap;
-  font-size: 0.9em;
-
-  border-top: solid 1px #dae1e7;
-  margin-top: 1em;
-  padding-top: 1em;
-
-  .label {
-    flex: 0 1 40%;
-    font-weight: normal;
-    text-align: right;
-
-    padding-bottom: 1em;
-    padding-right: 1em;
-  }
-
-  .options {
-    padding-bottom: 1em;
-  }
-}
-
 .resize-container {
   resize: both;
   overflow: scroll;

--- a/tests/dummy/app/styles/tables.scss
+++ b/tests/dummy/app/styles/tables.scss
@@ -4,6 +4,19 @@
   }
 }
 
+.demo-options-group {
+  display: flex;
+
+  & *:first-child {
+    text-align: right;
+    flex-basis: 40%;
+  }
+
+  & > * + * {
+    padding-left: 2em;
+  }
+}
+
 .demo-container {
   position: relative;
   width: 100%;


### PR DESCRIPTION
Change the styling so the interactive row-selection demo
moves the radio button labels to the right of the button, and
add back in some alignment and spacing between the labels.
The docs were using a tailwind CSS class "pr-4" but tailwind is no longer
provided via addon-docs, so those styles were not being applied.

Before
![image](https://user-images.githubusercontent.com/2023/61545763-34011780-aa16-11e9-990c-dd1add7a406e.png)

After
![image](https://user-images.githubusercontent.com/2023/61545739-2481ce80-aa16-11e9-8957-6d23c6b57df8.png)
