### PR TITLE
[BUG] Fix cases where manual selection includes unrendered or nonexistent rows

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -368,6 +368,7 @@ function mapSelectionToMeta(tree, selection) {
         `[ember-table] The selection included a row that was not found in the table's rows. This should be avoided as it causes performance issues. The missing row is: ${JSON.stringify(
           item
         )}`,
+        false,
         {
           id: 'ember-table.selection-invalid',
         }

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -365,9 +365,7 @@ function mapSelectionToMeta(tree, selection) {
 
     if (!rowMeta && didSetupAllRowMeta) {
       warn(
-        `[ember-table] The selection included a row that was not found in the table's rows. This should be avoided as it causes performance issues. The missing row is: ${JSON.stringify(
-          item
-        )}`,
+        "[ember-table] The selection included a row that was not found in the table's rows. This should be avoided as it causes performance issues.",
         false,
         {
           id: 'ember-table.selection-invalid',

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "broccoli-string-replace": "^0.1.2",
     "css-element-queries": "^0.4.0",
     "ember-assign-polyfill": "^2.2.0",
+    "ember-classy-page-object": "^0.5.0",
     "ember-cli-babel": "^6.7.1",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
@@ -38,7 +39,6 @@
     "ember-getowner-polyfill": "^2.2.0",
     "ember-legacy-class-shim": "^1.0.0",
     "ember-raf-scheduler": "^0.1.0",
-    "ember-classy-page-object": "^0.5.0",
     "ember-test-selectors": "^0.3.9",
     "ember-useragent": "^0.6.0",
     "hammerjs": "^2.0.8"
@@ -70,6 +70,7 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
+    "ember-debug-handlers-polyfill": "^1.1.1",
     "ember-decorators": "^2.2.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",

--- a/tests/helpers/warn-handlers.js
+++ b/tests/helpers/warn-handlers.js
@@ -1,8 +1,15 @@
 import { registerWarnHandler } from '@ember/debug';
 
 let _registeredHandler = null;
+let _didRegisterWarnHandler = false;
 
 export function setup() {
+  if (_didRegisterWarnHandler) {
+    // We cannot unregister a warn handler, so make sure to only register the
+    // handler one time during all tests.
+    return;
+  }
+  _didRegisterWarnHandler = true;
   registerWarnHandler((message, options, next) => {
     if (_registeredHandler) {
       _registeredHandler(message, options);
@@ -17,7 +24,5 @@ export function registerTestWarnHandler(callback) {
 }
 
 export function teardown() {
-  if (_registeredHandler) {
-    _registeredHandler = null;
-  }
+  _registeredHandler = null;
 }

--- a/tests/helpers/warn-handlers.js
+++ b/tests/helpers/warn-handlers.js
@@ -1,0 +1,23 @@
+import { registerWarnHandler } from '@ember/debug';
+
+let _registeredHandler = null;
+
+export function setup() {
+  registerWarnHandler((message, options, next) => {
+    if (_registeredHandler) {
+      _registeredHandler(message, options);
+    } else {
+      next(message, options);
+    }
+  });
+}
+
+export function registerTestWarnHandler(callback) {
+  _registeredHandler = callback;
+}
+
+export function teardown() {
+  if (_registeredHandler) {
+    _registeredHandler = null;
+  }
+}

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -549,6 +549,7 @@ module('Integration | selection', () => {
         this.set('selection', rows.slice(-5));
 
         await table.rows.objectAt(0).checkbox.click();
+        assert.ok(table.rows.objectAt(0).isSelected, 'first row is selected');
         assert.ok(true, 'no error');
       });
 

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -8,6 +8,7 @@ import { generateRows } from 'dummy/utils/generators';
 import { A as emberA } from '@ember/array';
 import { run } from '@ember/runloop';
 import { scrollTo } from 'ember-native-dom-helpers';
+import { registerTestWarnHandler } from '../../helpers/warn-handlers';
 
 let table = new TablePage({
   validateSelected(...selectedIndexes) {
@@ -577,6 +578,9 @@ module('Integration | selection', () => {
       });
 
       test('Issue 747: Programmatic selection that includes a row not part of `rows`', async function(assert) {
+        let capturedWarningIds = [];
+        registerTestWarnHandler((_message, { id }) => capturedWarningIds.push(id));
+
         let rows = generateRows(1, 1);
         await generateTable(this, { rows });
 
@@ -588,6 +592,11 @@ module('Integration | selection', () => {
         await table.rows.objectAt(0).checkbox.click();
         assert.ok(true, 'after un-checking, no error');
         assert.ok(table.validateSelected(), 'No rows remain selected');
+
+        assert.ok(
+          capturedWarningIds.includes('ember-table.selection-invalid'),
+          'ember-table warns about invalid selection'
+        );
       });
     });
   });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,8 +3,21 @@ import config from '../config/environment';
 import registerRAFWaiter from 'ember-raf-scheduler/test-support/register-waiter';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import QUnit from 'qunit';
+import {
+  setup as setupWarnHandlers,
+  teardown as teardownWarnHandlers,
+} from './helpers/warn-handlers';
 
 registerRAFWaiter();
 setApplication(Application.create(config.APP));
+
+QUnit.testStart(() => {
+  setupWarnHandlers();
+});
+
+QUnit.testDone(() => {
+  teardownWarnHandlers();
+});
 
 start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5855,6 +5855,11 @@ ember-copy@^1.0.0:
     ember-cli-typescript "^2.0.1"
     ember-inflector "^3.0.0"
 
+ember-debug-handlers-polyfill@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.1.1.tgz#e9ae0a720271a834221179202367421b580002ef"
+  integrity sha512-lO7FBAqJjzbL+IjnWhVfQITypPOJmXdZngZR/Vdn513W4g/Q6Sjicao/mDzeDCb48Y70C4Facwk0LjdIpSZkRg==
+
 ember-decorators@^2.2.0:
   version "2.5.2"
   resolved "https://registry.npmjs.org/ember-decorators/-/ember-decorators-2.5.2.tgz#6d69c48d86df5f90c3d540486681c08a33256196"


### PR DESCRIPTION
Modify `CollapseTree`:
  * Add a function `setupAllRowMeta` that walks all the table's rows and
sets up a row meta for each one. This is called lazily in the case where
the table has a `selection` that includes some rows that don't yet have
rowMetas. This can happen if the selection includes rows that haven't yet
rendered. The rowMeta for a row is lazily created when it is rendered,
so rows that haven't yet rendered won't have a row meta. This usually is
not a problem because in normal user interaction with a table, the user will
only interact with rows that are rendered. However, it's possible to
programmatically set a selection, and in this case a row in the selection
may not yet have been rendered.
  * Add `mapSelectionToMeta` to contain the extra complexity of finding the row metas (and calling of `setupAllRowMeta` if needed) for a selection

It's also possible for a `selection` to contain a row without a corresponding
rowMeta if that row is not part of the table's rows. This is an invalid selection,
and this commit adds an Ember.warning for times when we detect such a case.

Fixes #747

Modifies one of the 747 test cases to assert that the warning is triggered
when ET encounters a selection with a row that is not part of the table. The added warning has the id `ember-table.selection-invalid`.

Adds a `warn-handlers` test helper file that provides a function `registerTestWarnHandler` that can be used to capture and assert on runtime `Ember.warn` warnings that happen during a test.