### PR TITLE
[3.0] [tests] Only run "ember test" in primary workflow job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn lint
 
       - name: Run Tests
-        run: yarn test
+        run: yarn test:ember
         env:
           CI: true
 


### PR DESCRIPTION
**Note**: Targets base of `3.0-beta` not `master`

PR #842 accidentally runs *all* ember tests via `ember try:each` in the primary workflow job. This 
fixes that to only run the current dependencies. The matricized job runs the ember-try scenarios.