### PR TITLE
Avoid "update prop already used in computation"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn install --no-lockfile --non-interactive
+  - yarn install --no-lockfile --non-interactive --ignore-engines
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 
+import { run } from '@ember/runloop';
 import { computed } from '@ember/object';
 import { observer } from '../../-private/utils/observer';
 import { bool, readOnly, or } from '@ember/object/computed';
@@ -234,7 +235,9 @@ export default Component.extend({
   */
   canSelect: bool('onSelect'),
 
-  'data-test-row-count': readOnly('wrappedRows.length'),
+  dataTestRowCount: null,
+
+  'data-test-row-count': readOnly('dataTestRowCount'),
 
   init() {
     this._super(...arguments);
@@ -297,7 +300,7 @@ export default Component.extend({
 
   /**
     Computed property which updates the CollapseTree and erases caches. This is
-    a computed for 1.11 compatibility, otherwise it would make sense to use
+    a computed for 1.12 compatibility, otherwise it would make sense to use
     lifecycle hooks instead.
   */
   wrappedRows: computed('rows', function() {
@@ -305,6 +308,11 @@ export default Component.extend({
 
     this.collapseTree.set('rowMetaCache', this.rowMetaCache);
     this.collapseTree.set('rows', rows);
+
+    run.schedule('actions', () => {
+      // eslint-disable-next-line ember-best-practices/no-side-effect-cp
+      this.set('dataTestRowCount', this.get('wrappedRows.length')); // eslint-disable-line ember/no-side-effects
+    });
 
     return this.collapseTree;
   }),


### PR DESCRIPTION
Ember internals use an observer for attribute bindings. In this case the observer timing causes a computation based on a value which is then updated by a side-effect-having CP.

Here avoid the observer interaction by instead setting the count itself as part of the computation side effects.

See:

* https://github.com/Addepar/ember-table/issues/795
* https://github.com/emberjs/ember.js/issues/18613

Fixes #795