### PR TITLE
Scroll indicator fixes

### DIFF
--- a/addon-test-support/pages/ember-table.js
+++ b/addon-test-support/pages/ember-table.js
@@ -41,6 +41,14 @@ export default PageObject.extend({
   },
 
   /**
+   * Gets the width of overflow scrollbar-y in pixels
+   */
+  get scrollbarWidth() {
+    let scrollContainer = findElement(this, '[data-test-ember-table-overflow]');
+    return scrollContainer.offsetWidth - scrollContainer.clientWidth;
+  },
+
+  /**
    * Returns the table container width.
    */
   get containerWidth() {

--- a/tests/integration/components/scroll-indicators-test.js
+++ b/tests/integration/components/scroll-indicators-test.js
@@ -118,5 +118,130 @@ module('Integration | scroll indicators', function() {
       );
       assert.ok(isOffset('left', 100), 'left scroll indicator is offset');
     });
+
+    test('right scroll indicators accounts for scrollbar when determining positioning', async function(assert) {
+      this.set('enableScrollIndicators', true);
+      await generateTable(this, {
+        columnCount: 30,
+        rowCount: 100, // add rows to get overflow-y
+        columnOptions: {
+          width: 100,
+        },
+      });
+
+      /**
+       * Use a threshold instead of direct equality
+       * based on the test environment the window scrollbar size will vary due to scale/zoom
+       */
+      function isOffsetAbove(side, minDistance) {
+        let element = table.scrollIndicator(side);
+        let calculatedDistance = Number(getComputedStyle(element)[side].replace('px', ''));
+        return calculatedDistance > minDistance;
+      }
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        true,
+        'right scroll indicator is initially shown'
+      );
+
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        false,
+        'left scroll indicator is not initially shown'
+      );
+
+      // a little scroll
+      await scrollTo('[data-test-ember-table-overflow]', 150, 0);
+
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        true,
+        'left scroll indicator is shown after scrolling'
+      );
+
+      assert.ok(
+        isOffsetAbove('right', 0),
+        'right scrollbar is offset by the width of the scrollbar'
+      );
+
+      // scroll to the end
+      await scrollTo('[data-test-ember-table-overflow]', 9999999, 0);
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        false,
+        'right scroll indicator is not shown at end of scroll'
+      );
+
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        true,
+        'left scroll indicator is shown at end of scroll'
+      );
+    });
+
+    test('right scroll indicator account for scrollbar in conjunction with frozen rows', async function(assert) {
+      this.set('enableScrollIndicators', true);
+      await generateTable(this, {
+        columnCount: 30,
+        rowCount: 357,
+        columnOptions: {
+          fixedLeftCount: 1,
+          fixedRightCount: 1,
+          width: 100,
+        },
+      });
+
+      /**
+       * Use a threshold instead of direct equality
+       * based on the test environment the window scrollbar size will vary due to scale/zoom
+       */
+      function isOffsetAbove(side, minDistance) {
+        let element = table.scrollIndicator(side);
+        let calculatedDistance = Number(getComputedStyle(element)[side].replace('px', ''));
+        return calculatedDistance > minDistance;
+      }
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        true,
+        'right scroll indicator is initially shown'
+      );
+
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        false,
+        'left scroll indicator is not initially shown'
+      );
+
+      // a little scroll
+      await scrollTo('[data-test-ember-table-overflow]', 150, 0);
+
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        true,
+        'left scroll indicator is shown after scrolling'
+      );
+
+      assert.ok(
+        isOffsetAbove('right', 100),
+        'right scrollbar is offset by the width of the scrollbar'
+      );
+
+      // scroll to the end
+      await scrollTo('[data-test-ember-table-overflow]', 9999999, 0);
+
+      assert.equal(
+        table.isScrollIndicatorRendered('right'),
+        false,
+        'right scroll indicator is not shown at end of scroll'
+      );
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        true,
+        'left scroll indicator is shown at end of scroll'
+      );
+    });
   });
 });


### PR DESCRIPTION
Updated some calculations to account for scrollbar offset.

There were some issues with the scrollbar-y causing the box shadow to be improperly placed on the outside of the table area. Since we're already getting the boundRects for the elements in play and using them in calculations, it's easy to calculate the scrollbar width and accommodate for it.

Additionally, the scrollbar caused the shadow to stay on the box even when scrolled all the way to the end since the scrollbar-y made it impossible to horizontally scroll the full pixels distance required to meet the criteria to switch it off.

Included 2 integration tests to cover relevant scrollbar cases with and without frozen rows