### PR TITLE
move addon to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-getowner-polyfill": "^2.2.0",
     "ember-legacy-class-shim": "^1.0.0",
     "ember-raf-scheduler": "^0.1.0",
+    "ember-classy-page-object": "^0.5.0",
     "ember-test-selectors": "^0.3.9",
     "ember-useragent": "^0.6.0",
     "hammerjs": "^2.0.8"
@@ -55,7 +56,6 @@
     "ember-a11y-testing": "^0.5.0",
     "ember-ajax": "^4.0.2",
     "ember-angle-bracket-invocation-polyfill": "^1.3.1",
-    "ember-classy-page-object": "^0.5.0",
     "ember-cli": "~3.1.4",
     "ember-cli-addon-docs": "^0.6.13",
     "ember-cli-addon-docs-yuidoc": "^0.2.1",


### PR DESCRIPTION
Fix #741.
Required so consuming apps can import the helper.