### PR TITLE
Add selectionMatchFunction option

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -64,16 +64,24 @@ export const TableRowMeta = EmberObject.extend({
     }
   ),
 
-  isGroupSelected: computed('_tree.selection.[]', '_parentMeta.isSelected', function() {
-    let rowValue = get(this, '_rowValue');
-    let selection = get(this, '_tree.selection');
+  isGroupSelected: computed(
+    '_tree.{selection.[],selectionMatchFunction}',
+    '_parentMeta.isSelected',
+    function() {
+      let rowValue = get(this, '_rowValue');
+      let selection = get(this, '_tree.selection');
+      let selectionMatchFunction = get(this, '_tree.selectionMatchFunction');
 
-    if (!selection || !isArray(selection)) {
-      return false;
+      if (!selection || !isArray(selection)) {
+        return false;
+      }
+
+      let isSelectionMatch = selectionMatchFunction
+        ? selection.filter(item => selectionMatchFunction(item, rowValue)).length > 0
+        : selection.includes(rowValue);
+      return isSelectionMatch || get(this, '_parentMeta.isGroupSelected');
     }
-
-    return selection.includes(rowValue) || get(this, '_parentMeta.isGroupSelected');
-  }),
+  ),
 
   canCollapse: computed(
     '_tree.{enableTree,enableCollapse}',

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -44,16 +44,25 @@ export const TableRowMeta = EmberObject.extend({
     },
   }),
 
-  isSelected: computed('_tree.selection.[]', '_parentMeta.isSelected', function() {
-    let rowValue = get(this, '_rowValue');
-    let selection = get(this, '_tree.selection');
+  // eslint-disable-next-line ember/use-brace-expansion
+  isSelected: computed(
+    '_tree.{selection.[],selectionMatchFunction}',
+    '_parentMeta.isSelected',
+    function() {
+      let rowValue = get(this, '_rowValue');
+      let selection = get(this, '_tree.selection');
+      let selectionMatchFunction = get(this, '_tree.selectionMatchFunction');
 
-    if (isArray(selection)) {
-      return this.get('isGroupSelected');
+      if (isArray(selection)) {
+        return this.get('isGroupSelected');
+      }
+
+      let isRowSelection = selectionMatchFunction
+        ? selectionMatchFunction(selection, rowValue)
+        : selection === rowValue;
+      return isRowSelection || get(this, '_parentMeta.isSelected');
     }
-
-    return selection === rowValue || get(this, '_parentMeta.isSelected');
-  }),
+  ),
 
   isGroupSelected: computed('_tree.selection.[]', '_parentMeta.isSelected', function() {
     let rowValue = get(this, '_rowValue');

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -95,6 +95,14 @@ export default Component.extend({
   selection: null,
 
   /**
+    A function that will override how selection is compared to row value.
+
+    @argument selectionMatchFunction
+    @type function?
+  */
+  selectionMatchFunction: null,
+
+  /**
     An action that is called when the row selection of the table changes.
     Will be called with either an array or individual row, depending on the
     checkboxSelectionMode.
@@ -282,6 +290,7 @@ export default Component.extend({
     'enableCollapse',
     'enableTree',
     'selection',
+    'selectionMatchFunction',
     'selectingChildrenSelectsParent',
     'onSelect',
 
@@ -294,6 +303,7 @@ export default Component.extend({
       this.collapseTree.set('enableCollapse', this.get('enableCollapse'));
       this.collapseTree.set('enableTree', this.get('enableTree'));
       this.collapseTree.set('selection', this.get('selection'));
+      this.collapseTree.set('selectionMatchFunction', this.get('selectionMatchFunction'));
       this.collapseTree.set(
         'selectingChildrenSelectsParent',
         this.get('selectingChildrenSelectsParent')

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -61,6 +61,7 @@ const fullTable = hbs`
         checkboxSelectionMode=checkboxSelectionMode
         rowSelectionMode=rowSelectionMode
         selection=selection
+        selectionMatchFunction=selectionMatchFunction
 
         as |b|
       }}
@@ -142,7 +143,6 @@ export function generateTableValues(
   for (let property in options) {
     testContext.set(property, options[property]);
   }
-
   testContext.set('rowComponent', rowComponent);
 
   columns = columns || generateColumns(columnCount, columnOptions);

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -245,6 +245,29 @@ module('Integration | selection', () => {
 
         assert.ok(table.validateSelected(0), 'Zoe is selected after external change');
       });
+
+      test('Rows are selected when selection is changed externally with selectionMatchFunction', async function(assert) {
+        let selection = emberA();
+        let selectionMatchFunction = function(a, b) {
+          if (!a || !b) {
+            return false;
+          }
+          return a.id === b.id;
+        };
+        let rows = [
+          { id: 1, name: 'Zoe', age: 34 },
+          { id: 2, name: 'Alex', age: 43 },
+          { id: 3, name: 'Liz', age: 25 },
+        ];
+
+        await generateTable(this, { rows, selection, selectionMatchFunction });
+
+        assert.ok(table.validateSelected(), 'rows are not selected');
+
+        run(() => selection.pushObject({ id: rows[0].id }));
+
+        assert.ok(table.validateSelected(0), 'Zoe is selected after external change');
+      });
     });
 
     componentModule('single', function() {
@@ -313,6 +336,46 @@ module('Integration | selection', () => {
         await generateTable(this, { rowSelectionMode: 'single' });
 
         await table.selectRow(0);
+      });
+
+      test('Row is selected when selection is changed externally', async function(assert) {
+        this.set('selection', null);
+        let rows = [{ name: 'Zoe', age: 34 }, { name: 'Alex', age: 43 }, { name: 'Liz', age: 25 }];
+
+        await generateTable(this, { rows, rowSelectionMode: 'single' });
+
+        assert.ok(table.validateSelected(), 'rows are not selected');
+
+        run(() => this.set('selection', rows[0]));
+
+        assert.ok(table.validateSelected(0), 'Zoe is selected after external change');
+      });
+
+      test('Row is selected when selection is changed externally with selectionMatchFunction', async function(assert) {
+        this.set('selection', null);
+        let selectionMatchFunction = function(a, b) {
+          if (!a || !b) {
+            return false;
+          }
+          return a.id === b.id;
+        };
+        let rows = [
+          { id: 1, name: 'Zoe', age: 34 },
+          { id: 2, name: 'Alex', age: 43 },
+          { id: 3, name: 'Liz', age: 25 },
+        ];
+
+        await generateTable(this, {
+          rows,
+          rowSelectionMode: 'single',
+          selectionMatchFunction,
+        });
+
+        assert.ok(table.validateSelected(), 'rows are not selected');
+
+        run(() => this.set('selection', { id: rows[0].id }));
+
+        assert.ok(table.validateSelected(0), 'Zoe is selected after external change');
       });
     });
 

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -503,7 +503,7 @@ module('Integration | selection', () => {
     });
 
     test('rows can be selected using selectionMatchFunction', async function(assert) {
-      this.set('selection', undefined);
+      let selection = emberA();
       let rows = [
         { id: '1', name: 'Zoe', age: 34 },
         { id: '2', name: 'Alex', age: 43 },
@@ -516,13 +516,13 @@ module('Integration | selection', () => {
         return a.id === b.id;
       };
 
-      await generateTable(this, { rows, selectionMatchFunction });
+      await generateTable(this, { rows, selection, selectionMatchFunction });
 
       assert.ok(table.validateSelected(), 'rows are not selected');
 
-      this.set('selection', { id: '2' });
+      run(() => selection.pushObject({ id: rows[1].id }));
 
-      assert.ok(table.validateSelected(1), 'Alex is selected after external change');
+      assert.ok(table.validateSelected(1), 'Alex is selected after selection change');
     });
   });
 

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -501,6 +501,29 @@ module('Integration | selection', () => {
 
       assert.ok(table.validateSelected(1, 2, 3), 'only children are selected');
     });
+
+    test('rows can be selected using selectionMatchFunction', async function(assert) {
+      this.set('selection', undefined);
+      let rows = [
+        { id: '1', name: 'Zoe', age: 34 },
+        { id: '2', name: 'Alex', age: 43 },
+        { id: '3', name: 'Liz', age: 25 },
+      ];
+      let selectionMatchFunction = function(a, b) {
+        if (!a || !b) {
+          return false;
+        }
+        return a.id === b.id;
+      };
+
+      await generateTable(this, { rows, selectionMatchFunction });
+
+      assert.ok(table.validateSelected(), 'rows are not selected');
+
+      this.set('selection', { id: '2' });
+
+      assert.ok(table.validateSelected(1), 'Alex is selected after external change');
+    });
   });
 
   module('occluded selection', function() {


### PR DESCRIPTION
This PR adds an optional `selectionMatchFunction` to the `ember-tbody` component. When set, this function will be used in place of `===` when checking to see if a row should be marked as selected.

Fixes #823 (at least offers a workaround)