### PR TITLE
Add horizontal scroll indicator feature

### DIFF
--- a/addon-test-support/pages/ember-table.js
+++ b/addon-test-support/pages/ember-table.js
@@ -48,6 +48,20 @@ export default PageObject.extend({
   },
 
   /**
+   * Returns the specified scroll indicator element
+   */
+  scrollIndicator(side = 'right') {
+    return findElement(this, `[data-test-ember-table-scroll-indicator="${side}"]`);
+  },
+
+  /**
+   * Returns whether the specified scroll indicator is currently visible
+   */
+  isScrollIndicatorRendered(side = 'right') {
+    return !!this.scrollIndicator(side);
+  },
+
+  /**
    * Selects a row in the body
    *
    * @param {number} index

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -60,7 +60,7 @@ export default Component.extend({
 
   _addListeners() {
     this._scrollElement = this._getScrollElement();
-    this._onScroll = this._updateIndicatorShow.bind(this);
+    this._onScroll = bind(this, this._updateIndicatorShow);
     this._scrollElement.addEventListener('scroll', this._onScroll);
     this._tableElement = this._getScrollElement().querySelector('table');
     this._resizeSensor = new ResizeSensor(

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -62,7 +62,7 @@ export default Component.extend({
     this._scrollElement = this._getScrollElement();
     this._onScroll = bind(this, this._updateIndicatorShow);
     this._scrollElement.addEventListener('scroll', this._onScroll);
-    this._tableElement = this._getScrollElement().querySelector('table');
+    this._tableElement = this._scrollElement.querySelector('table');
     this._resizeSensor = new ResizeSensor(
       this._tableElement,
       bind(this, this._updateIndicatorShow)

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -1,10 +1,10 @@
 import Component from '@ember/component';
 import { readOnly } from '@ember/object/computed';
+import { addObserver } from 'ember-table/-private/utils/observer';
 import layout from './template';
 
 export default Component.extend({
   layout,
-
   tagName: '',
 
   /**
@@ -16,5 +16,58 @@ export default Component.extend({
   */
   api: null,
 
+  scrollElement: null,
+  showLeft: true,
+  showRight: false,
+
+  columnTree: readOnly('api.columnTree'),
   enableScrollIndicators: readOnly('api.enableScrollIndicators'),
+  tableScrollId: readOnly('api.tableId'),
+
+  _addScrollListener() {
+    this._boundOnScroll = this._onScroll.bind(this);
+    this.get('scrollElement').addEventListener('scroll', this._boundOnScroll);
+  },
+
+  _removeScrollListener() {
+    this.get('scrollElement').removeEventListener('scroll', this._boundOnScroll);
+  },
+
+  _onScroll(e) {
+    this._updateIndicatorShow(e.target);
+  },
+
+  _updateIndicatorShow(scrollElement) {
+    let scrollRect = scrollElement.getBoundingClientRect();
+    let tableRect = scrollElement.querySelector('table').getBoundingClientRect();
+    let xDiff = scrollRect.x - tableRect.x;
+    let widthDiff = tableRect.width - scrollRect.width;
+    this.set('showLeft', xDiff !== 0);
+    this.set('showRight', xDiff !== widthDiff);
+  },
+
+  _updateScrollListener() {
+    if (this.get('enableScrollIndicators')) {
+      this._addScrollListener();
+    } else {
+      this._removeScrollListener();
+    }
+  },
+
+  init() {
+    this._super(...arguments);
+    let scrollElement = document.getElementById(this.get('tableScrollId'));
+    this.set('scrollElement', scrollElement);
+    this._updateIndicatorShow(scrollElement);
+    if (this.get('enableScrollIndicators')) {
+      this._addScrollListener();
+    }
+    addObserver(this, 'enableScrollIndicators', this._updateScrollListener);
+  },
+
+  willDestroy() {
+    if (this.get('enableScrollIndicators')) {
+      this._removeScrollListener();
+    }
+  },
 });

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -58,8 +58,9 @@ export default Component.extend({
   rightStyle: indicatorStyle('right'),
 
   _addListeners() {
+    this._scrollElement = this._getScrollElement();
     this._onScroll = this._updateIndicatorShow.bind(this);
-    this._getScrollElement().addEventListener('scroll', this._onScroll);
+    this._scrollElement.addEventListener('scroll', this._onScroll);
     this._tableElement = this._getScrollElement().querySelector('table');
     this._resizeSensor = new ResizeSensor(
       this._tableElement,
@@ -72,8 +73,12 @@ export default Component.extend({
   },
 
   _removeListeners() {
-    this._getScrollElement().removeEventListener('scroll', this._onScroll);
-    this._resizeSensor.detach(this._tableElement);
+    if (this._scrollElement) {
+      this._scrollElement.removeEventListener('scroll', this._onScroll);
+    }
+    if (this._resizeSensor) {
+      this._resizeSensor.detach(this._tableElement);
+    }
   },
 
   _setRects() {

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -60,8 +60,11 @@ export default Component.extend({
   _addListeners() {
     this._onScroll = this._updateIndicatorShow.bind(this);
     this._getScrollElement().addEventListener('scroll', this._onScroll);
-    this._scrollElement = this._getScrollElement();
-    this._resizeSensor = new ResizeSensor(this._scrollElement, bind(this, this._setRects));
+    this._tableElement = this._getScrollElement().querySelector('table');
+    this._resizeSensor = new ResizeSensor(
+      this._tableElement,
+      bind(this, this._updateIndicatorShow)
+    );
   },
 
   _getScrollElement() {
@@ -70,7 +73,7 @@ export default Component.extend({
 
   _removeListeners() {
     this._getScrollElement().removeEventListener('scroll', this._onScroll);
-    this._resizeSensor.detach(this._scrollElement);
+    this._resizeSensor.detach(this._tableElement);
   },
 
   _setRects() {

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -58,6 +58,7 @@ export default Component.extend({
   },
 
   _updateIndicatorShow(scrollElement) {
+    scrollElement = scrollElement || this.get('scrollElement');
     let scrollRect = scrollElement.getBoundingClientRect();
     let tableRect = scrollElement.querySelector('table').getBoundingClientRect();
     let xDiff = scrollRect.x - tableRect.x;
@@ -78,10 +79,11 @@ export default Component.extend({
     this._super(...arguments);
     let scrollElement = document.getElementById(this.get('tableScrollId'));
     this.set('scrollElement', scrollElement);
-    this._updateIndicatorShow(scrollElement);
+    this._updateIndicatorShow();
     if (this.get('enableScrollIndicators')) {
       this._addScrollListener();
     }
+    addObserver(this, 'columnTree.columns.@each.width', this._updateIndicatorShow);
     addObserver(this, 'enableScrollIndicators', this._updateScrollListener);
   },
 

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -18,7 +18,6 @@ export default Component.extend({
   */
   api: null,
 
-  scrollElement: null,
   showLeft: true,
   showRight: false,
 
@@ -46,25 +45,29 @@ export default Component.extend({
 
   _addScrollListener() {
     this._boundOnScroll = this._onScroll.bind(this);
-    this.get('scrollElement').addEventListener('scroll', this._boundOnScroll);
+    this._getScrollElement().addEventListener('scroll', this._boundOnScroll);
+  },
+
+  _getScrollElement() {
+    return document.getElementById(this.get('tableScrollId'));
   },
 
   _removeScrollListener() {
-    this.get('scrollElement').removeEventListener('scroll', this._boundOnScroll);
+    this._getScrollElement().removeEventListener('scroll', this._boundOnScroll);
   },
 
   _onScroll(e) {
     this._updateIndicatorShow(e.target);
   },
 
-  _updateIndicatorShow(scrollElement) {
-    scrollElement = scrollElement || this.get('scrollElement');
+  _updateIndicatorShow() {
+    let scrollElement = this._getScrollElement();
     let scrollRect = scrollElement.getBoundingClientRect();
     let tableRect = scrollElement.querySelector('table').getBoundingClientRect();
     let xDiff = scrollRect.x - tableRect.x;
     let widthDiff = tableRect.width - scrollRect.width;
     this.set('showLeft', xDiff !== 0);
-    this.set('showRight', xDiff !== widthDiff);
+    this.set('showRight', widthDiff > 0 && xDiff !== widthDiff);
   },
 
   _updateScrollListener() {
@@ -75,15 +78,13 @@ export default Component.extend({
     }
   },
 
-  init() {
+  didInsertElement() {
     this._super(...arguments);
-    let scrollElement = document.getElementById(this.get('tableScrollId'));
-    this.set('scrollElement', scrollElement);
     this._updateIndicatorShow();
     if (this.get('enableScrollIndicators')) {
       this._addScrollListener();
     }
-    addObserver(this, 'columnTree.columns.@each.width', this._updateIndicatorShow);
+    addObserver(this, 'columnTree.root.width', this._updateIndicatorShow);
     addObserver(this, 'enableScrollIndicators', this._updateScrollListener);
   },
 

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -8,6 +8,12 @@ import { isEmpty } from '@ember/utils';
 import { addObserver } from 'ember-table/-private/utils/observer';
 import layout from './template';
 
+/**
+   Computed property macro that builds the CSS styles (position, height)
+   for each scroll indicator element.
+
+   @param {string} side - which side we are computing styles for: `left` or `right`
+ */
 const indicatorStyle = side => {
   return computed(
     `columnTree.${side}FixedNodes.@each.width`,

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -1,0 +1,20 @@
+import Component from '@ember/component';
+import { readOnly } from '@ember/object/computed';
+import layout from './template';
+
+export default Component.extend({
+  layout,
+
+  tagName: '',
+
+  /**
+    The API object passed in by the table
+
+    @argument api
+    @required
+    @type object
+  */
+  api: null,
+
+  enableScrollIndicators: readOnly('api.enableScrollIndicators'),
+});

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -60,11 +60,17 @@ export default Component.extend({
   _addListeners() {
     this._onScroll = this._updateIndicatorShow.bind(this);
     this._getScrollElement().addEventListener('scroll', this._onScroll);
-    this._resizeSensor = new ResizeSensor(this._getScrollElement(), bind(this, this._setRects));
+    this._scrollElement = this._getScrollElement();
+    this._resizeSensor = new ResizeSensor(this._scrollElement, bind(this, this._setRects));
   },
 
   _getScrollElement() {
     return document.getElementById(this.get('tableScrollId'));
+  },
+
+  _removeListeners() {
+    this._getScrollElement().removeEventListener('scroll', this._onScroll);
+    this._resizeSensor.detach(this._scrollElement);
   },
 
   _setRects() {
@@ -73,15 +79,12 @@ export default Component.extend({
     let tableRect = scrollElement.querySelector('table').getBoundingClientRect();
     this.set('scrollRect', scrollRect);
     this.set('tableRect', tableRect);
-    return { scrollRect, tableRect };
-  },
-
-  _removeListeners() {
-    this._getScrollElement().removeEventListener('scroll', this._onScroll);
   },
 
   _updateIndicatorShow() {
-    let { scrollRect, tableRect } = this._setRects();
+    this._setRects();
+    let scrollRect = this.get('scrollRect');
+    let tableRect = this.get('tableRect');
     let xDiff = scrollRect.x - tableRect.x;
     let widthDiff = tableRect.width - scrollRect.width;
     this.set('showLeft', xDiff !== 0);

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -1,5 +1,7 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
+import { isEmpty } from '@ember/utils';
 import { addObserver } from 'ember-table/-private/utils/observer';
 import layout from './template';
 
@@ -23,6 +25,24 @@ export default Component.extend({
   columnTree: readOnly('api.columnTree'),
   enableScrollIndicators: readOnly('api.enableScrollIndicators'),
   tableScrollId: readOnly('api.tableId'),
+
+  leftStyle: computed('columnTree.leftFixedNodes.@each.width', function() {
+    let leftFixedNodes = this.get('columnTree.leftFixedNodes');
+    if (isEmpty(leftFixedNodes)) {
+      return null;
+    }
+    let leftFixedWidth = leftFixedNodes.reduce((acc, node) => acc + node.get('width'), 0);
+    return `left:${leftFixedWidth}px;`;
+  }),
+
+  rightStyle: computed('columnTree.rightFixedNodes.@each.width', function() {
+    let rightFixedNodes = this.get('columnTree.rightFixedNodes');
+    if (isEmpty(rightFixedNodes)) {
+      return null;
+    }
+    let rightFixedWidth = rightFixedNodes.reduce((acc, node) => acc + node.get('width'), 0);
+    return `right:${rightFixedWidth}px;`;
+  }),
 
   _addScrollListener() {
     this._boundOnScroll = this._onScroll.bind(this);

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
 import { bind } from '@ember/runloop';
+import { htmlSafe } from '@ember/template';
 import { isEmpty } from '@ember/utils';
 import { addObserver } from 'ember-table/-private/utils/observer';
 import layout from './template';
@@ -29,7 +30,7 @@ const indicatorStyle = side => {
         style.push(`height:${Math.min(scrollRect.height, tableRect.height)}px;`);
       }
 
-      return style.join('');
+      return htmlSafe(style.join(''));
     }
   );
 };

--- a/addon/components/-private/scroll-indicators/template.hbs
+++ b/addon/components/-private/scroll-indicators/template.hbs
@@ -1,0 +1,4 @@
+{{#if enableScrollIndicators}}
+  <div class="scroll-indicator scroll-indicator__left"></div>
+  <div class="scroll-indicator scroll-indicator__right"></div>
+{{/if}}

--- a/addon/components/-private/scroll-indicators/template.hbs
+++ b/addon/components/-private/scroll-indicators/template.hbs
@@ -1,8 +1,16 @@
 {{#if enableScrollIndicators}}
   {{#if showLeft}}
-    <div class="scroll-indicator scroll-indicator__left" style={{leftStyle}}></div>
+    <div
+      data-test-ember-table-scroll-indicator="left"
+      class="scroll-indicator scroll-indicator__left"
+      style={{leftStyle}}
+    ></div>
   {{/if}}
   {{#if showRight}}
-    <div class="scroll-indicator scroll-indicator__right" style={{rightStyle}}></div>
+    <div
+      data-test-ember-table-scroll-indicator="right"
+      class="scroll-indicator scroll-indicator__right"
+      style={{rightStyle}}
+    ></div>
   {{/if}}
 {{/if}}

--- a/addon/components/-private/scroll-indicators/template.hbs
+++ b/addon/components/-private/scroll-indicators/template.hbs
@@ -1,8 +1,8 @@
 {{#if enableScrollIndicators}}
   {{#if showLeft}}
-    <div class="scroll-indicator scroll-indicator__left"></div>
+    <div class="scroll-indicator scroll-indicator__left" style={{leftStyle}}></div>
   {{/if}}
   {{#if showRight}}
-    <div class="scroll-indicator scroll-indicator__right"></div>
+    <div class="scroll-indicator scroll-indicator__right" style={{rightStyle}}></div>
   {{/if}}
 {{/if}}

--- a/addon/components/-private/scroll-indicators/template.hbs
+++ b/addon/components/-private/scroll-indicators/template.hbs
@@ -1,4 +1,8 @@
 {{#if enableScrollIndicators}}
-  <div class="scroll-indicator scroll-indicator__left"></div>
-  <div class="scroll-indicator scroll-indicator__right"></div>
+  {{#if showLeft}}
+    <div class="scroll-indicator scroll-indicator__left"></div>
+  {{/if}}
+  {{#if showRight}}
+    <div class="scroll-indicator scroll-indicator__right"></div>
+  {{/if}}
 {{/if}}

--- a/addon/components/ember-table/component.js
+++ b/addon/components/ember-table/component.js
@@ -91,7 +91,7 @@ export default Component.extend({
     return {
       columns: null,
       registerColumnTree: this.registerColumnTree.bind(this),
-      tableId: this.elementId,
+      tableId: `${this.elementId}-overflow`,
     };
   }),
 

--- a/addon/components/ember-table/template.hbs
+++ b/addon/components/ember-table/template.hbs
@@ -1,8 +1,11 @@
-<table>
-  {{yield (hash
-    api=api
-    head=(component "ember-thead" api=api)
-    body=(component "ember-tbody" api=api)
-    foot=(component "ember-tfoot" api=api)
-  )}}
-</table>
+<div class="ember-table-overflow" id="{{elementId}}-overflow">
+  <table>
+    {{yield (hash
+      api=api
+      head=(component "ember-thead" api=api)
+      body=(component "ember-tbody" api=api)
+      foot=(component "ember-tfoot" api=api)
+    )}}
+  </table>
+</div>
+{{-ember-table-private/scroll-indicators api=api}}

--- a/addon/components/ember-table/template.hbs
+++ b/addon/components/ember-table/template.hbs
@@ -1,4 +1,8 @@
-<div class="ember-table-overflow" id="{{elementId}}-overflow">
+<div
+  data-test-ember-table-overflow
+  class="ember-table-overflow"
+  id="{{elementId}}-overflow"
+>
   <table>
     {{yield (hash
       api=api

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -221,9 +221,10 @@ export default Component.extend({
     this._updateApi();
     this._updateColumnTree();
 
+    addObserver(this, 'enableScrollIndicators', this._updateApi);
+    addObserver(this, 'reorderFunction', this._updateApi);
     addObserver(this, 'sorts', this._updateApi);
     addObserver(this, 'sortFunction', this._updateApi);
-    addObserver(this, 'reorderFunction', this._updateApi);
 
     addObserver(this, 'sorts', this._updateColumnTree);
     addObserver(this, 'columns.[]', this._onColumnsChange);
@@ -239,10 +240,11 @@ export default Component.extend({
 
   _updateApi() {
     this.set('unwrappedApi.columnTree', this.columnTree);
-    this.set('unwrappedApi.sorts', this.get('sorts'));
-    this.set('unwrappedApi.sortFunction', this.get('sortFunction'));
     this.set('unwrappedApi.compareFunction', this.get('compareFunction'));
+    this.set('unwrappedApi.enableScrollIndicators', this.get('enableScrollIndicators'));
+    this.set('unwrappedApi.sorts', this.get('sorts'));
     this.set('unwrappedApi.sortEmptyLast', this.get('sortEmptyLast'));
+    this.set('unwrappedApi.sortFunction', this.get('sortFunction'));
   },
 
   _updateColumnTree() {

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -104,6 +104,13 @@ export default Component.extend({
   enableResize: defaultTo(true),
 
   /**
+    Flag that toggles scroll indicator shadows
+    @argument enableScrollIndicator
+    @type boolean? (false)
+  */
+  enableScrollIndicator: defaultTo(false),
+
+  /**
     Sets which column resizing behavior to use. Possible values are `standard`
     (resizing a column pushes or pulls all other columns) and `fluid` (resizing a
     column subtracts width from neighboring columns).

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -105,10 +105,10 @@ export default Component.extend({
 
   /**
     Flag that toggles scroll indicator shadows
-    @argument enableScrollIndicator
+    @argument enableScrollIndicators
     @type boolean? (false)
   */
-  enableScrollIndicator: defaultTo(false),
+  enableScrollIndicators: defaultTo(false),
 
   /**
     Sets which column resizing behavior to use. Possible values are `standard`

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -271,7 +271,7 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    this._container = closest(this.element, '.ember-table');
+    this._container = closest(this.element, '.ember-table-overflow');
 
     this.columnTree.registerContainer(this._container);
 

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -100,7 +100,7 @@
     top: 0;
     width: 8px;
     height: 100%;
-    background: linear-gradient(to right, rgba(#333, .2), rgba(#333 ,0));
+    background: linear-gradient(to right, rgba(168, 168, 168, 0.4), rgba(168, 168, 168, 0));
 
     &__right {
       right: 0;

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,9 +1,14 @@
 .ember-table {
   position: relative;
-  overflow: auto;
-  max-height: 100%;
-  max-width: 100%;
+  height: 100%;
+  width: 100%;
   box-sizing: border-box;
+
+  .ember-table-overflow {
+    overflow: auto;
+    max-height: 100%;
+    max-width: 100%;
+  }
 
   table {
     border-spacing: 0;
@@ -87,6 +92,20 @@
     bottom: 0;
     z-index: 2;
     box-sizing: border-box;
+  }
+
+  .scroll-indicator {
+    position: absolute;
+    z-index: 5;
+    top: 0;
+    width: 8px;
+    height: 100%;
+    background: linear-gradient(to right, rgba(#333, .2), rgba(#333 ,0));
+
+    &__right {
+      right: 0;
+      transform: scaleX(-1);
+    }
   }
 
   &.et-unselectable {

--- a/app/components/-ember-table-private/scroll-indicators.js
+++ b/app/components/-ember-table-private/scroll-indicators.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-table/components/-private/scroll-indicators/component';

--- a/tests/dummy/app/pods/docs/guides/header/scroll-indicators/controller.js
+++ b/tests/dummy/app/pods/docs/guides/header/scroll-indicators/controller.js
@@ -1,0 +1,46 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
+
+import { generateRows } from '../../../../../utils/generators';
+
+export default Controller.extend({
+  // BEGIN-SNIPPET docs-example-scroll-indicators.js
+  columns: computed(function() {
+    return [
+      { name: 'A', valuePath: 'A' },
+      { name: 'B', valuePath: 'B' },
+      { name: 'C', valuePath: 'C' },
+      { name: 'D', valuePath: 'D' },
+      { name: 'E', valuePath: 'E' },
+      { name: 'F', valuePath: 'F' },
+      { name: 'G', valuePath: 'G' },
+      { name: 'H', valuePath: 'H' },
+      { name: 'I', valuePath: 'I' },
+      { name: 'J', valuePath: 'J' },
+      { name: 'K', valuePath: 'K' },
+    ];
+  }),
+  // END-SNIPPET
+
+  // BEGIN-SNIPPET docs-example-scroll-indicators-with-fixed.js
+  columnsWithFixed: computed(function() {
+    return [
+      { name: 'A', valuePath: 'A', isFixed: 'left' },
+      { name: 'B', valuePath: 'B' },
+      { name: 'C', valuePath: 'C' },
+      { name: 'D', valuePath: 'D' },
+      { name: 'E', valuePath: 'E' },
+      { name: 'F', valuePath: 'F' },
+      { name: 'G', valuePath: 'G' },
+      { name: 'H', valuePath: 'H' },
+      { name: 'I', valuePath: 'I' },
+      { name: 'J', valuePath: 'J' },
+      { name: 'K', valuePath: 'K', isFixed: 'right' },
+    ];
+  }),
+  // END-SNIPPET
+
+  rows: computed(function() {
+    return generateRows(100);
+  }),
+});

--- a/tests/dummy/app/pods/docs/guides/header/scroll-indicators/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/scroll-indicators/template.md
@@ -10,8 +10,10 @@ respective direction.
     <div class="demo-container">
       {{! BEGIN-SNIPPET docs-example-scroll-indicators.hbs }}
         <EmberTable as |t|>
-          <t.head @columns={{columns}} @enableScrollIndicators={{true}} />
-
+          <t.head
+            @columns={{columns}}
+            @enableScrollIndicators={{true}}
+          />
           <t.body @rows={{rows}} />
         </EmberTable>
       {{! END-SNIPPET }}
@@ -32,8 +34,10 @@ them when they are present or at the edges of the table when they are not.
     <div class="demo-container">
       {{! BEGIN-SNIPPET docs-example-scroll-indicators-with-fixed.hbs }}
         <EmberTable as |t|>
-          <t.head @columns={{columnsWithFixed}} @enableScrollIndicators={{true}} />
-
+          <t.head
+            @columns={{columnsWithFixed}}
+            @enableScrollIndicators={{true}}
+          />
           <t.body @rows={{rows}} />
         </EmberTable>
       {{! END-SNIPPET }}

--- a/tests/dummy/app/pods/docs/guides/header/scroll-indicators/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/scroll-indicators/template.md
@@ -1,0 +1,45 @@
+# Scroll Indicators
+
+Set the `enableScrollIndicators` argument to `true` to
+enable visual indicators that the table content can be scrolled left-to-right.
+These indicators will show/hide when there is content overflowing in their
+respective direction.
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='scroll-indicators'}}
+    <div class="demo-container small">
+      {{! BEGIN-SNIPPET docs-example-scroll-indicators.hbs }}
+        <EmberTable as |t|>
+          <t.head @columns={{columns}} @enableScrollIndicators={{true}} />
+
+          <t.body @rows={{rows}} />
+        </EmberTable>
+      {{! END-SNIPPET }}
+    </div>
+  {{/demo.example}}
+
+  {{demo.snippet name='docs-example-scroll-indicators.hbs'}}
+  {{demo.snippet name='docs-example-scroll-indicators.js' label='component.js'}}
+{{/docs-demo}}
+
+## Scroll Indicators with Fixed Columns
+
+Scroll indicators will respect fixed columns, appearing inside of
+them when they are present or at the edges of the table when they are not.
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='scroll-indicators-with-fixed'}}
+    <div class="demo-container small">
+      {{! BEGIN-SNIPPET docs-example-scroll-indicators-with-fixed.hbs }}
+        <EmberTable as |t|>
+          <t.head @columns={{columnsWithFixed}} @enableScrollIndicators={{true}} />
+
+          <t.body @rows={{rows}} />
+        </EmberTable>
+      {{! END-SNIPPET }}
+    </div>
+  {{/demo.example}}
+
+  {{demo.snippet name='docs-example-scroll-indicators-with-fixed.hbs'}}
+  {{demo.snippet name='docs-example-scroll-indicators-with-fixed.js' label='component.js'}}
+{{/docs-demo}}

--- a/tests/dummy/app/pods/docs/guides/header/scroll-indicators/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/scroll-indicators/template.md
@@ -7,7 +7,7 @@ respective direction.
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='scroll-indicators'}}
-    <div class="demo-container small">
+    <div class="demo-container">
       {{! BEGIN-SNIPPET docs-example-scroll-indicators.hbs }}
         <EmberTable as |t|>
           <t.head @columns={{columns}} @enableScrollIndicators={{true}} />
@@ -29,7 +29,7 @@ them when they are present or at the edges of the table when they are not.
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='scroll-indicators-with-fixed'}}
-    <div class="demo-container small">
+    <div class="demo-container">
       {{! BEGIN-SNIPPET docs-example-scroll-indicators-with-fixed.hbs }}
         <EmberTable as |t|>
           <t.head @columns={{columnsWithFixed}} @enableScrollIndicators={{true}} />

--- a/tests/dummy/app/pods/docs/template.hbs
+++ b/tests/dummy/app/pods/docs/template.hbs
@@ -21,6 +21,7 @@
     {{nav.item 'Fixed Columns' 'docs.guides.header.fixed-columns'}}
     {{nav.item 'Size Constraints' 'docs.guides.header.size-constraints'}}
     {{nav.item 'Sorting' 'docs.guides.header.sorting'}}
+    {{nav.item 'Scroll Indicators' 'docs.guides.header.scroll-indicators'}}
 
     {{nav.section 'Body'}}
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -26,7 +26,7 @@ Router.map(function() {
         this.route('fixed-columns');
         this.route('size-constraints');
         this.route('sorting');
-        this.route('actions');
+        this.route('scroll-indicators');
       });
 
       this.route('body', function() {

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -18,15 +18,15 @@ const fullTable = hbs`
 
         columns=columns
         containerWidthAdjustment=containerWidthAdjustment
+        enableReorder=enableReorder
+        enableResize=enableResize
+        enableScrollIndicators=enableScrollIndicators
+        fillColumnIndex=fillColumnIndex
+        fillMode=fillMode
+        resizeMode=resizeMode
         sorts=sorts
         sortEmptyLast=sortEmptyLast
-        resizeMode=resizeMode
-        fillMode=fillMode
-        enableResize=enableResize
-        enableReorder=enableReorder
         widthConstraint=widthConstraint
-        fillColumnIndex=fillColumnIndex
-
 
         onUpdateSorts="onUpdateSorts"
         onReorder="onReorder"

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -146,21 +146,21 @@ module('Integration | basic', function() {
       validateElements(tableContainerRect, findAll('tr > *:last-child'), 'right');
       validateElements(tableContainerRect, findAll('tfoot td'), 'bottom');
 
-      await scrollTo('[data-test-ember-table]', 10000, 0);
+      await scrollTo('[data-test-ember-table-overflow]', 10000, 0);
 
       validateElements(tableContainerRect, findAll('thead th'), 'top');
       validateElements(tableContainerRect, findAll('tr > *:first-child'), 'left');
       validateElements(tableContainerRect, findAll('tr > *:last-child'), 'right');
       validateElements(tableContainerRect, findAll('tfoot td'), 'bottom');
 
-      await scrollTo('[data-test-ember-table]', 10000, 10000);
+      await scrollTo('[data-test-ember-table-overflow]', 10000, 10000);
 
       validateElements(tableContainerRect, findAll('thead th'), 'top');
       validateElements(tableContainerRect, findAll('tr > *:first-child'), 'left');
       validateElements(tableContainerRect, findAll('tr > *:last-child'), 'right');
       validateElements(tableContainerRect, findAll('tfoot td'), 'bottom');
 
-      await scrollTo('[data-test-ember-table]', 0, 10000);
+      await scrollTo('[data-test-ember-table-overflow]', 0, 10000);
 
       validateElements(tableContainerRect, findAll('thead th'), 'top');
       validateElements(tableContainerRect, findAll('tr > *:first-child'), 'left');

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -79,7 +79,7 @@ module('Integration | basic', function() {
       );
 
       // scroll all the way down
-      await scrollTo('[data-test-ember-table]', 0, 10000);
+      await scrollTo('[data-test-ember-table-overflow]', 0, 10000);
 
       assert.notEqual(
         table.getCell(0, 0).text.trim(),

--- a/tests/integration/components/headers/reorder-test.js
+++ b/tests/integration/components/headers/reorder-test.js
@@ -104,13 +104,13 @@ module('Integration | headers | reorder', function() {
       let columnCount = 20;
       await generateTable(this, { columnCount });
 
-      let tableContainer = find('.ember-table');
+      let tableOverflowContainer = find('[data-test-ember-table-overflow]');
       let header = findAll('th')[columnCount - 1];
 
-      await scrollTo(tableContainer, 10000, 0);
+      await scrollTo(tableOverflowContainer, 10000, 0);
       await reorderToLeftEdge(header);
 
-      assert.equal(tableContainer.scrollLeft, 0, 'table scrolled back to the left');
+      assert.equal(tableOverflowContainer.scrollLeft, 0, 'table scrolled back to the left');
       assert.equal(table.headers.objectAt(0).text, toBase26(columnCount - 1), 'table scrolled');
     });
 
@@ -298,13 +298,13 @@ module('Integration | headers | reorder', function() {
         },
       });
 
-      let tableContainer = find('.ember-table');
+      let tableOverflowContainer = find('[data-test-ember-table-overflow]');
       let header = findAll('th')[columnCount - 1];
 
-      await scrollTo(tableContainer, 10000, 0);
+      await scrollTo(tableOverflowContainer, 10000, 0);
       await reorderToLeftEdge(header, columnWidth);
 
-      assert.equal(tableContainer.scrollLeft, 0, 'table scrolled back to the left');
+      assert.equal(tableOverflowContainer.scrollLeft, 0, 'table scrolled back to the left');
       assert.equal(table.headers.objectAt(1).text, toBase26(columnCount - 1), 'table scrolled');
     });
   });

--- a/tests/integration/components/headers/reorder-test.js
+++ b/tests/integration/components/headers/reorder-test.js
@@ -56,11 +56,11 @@ const USE_EMBER_ARRAY_PARAMETERS = {
 };
 
 async function reorderToLeftEdge(column, edgeOffset = 0) {
-  await scrollToEdge(column, edgeOffset, 'left', true);
+  await scrollToEdge(column, edgeOffset, 'left');
 }
 
 async function reorderToRightEdge(column, edgeOffset = 0) {
-  await scrollToEdge(column, edgeOffset, 'right', true);
+  await scrollToEdge(column, edgeOffset, 'right');
 }
 
 module('Integration | headers | reorder', function() {
@@ -91,12 +91,12 @@ module('Integration | headers | reorder', function() {
       let columnCount = 20;
       await generateTable(this, { columnCount });
 
-      let tableContainer = find('.ember-table');
+      let tableOverflowContainer = find('[data-test-ember-table-overflow]');
       let header = findAll('th')[0];
 
       await reorderToRightEdge(header);
 
-      assert.ok(tableContainer.scrollLeft > 0, 'table scrolled');
+      assert.ok(tableOverflowContainer.scrollLeft > 0, 'table scrolled');
       assert.equal(table.headers.objectAt(columnCount - 1).text, toBase26(0), 'table scrolled');
     });
 
@@ -277,12 +277,12 @@ module('Integration | headers | reorder', function() {
         },
       });
 
-      let tableContainer = find('.ember-table');
+      let tableOverflowContainer = find('[data-test-ember-table-overflow]');
       let header = findAll('th')[0];
 
       await reorderToRightEdge(header, columnWidth);
 
-      assert.ok(tableContainer.scrollLeft > 0, 'table scrolled');
+      assert.ok(tableOverflowContainer.scrollLeft > 0, 'table scrolled');
       assert.equal(table.headers.objectAt(columnCount - 2).text, toBase26(0), 'table scrolled');
     });
 

--- a/tests/integration/components/meta-test.js
+++ b/tests/integration/components/meta-test.js
@@ -79,7 +79,7 @@ module('Integration | meta', function() {
       assert.ok(table.headers.objectAt(0).text.match(/column/i), 'header meta correct');
       assert.ok(table.footers.objectAt(0).text.includes('column'), 'footer meta correct');
 
-      await scrollTo('[data-test-ember-table]', 0, 100000);
+      await scrollTo('[data-test-ember-table-overflow]', 0, 100000);
 
       assert.notOk(table.getCell(0, 0).text.includes('cell'), 'meta updated on scroll');
 
@@ -94,7 +94,7 @@ module('Integration | meta', function() {
       assert.ok(table.headers.objectAt(0).text.match(/column/i), 'header meta correct');
       assert.ok(table.footers.objectAt(0).text.includes('column'), 'footer meta correct');
 
-      await scrollTo('[data-test-ember-table]', 0, 0);
+      await scrollTo('[data-test-ember-table-overflow]', 0, 0);
 
       assert.ok(table.getCell(0, 0).text.includes('cell'), 'meta updated when scrolling back');
 

--- a/tests/integration/components/meta-test.js
+++ b/tests/integration/components/meta-test.js
@@ -201,10 +201,11 @@ module('Integration | meta', function() {
       await table.getCell(0, 0).click();
 
       // ensure we trigger property updates by scrolling around a bit
-      await scrollTo('[data-test-other-table]', 0, 10000);
-      await scrollTo('[data-test-other-table]', 0, 1000);
-      await scrollTo('[data-test-other-table]', 0, 100);
-      await scrollTo('[data-test-other-table]', 0, 0);
+      let scrollSelector = '[data-test-other-table] [data-test-ember-table-overflow]';
+      await scrollTo(scrollSelector, 0, 10000);
+      await scrollTo(scrollSelector, 0, 1000);
+      await scrollTo(scrollSelector, 0, 100);
+      await scrollTo(scrollSelector, 0, 0);
 
       // Main table was affected
       assert.ok(table.getCell(0, 0).text.includes('cell'), 'meta property set correctly');

--- a/tests/integration/components/scroll-indicators-test.js
+++ b/tests/integration/components/scroll-indicators-test.js
@@ -1,0 +1,122 @@
+import { module, test } from 'ember-qunit';
+
+import { generateTable } from '../../helpers/generate-table';
+import { componentModule } from '../../helpers/module';
+
+import { scrollTo } from 'ember-native-dom-helpers';
+
+import TablePage from 'ember-table/test-support/pages/ember-table';
+
+let table = new TablePage();
+
+module('Integration | scroll indicators', function() {
+  componentModule('rendering', function() {
+    test('it renders scroll indicators appropriately', async function(assert) {
+      this.set('enableScrollIndicators', true);
+
+      await generateTable(this, {
+        columnCount: 30,
+      });
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        true,
+        'right scroll indicator is initially shown'
+      );
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        false,
+        'left scroll indicator is not initially shown'
+      );
+
+      // scroll horizontally just a little bit
+      await scrollTo('[data-test-ember-table-overflow]', 100, 0);
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        true,
+        'right scroll indicator is shown during partial scroll'
+      );
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        true,
+        'left scroll indicator is shown during partial scroll'
+      );
+
+      // scroll horizontally to the end
+      await scrollTo('[data-test-ember-table-overflow]', 999999, 0);
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        false,
+        'right scroll indicator is not shown at end of scroll'
+      );
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        true,
+        'left scroll indicator is still shown at end of scroll'
+      );
+    });
+
+    test('scroll indicators respect fixed columns', async function(assert) {
+      this.set('enableScrollIndicators', true);
+
+      await generateTable(this, {
+        columnCount: 30,
+        columnOptions: {
+          fixedLeftCount: 1,
+          fixedRightCount: 1,
+          width: 100,
+        },
+      });
+
+      function isOffset(side, distance) {
+        let element = table.scrollIndicator(side);
+        return getComputedStyle(element)[side] === `${distance}px`;
+      }
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        true,
+        'right scroll indicator is initially shown'
+      );
+      assert.ok(isOffset('right', 100), 'right scroll indicator is offset');
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        false,
+        'left scroll indicator is not initially shown'
+      );
+
+      // scroll horizontally just a little bit
+      await scrollTo('[data-test-ember-table-overflow]', 100, 0);
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        true,
+        'right scroll indicator is shown during partial scroll'
+      );
+      assert.ok(isOffset('right', 100), 'right scroll indicator is offset');
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        true,
+        'left scroll indicator is shown during partial scroll'
+      );
+      assert.ok(isOffset('left', 100), 'left scroll indicator is offset');
+
+      // scroll horizontally to the end
+      await scrollTo('[data-test-ember-table-overflow]', 999999, 0);
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        false,
+        'right scroll indicator is not shown at end of scroll'
+      );
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        true,
+        'left scroll indicator is still shown at end of scroll'
+      );
+      assert.ok(isOffset('left', 100), 'left scroll indicator is offset');
+    });
+  });
+});

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -540,7 +540,7 @@ module('Integration | selection', () => {
         assert.ok(table.validateSelected(), 'No rows are selected');
 
         // scroll all the way down
-        await scrollTo('[data-test-ember-table]', 0, 10000);
+        await scrollTo('[data-test-ember-table-overflow]', 0, 10000);
 
         assert.ok(
           table.validateSelected(),

--- a/tests/unit/-private/table-sticky-polyfill-test.js
+++ b/tests/unit/-private/table-sticky-polyfill-test.js
@@ -19,35 +19,37 @@ function isNearTo(value, expected, epsilon = 0.01) {
 const standardTemplate = hbs`
   <div style="height: 500px;">
     <div class="ember-table">
-      <table>
-        <thead>
-          {{#each headerRows as |row|}}
-            <tr>
-              {{#each row as |item|}}
-                <th style="width: 100px; min-width: 100px; height: 50px;">{{item}}</th>
-              {{/each}}
-            </tr>
-          {{/each}}
-        </thead>
-        <tbody>
-          {{#each bodyRows as |row|}}
-            <tr>
-              {{#each row as |item|}}
-                <td style="width: 100px; min-width: 100px; height: 50px;">{{item}}</td>
-              {{/each}}
-            </tr>
-          {{/each}}
-        </tbody>
-        <tfoot>
-          {{#each footerRows as |row|}}
-            <tr>
-              {{#each row as |item|}}
-                <td style="width: 100px; min-width: 100px; height: 50px;">{{item}}</td>
-              {{/each}}
-            </tr>
-          {{/each}}
-        </tfoot>
-      </table>
+      <div class="ember-table-overflow">
+        <table>
+          <thead>
+            {{#each headerRows as |row|}}
+              <tr>
+                {{#each row as |item|}}
+                  <th style="width: 100px; min-width: 100px; height: 50px;">{{item}}</th>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </thead>
+          <tbody>
+            {{#each bodyRows as |row|}}
+              <tr>
+                {{#each row as |item|}}
+                  <td style="width: 100px; min-width: 100px; height: 50px;">{{item}}</td>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </tbody>
+          <tfoot>
+            {{#each footerRows as |row|}}
+              <tr>
+                {{#each row as |item|}}
+                  <td style="width: 100px; min-width: 100px; height: 50px;">{{item}}</td>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </tfoot>
+        </table>
+      </div>
     </div>
   </div>
 `;
@@ -174,7 +176,7 @@ componentModule('Unit | Private | TableStickyPolyfill', function() {
     setupTableStickyPolyfill(find('thead'));
     setupTableStickyPolyfill(find('tfoot'));
 
-    await scrollTo('.ember-table', 0, 500);
+    await scrollTo('.ember-table-overflow', 0, 500);
 
     verifyHeader(assert);
     verifyFooter(assert);
@@ -190,7 +192,7 @@ componentModule('Unit | Private | TableStickyPolyfill', function() {
     setupTableStickyPolyfill(find('thead'));
     setupTableStickyPolyfill(find('tfoot'));
 
-    await scrollTo('.ember-table', 0, 500);
+    await scrollTo('.ember-table-overflow', 0, 500);
 
     this.set('headerRows', constructMatrix(3, 5));
     this.set('footerRows', constructMatrix(3, 5));
@@ -211,7 +213,7 @@ componentModule('Unit | Private | TableStickyPolyfill', function() {
     setupTableStickyPolyfill(find('thead'));
     setupTableStickyPolyfill(find('tfoot'));
 
-    await scrollTo('.ember-table', 0, 500);
+    await scrollTo('.ember-table-overflow', 0, 500);
 
     this.set('headerRows', constructMatrix(5, 3));
     this.set('footerRows', constructMatrix(5, 3));
@@ -232,7 +234,7 @@ componentModule('Unit | Private | TableStickyPolyfill', function() {
     setupTableStickyPolyfill(find('thead'));
     setupTableStickyPolyfill(find('tfoot'));
 
-    await scrollTo('.ember-table', 0, 500);
+    await scrollTo('.ember-table-overflow', 0, 500);
 
     this.set('headerRows', constructMatrix(3, 5));
     this.set('footerRows', constructMatrix(3, 5));
@@ -263,7 +265,7 @@ componentModule('Unit | Private | TableStickyPolyfill', function() {
 
     let firstCell = find('tfoot tr:first-child td:first-child');
     let lastCell = find('tfoot tr:last-child td:first-child');
-    let container = find('.ember-table');
+    let container = find('.ember-table-overflow');
 
     let firstCellRect = firstCell.getBoundingClientRect();
     let lastCellRect = lastCell.getBoundingClientRect();
@@ -289,7 +291,7 @@ componentModule('Unit | Private | TableStickyPolyfill', function() {
 
     assert.ok(lastCellRect.top > containerRect.bottom, 'last footer cell is out of view');
 
-    await scrollTo('.ember-table', 0, container.scrollHeight);
+    await scrollTo('.ember-table-overflow', 0, container.scrollHeight);
 
     // Recompute dimensions
     lastCellRect = lastCell.getBoundingClientRect();
@@ -317,7 +319,7 @@ componentModule('Unit | Private | TableStickyPolyfill', function() {
 
     let firstCell = find('thead tr:first-child th:first-child');
     let lastCell = find('thead tr:last-child th:first-child');
-    let container = find('.ember-table');
+    let container = find('.ember-table-overflow');
 
     let firstCellRect = firstCell.getBoundingClientRect();
     let lastCellRect = lastCell.getBoundingClientRect();
@@ -335,7 +337,7 @@ componentModule('Unit | Private | TableStickyPolyfill', function() {
     );
     assert.ok(lastCellRect.top > containerRect.bottom, 'last header cell is out of view');
 
-    await scrollTo('.ember-table', 0, container.scrollHeight);
+    await scrollTo('.ember-table-overflow', 0, container.scrollHeight);
 
     // recompute dimensions
     lastCellRect = lastCell.getBoundingClientRect();


### PR DESCRIPTION
Adds a new feature to optionally enable horizontal scroll indicator gradients on either side if there is scrollable overflow extending in that direction:

![scroll-indicators](https://user-images.githubusercontent.com/250934/81120774-5dcef080-8efb-11ea-8252-39b11e0e89f7.gif)

The scroll indicator gradients respect changes to the size of the ember-table container and table both, and they will render inside fixed columns if they are present. Includes documentation page demonstrating the feature and tests exercising the feature.