### PR TITLE
[TESTS] footer page object extends body page object

### DIFF
--- a/addon-test-support/pages/-private/ember-table-body.js
+++ b/addon-test-support/pages/-private/ember-table-body.js
@@ -1,9 +1,15 @@
-import { alias, triggerable, collection, hasClass, property } from 'ember-classy-page-object';
+import PageObject, {
+  alias,
+  triggerable,
+  collection,
+  hasClass,
+  property,
+} from 'ember-classy-page-object';
 import { findElement } from 'ember-classy-page-object/extend';
 
 import { click } from 'ember-native-dom-helpers';
 
-export default {
+export default PageObject.extend({
   scope: 'tbody',
 
   /**
@@ -80,4 +86,4 @@ export default {
   getCell(rowIndex, columnIndex) {
     return this.rows.objectAt(rowIndex).cells.objectAt(columnIndex);
   },
-};
+});

--- a/addon-test-support/pages/-private/ember-table-footer.js
+++ b/addon-test-support/pages/-private/ember-table-footer.js
@@ -1,25 +1,10 @@
 import { collection } from 'ember-classy-page-object';
-import { findElement } from 'ember-classy-page-object/extend';
+import EmberTableBody from './ember-table-body';
 
-export default {
+export default EmberTableBody.extend({
   scope: 'tfoot',
-
-  /**
-    Returns the number of rows in the footer.
-  */
-  get rowCount() {
-    return Number(findElement(this).getAttribute('data-test-row-count'));
-  },
 
   footers: collection({
     scope: 'td',
   }),
-
-  rows: collection({
-    scope: 'tr',
-
-    cells: collection({
-      scope: 'td',
-    }),
-  }),
-};
+});


### PR DESCRIPTION
The footer component extends the body component. This makes the
exported Test Page object able to operate on `table.footer` the same
way it does on `table.body`.