### PR TITLE
Use passed attributes to `EmberTable` for the table tag

### DIFF
--- a/addon/components/ember-table/template.hbs
+++ b/addon/components/ember-table/template.hbs
@@ -1,4 +1,4 @@
-<table>
+<table ...attributes>
   {{yield (hash
     api=api
     head=(component "ember-thead" api=api)


### PR DESCRIPTION
With the current layout one could not set a class to the `<table>` html element. By appending `...attributes` to that element with in this template one can 

```
<EmberTable class="table ...." title="An awesome table that supports native html attributes">
...
</EmberTable>
```

which would apply the class (and any other valid html attribute) to the table element.