### PR TITLE
some backwards-compatible closure action usage (#614)

### DIFF
--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -8,6 +8,7 @@ import { computed } from '@ember/object';
 import { gt, readOnly } from '@ember/object/computed';
 
 import { scheduler, Token } from 'ember-raf-scheduler';
+import { SUPPORTS_CLOSURE_ACTIONS } from 'ember-compatibility-helpers';
 
 import { getOrCreate } from './meta-cache';
 import { objectAt, move, splice } from './utils/array';
@@ -860,7 +861,13 @@ export default EmberObject.extend({
 
     this.container.classList.remove('is-reordering');
 
-    this.sendAction('onReorder', get(node, 'column'), get(closestColumn, 'column'));
+    if (SUPPORTS_CLOSURE_ACTIONS) {
+      if (typeof this.onReorder === 'function') {
+        this.onReorder(get(node, 'column'), get(closestColumn, 'column'));
+      }
+    } else {
+      this.sendAction('onReorder', get(node, 'column'), get(closestColumn, 'column'));
+    }
   },
 
   startResize(node, clientX) {

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -205,6 +205,7 @@ export default Component.extend({
     this.columnMetaCache = new Map();
 
     this.columnTree = ColumnTree.create({
+      onReorder: typeof this.onReorder === 'function' ? this.onReorder.bind(this) : null,
       sendAction: this.sendAction.bind(this),
       columnMetaCache: this.columnMetaCache,
       containerWidthAdjustment: this.containerWidthAdjustment,

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -1,7 +1,6 @@
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import { generateColumns, generateRows } from 'dummy/utils/generators';
-import { SUPPORTS_CLOSURE_ACTIONS } from 'ember-compatibility-helpers';
 
 // reexport for use in tests
 export { generateColumns, generateRows };
@@ -25,7 +24,7 @@ const fullTable = hbs`
 
 
         onUpdateSorts="onUpdateSorts"
-        onReorder=${SUPPORTS_CLOSURE_ACTIONS ? 'onReorder' : '"onReorder"'}
+        onReorder=(if supportsClosureActions onReorder "onReorder")
         onResize="onResize"
 
         as |h|

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -1,6 +1,7 @@
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import { generateColumns, generateRows } from 'dummy/utils/generators';
+import { SUPPORTS_CLOSURE_ACTIONS } from 'ember-compatibility-helpers';
 
 // reexport for use in tests
 export { generateColumns, generateRows };
@@ -24,7 +25,7 @@ const fullTable = hbs`
 
 
         onUpdateSorts="onUpdateSorts"
-        onReorder=onReorder
+        onReorder=${SUPPORTS_CLOSURE_ACTIONS ? 'onReorder' : '"onReorder"'}
         onResize="onResize"
 
         as |h|

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -24,7 +24,7 @@ const fullTable = hbs`
 
 
         onUpdateSorts="onUpdateSorts"
-        onReorder="onReorder"
+        onReorder=onReorder
         onResize="onResize"
 
         as |h|

--- a/tests/integration/components/headers/reorder-test.js
+++ b/tests/integration/components/headers/reorder-test.js
@@ -66,7 +66,7 @@ module('Integration | headers | reorder', function() {
         assert.equal(insertedAfter.name, 'B', 'new column index is correct');
       };
       if (SUPPORTS_CLOSURE_ACTIONS) {
-        await generateTable(this, { onReorder });
+        await generateTable(this, { onReorder, supportsClosureActions: SUPPORTS_CLOSURE_ACTIONS });
       } else {
         this.on('onReorder', onReorder);
         await generateTable(this);

--- a/tests/integration/components/headers/reorder-test.js
+++ b/tests/integration/components/headers/reorder-test.js
@@ -10,6 +10,8 @@ import { getScale } from 'ember-table/test-support/helpers/element';
 import TablePage from 'ember-table/test-support/pages/ember-table';
 import { toBase26 } from 'dummy/utils/base-26';
 
+import { gte } from 'ember-compatibility-helpers';
+
 const table = new TablePage();
 
 export async function scrollToEdge(targetElement, edgeOffset, direction) {
@@ -58,13 +60,17 @@ module('Integration | headers | reorder', function() {
       assert.equal(table.headers.objectAt(0).text.trim(), 'A', 'First column is swapped forward');
     });
 
-    test('calls the closure action onReorder', async function(assert) {
+    test('calls the closure action onReorder or sendAction given the ember version', async function(assert) {
       let onReorder = function(insertedColumn, insertedAfter) {
         assert.equal(insertedColumn.name, 'A', 'old column index is correct');
         assert.equal(insertedAfter.name, 'B', 'new column index is correct');
       };
-
-      await generateTable(this, { onReorder });
+      if (gte('1.13')) {
+        await generateTable(this, { onReorder });
+      } else {
+        this.on('onReorder', onReorder);
+        await generateTable(this);
+      }
       await table.headers.objectAt(0).reorderBy(1);
     });
 

--- a/tests/integration/components/headers/reorder-test.js
+++ b/tests/integration/components/headers/reorder-test.js
@@ -58,13 +58,13 @@ module('Integration | headers | reorder', function() {
       assert.equal(table.headers.objectAt(0).text.trim(), 'A', 'First column is swapped forward');
     });
 
-    test('column reorder action is sent up to controller', async function(assert) {
-      this.on('onReorder', function(insertedColumn, insertedAfter) {
+    test('calls the closure action onReorder', async function(assert) {
+      let onReorder = function(insertedColumn, insertedAfter) {
         assert.equal(insertedColumn.name, 'A', 'old column index is correct');
         assert.equal(insertedAfter.name, 'B', 'new column index is correct');
-      });
+      };
 
-      await generateTable(this);
+      await generateTable(this, { onReorder });
       await table.headers.objectAt(0).reorderBy(1);
     });
 

--- a/tests/integration/components/headers/reorder-test.js
+++ b/tests/integration/components/headers/reorder-test.js
@@ -10,7 +10,7 @@ import { getScale } from 'ember-table/test-support/helpers/element';
 import TablePage from 'ember-table/test-support/pages/ember-table';
 import { toBase26 } from 'dummy/utils/base-26';
 
-import { gte } from 'ember-compatibility-helpers';
+import { SUPPORTS_CLOSURE_ACTIONS } from 'ember-compatibility-helpers';
 
 const table = new TablePage();
 
@@ -65,7 +65,7 @@ module('Integration | headers | reorder', function() {
         assert.equal(insertedColumn.name, 'A', 'old column index is correct');
         assert.equal(insertedAfter.name, 'B', 'new column index is correct');
       };
-      if (gte('1.13')) {
+      if (SUPPORTS_CLOSURE_ACTIONS) {
         await generateTable(this, { onReorder });
       } else {
         this.on('onReorder', onReorder);


### PR DESCRIPTION
start to fix #614.
The way I safely check for the action feels repetitive so am open to
better approaches.
I noticed 2 forks of ember-table solve this so I think it makes sense to add backwards compatibility  into the addon. I followed Chris's [comment](https://github.com/Addepar/ember-table/issues/614#issuecomment-421419454).