### PR TITLE
Use scrollLeft to detect when scroll indicators should appear

### DIFF
--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -15,28 +15,24 @@ import layout from './template';
    @param {string} side - which side we are computing styles for: `left` or `right`
  */
 const indicatorStyle = side => {
-  return computed(
-    `columnTree.${side}FixedNodes.@each.width`,
-    'height',
-    function() {
-      let style = [];
+  return computed(`columnTree.${side}FixedNodes.@each.width`, 'height', function() {
+    let style = [];
 
-      // left/right position
-      let fixedNodes = this.get(`columnTree.${side}FixedNodes`);
-      if (!isEmpty(fixedNodes)) {
-        let fixedWidth = fixedNodes.reduce((acc, node) => acc + node.get('width'), 0);
-        style.push(`${side}:${fixedWidth}px;`);
-      }
-
-      // height
-      let height = this.get('height');
-      if (!isNone(height)) {
-        style.push(`height:${height}px;`);
-      }
-
-      return htmlSafe(style.join(''));
+    // left/right position
+    let fixedNodes = this.get(`columnTree.${side}FixedNodes`);
+    if (!isEmpty(fixedNodes)) {
+      let fixedWidth = fixedNodes.reduce((acc, node) => acc + node.get('width'), 0);
+      style.push(`${side}:${fixedWidth}px;`);
     }
-  );
+
+    // height
+    let height = this.get('height');
+    if (!isNone(height)) {
+      style.push(`height:${height}px;`);
+    }
+
+    return htmlSafe(style.join(''));
+  });
 };
 
 export default Component.extend({
@@ -68,10 +64,7 @@ export default Component.extend({
     this._onScroll = bind(this, this._updateIndicators);
     this._scrollElement.addEventListener('scroll', this._onScroll);
     this._tableElement = this._scrollElement.querySelector('table');
-    this._resizeSensor = new ResizeSensor(
-      this._tableElement,
-      bind(this, this._updateIndicators)
-    );
+    this._resizeSensor = new ResizeSensor(this._tableElement, bind(this, this._updateIndicators));
   },
 
   _getScrollElement() {

--- a/tests/integration/components/scroll-indicators-test.js
+++ b/tests/integration/components/scroll-indicators-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'ember-qunit';
 import { generateTable } from '../../helpers/generate-table';
 import { componentModule } from '../../helpers/module';
 
+import { findElement } from 'ember-classy-page-object/extend';
 import { scrollTo } from 'ember-native-dom-helpers';
 
 import TablePage from 'ember-table/test-support/pages/ember-table';
@@ -117,6 +118,29 @@ module('Integration | scroll indicators', function() {
         'left scroll indicator is still shown at end of scroll'
       );
       assert.ok(isOffset('left', 100), 'left scroll indicator is offset');
+    });
+
+    test('does not show left scroll indicator when table has negative left margin and user scrolls all the way to the left', async function(assert) {
+      this.set('enableScrollIndicators', true);
+
+      await generateTable(this, {
+        columnCount: 30,
+      });
+
+      let tableElement = await findElement(table, 'table');
+
+      // negative margin pushes the left edge of the table outside of overflow
+      tableElement.style.marginLeft = '-1px';
+
+      // scroll horizontally just a little bit and back to reset indicators
+      await scrollTo('[data-test-ember-table-overflow]', 1, 0);
+      await scrollTo('[data-test-ember-table-overflow]', 0, 0);
+
+      assert.equal(
+        table.isScrollIndicatorRendered('left'),
+        false,
+        'left scroll indicator is not shown'
+      );
     });
   });
 });


### PR DESCRIPTION
If the table element has a negative `margin-left` style, the left scroll indicator will always show, even when scrolled all the way to the left. This negative margin trick is commonly used in conjunction with `border-spacing` and an overflow element in order to eliminate leading whitespace in the leftmost column of a table (`border-spacing` cannot be overridden at a cell level).

By examining `scrollLeft` instead of the bounding box positions of the table & overflow elements, the same effect is achieved without making any assumptions about the relative positions of elements.