### PR TITLE
Tweak Sass styles

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -33,11 +33,11 @@ $colors: (
 );
 
 @each $color-name, $color-value in $colors {
-  .bg-#{$color-name} {
+  .bg-#{"" + $color-name} {
     background-color: #{$color-value};
     color: white;
   }
-  .text-#{$color-name} {
+  .text-#{"" + $color-name} {
     color: #{$color-value};
   }
 }


### PR DESCRIPTION
After we have updated `ember-cli-sass` to `10`, the following warnings
started popping up:

```sh
WARNING: You probably don't mean to use the color value silver in interpolation here.
It may end up represented as silver, which will likely produce invalid CSS.
Always quote color names when using them as strings or map keys (for example, "silver").
If you really want to use the color value here, use '"" + $color-name'.
```

This change will get rid of the warnings without changing the output
CSS.