### PR TITLE
Fix release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/Addepar/ember-table.svg?branch=master)](https://travis-ci.org/Addepar/ember-table)
-![GitHub release](https://img.shields.io/github/release/Addepar/ember-table)
+![npm version](https://img.shields.io/npm/v/ember-table)
 
 # Ember Table
 


### PR DESCRIPTION
Use the "npm version" badge since the "release" badge only shows github releases (not tags), and we don't always create an official github release when we tag a new version.