### PR TITLE
[DOCS] Miscellaneous small fixes

### DIFF
--- a/tests/dummy/app/pods/docs/guides/body/row-selection/controller.js
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/controller.js
@@ -100,15 +100,16 @@ export default class SimpleController extends Controller {
     ];
   }
 
-  @computed('selection')
+  @computed('demoSelection')
   get currentSelection() {
-    if (!this.selection || this.selection.length === 0) {
+    let selection = this.demoSelection;
+    if (!selection || selection.length === 0) {
       return 'Nothing selected';
     } else {
-      if (Array.isArray(this.selection)) {
-        return `Array: [${this.selection.map(row => row.A).join(',')}]`;
+      if (Array.isArray(selection)) {
+        return `Array: [${selection.map(row => row.A).join(',')}]`;
       } else {
-        let row = this.selection;
+        let row = selection;
         return `Single: ${row.A}`;
       }
     }

--- a/tests/dummy/app/pods/docs/guides/body/row-selection/template.md
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/template.md
@@ -99,8 +99,8 @@ itself.
           @checkboxSelectionMode={{checkboxSelectionMode}}
           @selectingChildrenSelectsParent={{selectingChildrenSelectsParent}}
 
-          @onSelect={{action (mut selection)}}
-          @selection={{selection}}
+          @onSelect={{action (mut demoSelection)}}
+          @selection={{demoSelection}}
         />
       </EmberTable>
     </div>

--- a/tests/dummy/app/pods/docs/guides/body/rows-and-trees/template.md
+++ b/tests/dummy/app/pods/docs/guides/body/rows-and-trees/template.md
@@ -49,7 +49,7 @@ the table body.
 {{#docs-demo as |demo|}}
   {{#demo.example name="trees"}}
     {{! BEGIN-SNIPPET docs-example-tree-rows.hbs }}
-    <div class="py-2">
+    <div class="demo-options">
       <label>
         {{input type="checkbox" checked=treeEnabled}}
         Enable Tree
@@ -88,7 +88,7 @@ If you want to disable collapsing at a row level, you can pass
 {{#docs-demo as |demo|}}
   {{#demo.example name="collapse"}}
     {{! BEGIN-SNIPPET docs-example-rows-with-collapse.hbs }}
-    <div class="py-2">
+    <div class="demo-options">
       <label>
         {{input type="checkbox" checked=collapseEnabled}}
         Enable Collapse

--- a/tests/dummy/app/pods/docs/guides/header/columns/controller.js
+++ b/tests/dummy/app/pods/docs/guides/header/columns/controller.js
@@ -28,13 +28,13 @@ export default class ColumnsController extends Controller {
   @computed
   get columnsWithComponents() {
     return [
-      { heading: 'A', valuePath: 'A', component: 'custom-header', color: 'text-navy' },
-      { heading: 'B', valuePath: 'B', component: 'custom-header', color: 'text-blue' },
-      { heading: 'C', valuePath: 'C', component: 'custom-header', color: 'text-aqua' },
-      { heading: 'D', valuePath: 'D', component: 'custom-header', color: 'text-teal' },
-      { heading: 'E', valuePath: 'E', component: 'custom-header', color: 'text-orange' },
-      { heading: 'F', valuePath: 'F', component: 'custom-header', color: 'text-red' },
-      { heading: 'G', valuePath: 'G', component: 'custom-header', color: 'text-maroon' },
+      { heading: 'A', valuePath: 'A', component: 'custom-header', color: 'navy' },
+      { heading: 'B', valuePath: 'B', component: 'custom-header', color: 'blue' },
+      { heading: 'C', valuePath: 'C', component: 'custom-header', color: 'aqua' },
+      { heading: 'D', valuePath: 'D', component: 'custom-header', color: 'teal' },
+      { heading: 'E', valuePath: 'E', component: 'custom-header', color: 'orange' },
+      { heading: 'F', valuePath: 'F', component: 'custom-header', color: 'red' },
+      { heading: 'G', valuePath: 'G', component: 'custom-header', color: 'maroon' },
     ];
   }
   // END-SNIPPET

--- a/tests/dummy/app/pods/docs/guides/header/columns/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/columns/template.md
@@ -107,15 +107,15 @@ using the `enableResize` and `enableReorder` flags. You can also change the
   {{#demo.example name="column-resize-reorder"}}
     {{! BEGIN-SNIPPET docs-example-column-resize-reorder.hbs }}
     <div class='demo-options'>
-      <label class='demo-option'>
+      <label>
         {{input type="checkbox" checked=resizeEnabled}}
         Enable Resizing
       </label>
-      <label class='demo-option'>
+      <label>
         {{input type="checkbox" checked=reorderEnabled}}
         Enable Reordering
       </label>
-      <label class='demo-option'>
+      <label>
         {{input type="checkbox" checked=resizeModeFluid}}
         Resize Mode Fluid
       </label>
@@ -164,7 +164,7 @@ reorder has occured.
   {{#demo.example name="resize-reorder-actions"}}
     {{! BEGIN-SNIPPET docs-example-resize-reorder-actions.hbs }}
     <p>Resized {{resizeCount}} times</p>
-    <p>Reorder {{reorderCount}} times</p>
+    <p>Reordered {{reorderCount}} times</p>
 
     <div class="demo-container small">
       <EmberTable as |t|>

--- a/tests/dummy/app/pods/docs/guides/header/fixed-columns/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/fixed-columns/template.md
@@ -25,7 +25,7 @@ parent's value instead.
 ## Multiple Fixed Columns and Ordering
 
 Multiple columns may be fixed to either side of the table. Fixed columns _must_
-be place contiguously at the start or end of the `columns` array. If columns
+be placed contiguously at the start or end of the `columns` array. If columns
 are marked as fixed and are out of order, Ember Table will sort the columns
 array directly to fix the ordering.
 

--- a/tests/dummy/app/pods/docs/guides/header/size-constraints/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/size-constraints/template.md
@@ -30,25 +30,27 @@ override the min/max widths provided by columns.
 {{#docs-demo as |demo|}}
   {{#demo.example}}
     {{! BEGIN-SNIPPET docs-example-header-size-constraint.hbs }}
-    <label class="pr-4">
-      eq-container
-      {{radio-button name='width-constraint' value='eq-container' groupValue=widthConstraint}}
-    </label>
+    <div class="demo-options">
+      <label>
+        eq-container
+        {{radio-button name='width-constraint' value='eq-container' groupValue=widthConstraint}}
+      </label>
 
-    <label class="pr-4">
-      gte-container
-      {{radio-button name='width-constraint' value='gte-container' groupValue=widthConstraint}}
-    </label>
+      <label>
+        gte-container
+        {{radio-button name='width-constraint' value='gte-container' groupValue=widthConstraint}}
+      </label>
 
-    <label class="pr-4">
-      lte-container
-      {{radio-button name='width-constraint' value='lte-container' groupValue=widthConstraint}}
-    </label>
+      <label>
+        lte-container
+        {{radio-button name='width-constraint' value='lte-container' groupValue=widthConstraint}}
+      </label>
 
-    <label>
-      none
-      {{radio-button name='width-constraint' value='none' groupValue=widthConstraint}}
-    </label>
+      <label>
+        none
+        {{radio-button name='width-constraint' value='none' groupValue=widthConstraint}}
+      </label>
+    </div>
 
     <div class="resize-container">
       <EmberTable as |t|>
@@ -81,20 +83,22 @@ constraint. The options are:
 {{#docs-demo as |demo|}}
   {{#demo.example name='docs-example-header-fill-mode'}}
     {{! BEGIN-SNIPPET docs-example-header-fill-mode.hbs }}
-    <label class="pr-4">
-      equal-column
-      {{radio-button name='fill-mode' value='equal-column' groupValue=fillMode}}
-    </label>
+    <div class="demo-options">
+      <label>
+        equal-column
+        {{radio-button name='fill-mode' value='equal-column' groupValue=fillMode}}
+      </label>
 
-    <label class="pr-4">
-      first-column
-      {{radio-button name='fill-mode' value='first-column' groupValue=fillMode}}
-    </label>
+      <label>
+        first-column
+        {{radio-button name='fill-mode' value='first-column' groupValue=fillMode}}
+      </label>
 
-    <label>
-      last-column
-      {{radio-button name='fill-mode' value='last-column' groupValue=fillMode}}
-    </label>
+      <label>
+        last-column
+        {{radio-button name='fill-mode' value='last-column' groupValue=fillMode}}
+      </label>
+    </div>
 
 
     <div class="resize-container">

--- a/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/template.hbs
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/empty-values/template.hbs
@@ -2,7 +2,7 @@
   {{#demo.example name='sorting-empty-values'}}
     {{! BEGIN-SNIPPET docs-example-sorting-empty-values.hbs }}
     <div class='demo-options'>
-      <label class='demo-option'>
+      <label>
         {{input type="checkbox" checked=sortEmptyLast}}
         Sort Empty Last
       </label>

--- a/tests/dummy/app/pods/docs/guides/header/sorting/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/template.md
@@ -124,6 +124,7 @@ This demo shows that in action:
   {{demo.snippet name='docs-example-2-state-sortings.hbs'}}
   {{demo.snippet label='component.js' name='docs-example-2-state-sortings.js'}}
 {{/docs-demo}}
+
 ## Sorting empty values
 
 Empty values can be treated differently depending on the needs by using the `sortEmptyLast` option.

--- a/tests/dummy/app/pods/docs/guides/main/table-customization/template.md
+++ b/tests/dummy/app/pods/docs/guides/main/table-customization/template.md
@@ -50,12 +50,12 @@ components:
   {{#demo.example}}
     {{! BEGIN-SNIPPET table-customization-example-sorting.hbs }}
     <div class='demo-options'>
-      <label class='demo-option'>
+      <label>
         <input type='checkbox' checked={{showSortIndicator}} onclick={{action (mut showSortIndicator) (not showSortIndicator)}}>
         Show Sort Indicator
         <span class='small'>(Click header to sort)</span>
       </label>
-      <label class='demo-option'>
+      <label>
         <input type='checkbox' checked={{showResizeHandle}} onclick={{action (mut showResizeHandle) (not showResizeHandle)}}>
         Show Resize Handle <span class='small'>(Only appears on hover)</span>
       </label>

--- a/tests/dummy/app/styles/tables.scss
+++ b/tests/dummy/app/styles/tables.scss
@@ -2,6 +2,8 @@
   & > * + * {
     padding-left: 2em;
   }
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
 }
 
 .demo-current-selection {


### PR DESCRIPTION
Remove undefined `py-2` and `pr-4` CSS classes (vestiges from when tailwind
was included in the build from addon-docs).
Consolidate example options to use `demo-options` class wherever possible.
Remove unneeded `demo-option` class.

Fix the 'color' property on the columns in the custom-header example so that
the correct bg-color CSS classes are applied.

Use a separate selection property `demoSelection` for the last demo on the
'row selection' page. When the `selection` property was shared amongst all
the demos on the page, it was possible to select a row in one of the demos
that didn't exist in the later ones, and would cause an error.

Fix typos.