### PR TITLE
Repair license file, correct metadata

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,7 @@
-Copyright © 2018 Addepar, Inc. All Rights Reserved.
+Copyright © 2017-2020 Addepar, Inc. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
 list of conditions and the following disclaimer.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "ember-addon"
   ],
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "author": "",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
The LICENSE.md file was corrupted during an Ember version update in:

* https://github.com/Addepar/ember-table/commit/48939919044baa2c71f360b1be13915c472360d9#diff-4673a3aba01813b595de187a7a6e9e63a3491d55821606fecd9f13a10c188a1d

Additionally the `package.json` has been out of date, claiming MIT license, since the original change to BSD-3 in:

* https://github.com/Addepar/ember-table/commit/e7ce9930fef36ffc32940ebf1d46fc76dcbe11bf#diff-4673a3aba01813b595de187a7a6e9e63a3491d55821606fecd9f13a10c188a1d

This corrects those errors, with re-approval from Addepar legal on 2021-01-10.

Fixes https://github.com/Addepar/ember-table/issues/836