### PR TITLE
Remove unused `_notifyCollection` property

### DIFF
--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -176,7 +176,6 @@ const ColumnTreeNode = EmberObject.extend({
       // watchers
       this._notifyMaxChildDepth = () => notifyPropertyChange(parent, 'maxChildDepth');
       this._notifyLeaves = () => notifyPropertyChange(parent, 'leaves');
-      this._notifyCollection = () => notifyPropertyChange(parent, '[]');
 
       addObserver(this, 'maxChildDepth', this._notifyMaxChildDepth);
       addObserver(this, 'leaves.[]', this._notifyLeaves);


### PR DESCRIPTION
This was introduced in #529 but never used either in that change
or since, so it seems like it can be safely removed.