### PR TITLE
Bump ember-test-selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-compatibility-helpers": "^1.2.0",
     "ember-getowner-polyfill": "^2.2.0",
     "ember-raf-scheduler": "^0.1.0",
-    "ember-test-selectors": "^0.3.9",
+    "ember-test-selectors": "^2.1.0",
     "ember-useragent": "^0.6.0",
     "hammerjs": "^2.0.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6251,13 +6251,13 @@ ember-svg-jar@^1.2.2:
     mkdirp "^0.5.1"
     path-posix "^1.0.0"
 
-ember-test-selectors@^0.3.9:
-  version "0.3.9"
-  resolved "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-0.3.9.tgz#dbe0a815cf04cad83c555f232cd69f50e95b342a"
-  integrity sha1-2+CoFc8Eytg8VV8jLNafUOlbNCo=
+ember-test-selectors@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-2.1.0.tgz#faebdf06702aaa0bc510d55eb721ce54d2e85793"
+  integrity sha512-c5HmvefmeABH8hg380TSNZiE9VAK1CBeXWrgyXy+IXHtsew4lZHHw7GnqCAqsakxwvmaMARbAKY9KfSAE91s1g==
   dependencies:
     ember-cli-babel "^6.8.2"
-    ember-cli-version-checker "^2.0.0"
+    ember-cli-version-checker "^3.1.2"
 
 ember-test-waiters@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
0.3.9 of Ember test selectors is very old and does not strip `data-test-` when using Babel 7. Bump to 2.1.0.

See: https://github.com/simplabs/ember-test-selectors/releases