### PR TITLE
Render tables with no columns correctly

### DIFF
--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -216,8 +216,11 @@ const ColumnTreeNode = EmberObject.extend({
     return this._subcolumnNodes;
   }),
 
-  isLeaf: computed('column.subcolumns.[]', function() {
+  isLeaf: computed('column.subcolumns.[]', 'isRoot', function() {
     let subcolumns = get(this, 'column.subcolumns');
+    if (get(this, 'isRoot')) {
+      return false;
+    }
 
     return !subcolumns || get(subcolumns, 'length') === 0;
   }),

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -277,6 +277,11 @@ module('Integration | basic', function() {
         );
       }
     });
+
+    test('it can be rendered with no columns', async function(assert) {
+      await generateTable(this, { rows: [], columns: [] });
+      assert.ok(true, 'The empty table rendered without incident');
+    });
   });
 
   componentModule('lifecycle', function() {


### PR DESCRIPTION
Fixes #735. 

When a table has no columns, the root `ColumnTreeNode`'s `isLeaf` property was mistakenly evaluated as `true` because it (the columnTreeNode) itself has no subcolumns. As a result, when `ensureWidthConstraint` is called and the `ColumnTree` iterates the columns to tally their width, the `meta` for the root node is incorrectly retrieved:

https://github.com/Addepar/ember-table/blob/024b2af4420ebc50fc01f8a2a1aa0d851f922b49/addon/-private/column-tree.js#L327-L337

There is no meta for the root `ColumnTreeNode`, though, so the attempt to `get(meta, '_width'`) throws: `Assertion Failed: Cannot call get with '_width' on an undefined object`.

The root column tree node should not ever be treated as a leaf, so this PR ensures that it won't be.