### PR TITLE
[CHORE] use vertical-collection @ ^1.0.0-beta.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@ember-decorators/babel-transforms": "^0.1.1",
-    "@html-next/vertical-collection": "https://github.com/html-next/vertical-collection.git#ca8cab8a3204f99cca1cf7661e4170ac41dc3a07",
+    "@html-next/vertical-collection": "^1.0.0-beta.14",
     "broccoli-string-replace": "^0.1.2",
     "css-element-queries": "^0.4.0",
     "ember-assign-polyfill": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,9 +1068,10 @@
   dependencies:
     "@glimmer/util" "^0.36.6"
 
-"@html-next/vertical-collection@https://github.com/html-next/vertical-collection.git#ca8cab8a3204f99cca1cf7661e4170ac41dc3a07":
-  version "1.0.0-beta.13"
-  resolved "https://github.com/html-next/vertical-collection.git#ca8cab8a3204f99cca1cf7661e4170ac41dc3a07"
+"@html-next/vertical-collection@^1.0.0-beta.14":
+  version "1.0.0-beta.14"
+  resolved "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-1.0.0-beta.14.tgz#114909d62ea6358a3401ca0d1d7547030e702530"
+  integrity sha512-HMmbYAe8UtEB9LFb7TtjsRvMgTYXMLNHJKd4z6QIpn0UAYJmXErIwJGIaK5Z7T3DYto4w10jD89HPhbCEyJG0Q==
   dependencies:
     babel-plugin-transform-es2015-block-scoping "^6.24.1"
     babel6-plugin-strip-class-callcheck "^6.0.0"


### PR DESCRIPTION
The latest beta release. Does not include any new functionality.

The comparison between the previous pinned sha and this version:

https://github.com/html-next/vertical-collection/compare/ca8cab8a3204f99cca1cf7661e4170ac41dc3a07...v1.0.0-beta.14
