### PR TITLE
Update test rowcount when collapse state changes

### DIFF
--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -11,7 +11,7 @@ import CollapseTree, { SELECT_MODE } from '../../-private/collapse-tree';
 import defaultTo from '../../-private/utils/default-to';
 
 import layout from './template';
-import { assert } from '@ember/debug';
+import { assert, runInDebug } from '@ember/debug';
 
 /**
   The table body component. This component manages the main bulk of the rows of
@@ -258,10 +258,22 @@ export default Component.extend({
 
     this._updateCollapseTree();
 
+    runInDebug(() => {
+      let scheduleUpdate = () => {
+        run.scheduleOnce('actions', this, this._updateDataTestRowCount);
+      };
+      this.collapseTree.addObserver('rows', scheduleUpdate);
+      this.collapseTree.addObserver('[]', scheduleUpdate);
+    });
+
     assert(
       'You must create an {{ember-thead}} with columns before creating an {{ember-tbody}}',
       !!this.get('unwrappedApi.columnTree')
     );
+  },
+
+  _updateDataTestRowCount() {
+    this.set('dataTestRowCount', this.get('collapseTree.length'));
   },
 
   // eslint-disable-next-line
@@ -308,11 +320,6 @@ export default Component.extend({
 
     this.collapseTree.set('rowMetaCache', this.rowMetaCache);
     this.collapseTree.set('rows', rows);
-
-    run.schedule('actions', () => {
-      // eslint-disable-next-line ember-best-practices/no-side-effect-cp
-      this.set('dataTestRowCount', this.get('wrappedRows.length')); // eslint-disable-line ember/no-side-effects
-    });
 
     return this.collapseTree;
   }),

--- a/tests/integration/components/tree-test.js
+++ b/tests/integration/components/tree-test.js
@@ -47,18 +47,21 @@ module('Integration | Tree', () => {
       await generateTable(this, { rowCount: 2, rowDepth: 2 });
 
       assert.equal(table.rows.length, 6, 'renders all rows');
+      assert.equal(table.body.rowCount, 6, 'total number of rows');
       assert.equal(table.getCell(0, 0).text, '0A', 'correct cell rendered');
       assert.equal(table.getCell(1, 0).text, '00A', 'correct cell rendered');
 
       // toggle a row
       await table.rows.objectAt(0).toggleCollapse();
       assert.equal(table.rows.length, 4, 'rows were removed');
+      assert.equal(table.body.rowCount, 4, 'total number of rows removed');
       assert.equal(table.getCell(0, 0).text, '0A', 'correct cell rendered');
       assert.equal(table.getCell(1, 0).text, '1A', 'correct cell rendered');
 
       // uncollapse
       await table.rows.objectAt(0).toggleCollapse();
       assert.equal(table.rows.length, 6, 'rows were removed');
+      assert.equal(table.body.rowCount, 6, 'total number of rows removed');
       assert.equal(table.getCell(0, 0).text, '0A', 'correct cell rendered');
       assert.equal(table.getCell(1, 0).text, '00A', 'correct cell rendered');
     });


### PR DESCRIPTION
Fixes https://github.com/Addepar/ember-table/issues/804

Based on and replaces https://github.com/Addepar/ember-table/pull/803

The test rowcount did not update when collapse is triggered. Here do that, but via an observer in non-production builds only.