### PR TITLE
Fix column-reordering with Ember 3.13+

### DIFF
--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -791,7 +791,7 @@ export default EmberObject.extend({
 
     move(subcolumns, insertIndex, afterIndex);
 
-    notifyPropertyChange(parent, 'column.subcolumns.[]');
+    notifyPropertyChange(subcolumns, '[]');
   },
 
   startReorder(node, clientX) {

--- a/tests/dummy/app/utils/generators.js
+++ b/tests/dummy/app/utils/generators.js
@@ -2,6 +2,17 @@ import { A as emberA } from '@ember/array';
 import { toBase26 } from './base-26';
 import faker from 'faker';
 
+const DEFAULT_USE_EMBER_ARRAY = true;
+let useEmberArray = DEFAULT_USE_EMBER_ARRAY;
+
+export function configureTableGeneration({ useEmberArray: _useEmberArray }) {
+  useEmberArray = _useEmberArray;
+}
+
+export function resetTableGenerationConfig() {
+  useEmberArray = DEFAULT_USE_EMBER_ARRAY;
+}
+
 export function getRandomInt(max, min) {
   return faker.random.number({ min, max });
 }
@@ -43,7 +54,7 @@ export function generateRows(rowCount, depth, format, idPrefix = '') {
     arr.push(row);
   }
 
-  return emberA(arr);
+  return useEmberArray ? emberA(arr) : arr;
 }
 
 export function generateColumn(id, options) {
@@ -95,5 +106,5 @@ export function generateColumns(
     columns[columnCount - i - 1].isFixed = 'right';
   }
 
-  return emberA(columns);
+  return useEmberArray ? emberA(columns) : columns;
 }

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -1,9 +1,14 @@
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
-import { generateColumns, generateRows } from 'dummy/utils/generators';
+import {
+  configureTableGeneration,
+  generateColumns,
+  generateRows,
+  resetTableGenerationConfig,
+} from 'dummy/utils/generators';
 
 // reexport for use in tests
-export { generateColumns, generateRows };
+export { configureTableGeneration, resetTableGenerationConfig, generateColumns, generateRows };
 
 const fullTable = hbs`
   <div style="height: 500px;">

--- a/tests/helpers/module.js
+++ b/tests/helpers/module.js
@@ -13,3 +13,22 @@ export function componentModule(moduleName, callback) {
 
   callback();
 }
+
+export function parameterizedComponentModule(moduleName, parameters, callback) {
+  Object.keys(parameters).forEach(key => {
+    let { values, hooks } = parameters[key];
+
+    for (let value of values) {
+      moduleForComponent('ember-table', `${moduleName} > params {${key}: ${value}}`, {
+        integration: true,
+        beforeEach() {
+          hooks.beforeEach && hooks.beforeEach(value);
+        },
+        afterEach() {
+          hooks.afterEach && hooks.afterEach(value);
+        },
+      });
+      callback();
+    }
+  });
+}

--- a/tests/integration/components/headers/reorder-test.js
+++ b/tests/integration/components/headers/reorder-test.js
@@ -1,7 +1,12 @@
 import { module, test, skip } from 'ember-qunit';
 
-import { generateTable, generateColumns } from '../../../helpers/generate-table';
-import { componentModule } from '../../../helpers/module';
+import {
+  configureTableGeneration,
+  generateTable,
+  generateColumns,
+  resetTableGenerationConfig,
+} from '../../../helpers/generate-table';
+import { parameterizedComponentModule } from '../../../helpers/module';
 
 import { find, findAll, scrollTo } from 'ember-native-dom-helpers';
 import { mouseDown, mouseMove, mouseUp } from 'ember-table/test-support/helpers/mouse';
@@ -36,6 +41,20 @@ export async function scrollToEdge(targetElement, edgeOffset, direction) {
   await mouseUp(targetElement);
 }
 
+const USE_EMBER_ARRAY_PARAMETERS = {
+  useEmberArray: {
+    values: [true, false],
+    hooks: {
+      beforeEach(value) {
+        configureTableGeneration({ useEmberArray: value });
+      },
+      afterEach() {
+        resetTableGenerationConfig();
+      },
+    },
+  },
+};
+
 async function reorderToLeftEdge(column, edgeOffset = 0) {
   await scrollToEdge(column, edgeOffset, 'left', true);
 }
@@ -45,7 +64,7 @@ async function reorderToRightEdge(column, edgeOffset = 0) {
 }
 
 module('Integration | headers | reorder', function() {
-  componentModule('reordering', function() {
+  parameterizedComponentModule('reordering', USE_EMBER_ARRAY_PARAMETERS, function() {
     test('standard columns', async function(assert) {
       await generateTable(this);
 
@@ -181,7 +200,7 @@ module('Integration | headers | reorder', function() {
     });
   });
 
-  componentModule('fixed columns', function() {
+  parameterizedComponentModule('fixed columns', USE_EMBER_ARRAY_PARAMETERS, function() {
     test('left fixed column can be reordered with other left fixed columns', async function(assert) {
       await generateTable(this, { columnOptions: { fixedLeftCount: 2 } });
 
@@ -290,7 +309,7 @@ module('Integration | headers | reorder', function() {
     });
   });
 
-  componentModule('subheaders', function() {
+  parameterizedComponentModule('subheaders', USE_EMBER_ARRAY_PARAMETERS, function() {
     test('subheaders can be reordered', async function(assert) {
       await generateTable(this, { columnCount: 1, columnOptions: { subcolumnCount: 2 } });
 

--- a/tests/integration/components/headers/resize-test.js
+++ b/tests/integration/components/headers/resize-test.js
@@ -1,14 +1,33 @@
 import { module, test } from 'ember-qunit';
 
-import { generateTable, generateColumns } from '../../../helpers/generate-table';
-import { componentModule } from '../../../helpers/module';
+import {
+  configureTableGeneration,
+  resetTableGenerationConfig,
+  generateTable,
+  generateColumns,
+} from '../../../helpers/generate-table';
+import { componentModule, parameterizedComponentModule } from '../../../helpers/module';
 
 import TablePage from 'ember-table/test-support/pages/ember-table';
 
 const table = new TablePage();
 
+const USE_EMBER_ARRAY_PARAMETERS = {
+  useEmberArray: {
+    values: [true, false],
+    hooks: {
+      beforeEach(value) {
+        configureTableGeneration({ useEmberArray: value });
+      },
+      afterEach() {
+        resetTableGenerationConfig();
+      },
+    },
+  },
+};
+
 module('Integration | header | resize', function() {
-  componentModule('basic', function() {
+  parameterizedComponentModule('basic', USE_EMBER_ARRAY_PARAMETERS, function() {
     test('basic', async function(assert) {
       await generateTable(this);
 

--- a/tests/integration/components/row-test.js
+++ b/tests/integration/components/row-test.js
@@ -1,7 +1,11 @@
 import { module, test } from 'ember-qunit';
 
-import { generateTable } from '../../helpers/generate-table';
-import { componentModule } from '../../helpers/module';
+import {
+  generateTable,
+  configureTableGeneration,
+  resetTableGenerationConfig,
+} from '../../helpers/generate-table';
+import { parameterizedComponentModule } from '../../helpers/module';
 
 import TablePage from 'ember-table/test-support/pages/ember-table';
 import { collection, hasClass } from 'ember-classy-page-object';
@@ -14,8 +18,22 @@ let table = new TablePage({
   },
 });
 
+const USE_EMBER_ARRAY_PARAMETERS = {
+  useEmberArray: {
+    values: [true, false],
+    hooks: {
+      beforeEach(value) {
+        configureTableGeneration({ useEmberArray: value });
+      },
+      afterEach() {
+        resetTableGenerationConfig();
+      },
+    },
+  },
+};
+
 module('Integration | row', function() {
-  componentModule('basic', function() {
+  parameterizedComponentModule('basic', USE_EMBER_ARRAY_PARAMETERS, function() {
     test('can use a custom row component', async function(assert) {
       await generateTable(this, {
         rowComponent: 'custom-row',


### PR DESCRIPTION
Fixes #776.

The initial commit on this PR modifies several of the tests to be run with and without Columns and Rows as `Ember.A`-wrapped arrays.

In order to avoid duplicating many of the tests, I created a new test helper called `parameterizedComponentModule` that runs the `componentModule` with each possible value of the given parameter.

Also add additional helpers to the table-generation test utility to allow setting and unsetting a flag to instruct the internal row- and column-generation code to return `Ember.A`-wrapped or plain-JavaScript arrays. This seemed simpler and more comprehensive than threading through the arguments at every call of `generateTable`.

The ultimate fix, discovered via pairing with @pzuraq (thank you!) is to pass the key name `[]` rather than the full path `column.subcolumns.[]` to the `notifyPropertyChange` call that happens after moving a column. According to the Ember docs the argument here was always supposed to be a keyName — but it seems like the internal implementation may have been splitting that up in the past as though it were a dot-separated path. In Ember 3.13 that no longer seems to be the case, hence the need for this fix.

Rather than changing all test modules to use the parameterized helper to run w/ and w/out emberA-wrapped columns, I changed the ones that seemed most likely to have potential differing behavior, primairly the resize and reorder tests.

Feedback requested:
  * Does this change seem sensible? I can't think of any drawbacks to changing the notified property this way, but I don't fully follow the internals of property chains so I wonder if some intermittent observers will now fail to fire?
  * Does the `parameterizedModuleComponent` test helper make sense? 
  * Should more of the tests be changed to explicitly test both with and without `Ember.A`-wrapped row/col definitions?