### PR TITLE
Fix vertical scroll indicator placement

### DIFF
--- a/addon-test-support/pages/ember-table.js
+++ b/addon-test-support/pages/ember-table.js
@@ -91,11 +91,16 @@ export default PageObject.extend({
     let footerCells = findElement(this, 'tfoot td', { multiple: true });
 
     if (footerCells.length > 0) {
-      let firstFooterCellRect = footerCells[0].getBoundingClientRect();
+      let footerCellY = footerCells[0].getBoundingClientRect().y;
+
       let overflow = this.overflow();
       let overflowRect = overflow.getBoundingClientRect();
       let scale = overflow.offsetHeight / overflowRect.height;
-      return scale * (overflowRect.height - (firstFooterCellRect.y - overflowRect.y));
+
+      return Math.min(
+        overflow.clientHeight - scale * (footerCellY - overflowRect.y),
+        overflow.clientHeight
+      );
     }
 
     return 0;

--- a/addon-test-support/pages/ember-table.js
+++ b/addon-test-support/pages/ember-table.js
@@ -85,6 +85,23 @@ export default PageObject.extend({
   },
 
   /**
+   * Returns the height of the visible portion of the footer
+   */
+  visibleFooterHeight() {
+    let footerCells = findElement(this, 'tfoot td', { multiple: true });
+
+    if (footerCells.length > 0) {
+      let firstFooterCellRect = footerCells[0].getBoundingClientRect();
+      let overflow = this.overflow();
+      let overflowRect = overflow.getBoundingClientRect();
+      let scale = overflow.offsetHeight / overflowRect.height;
+      return scale * (overflowRect.height - (firstFooterCellRect.y - overflowRect.y));
+    }
+
+    return 0;
+  },
+
+  /**
    * Selects a row in the body
    *
    * @param {number} index

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -208,8 +208,9 @@ export default Component.extend({
     let footerCell = table.querySelector('tfoot td');
     if (footerCell) {
       let footerCellY = footerCell.getBoundingClientRect().y;
-      let overflowY = el.getBoundingClientRect().y;
-      visibleFooterHeight = overflowHeight - (footerCellY - overflowY);
+      let overflowRect = el.getBoundingClientRect();
+      let scale = overflowHeight / overflowRect.height;
+      visibleFooterHeight = scale * (overflowRect.height - (footerCellY - overflowRect.y));
     }
 
     this.setProperties({

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -65,6 +65,7 @@ const verticalIndicatorStyle = location => {
     'headerHeight',
     'scrollbarHeight',
     'visibleFooterHeight',
+    'footerRatio',
     function() {
       let style = [];
       let offset = 0;
@@ -76,13 +77,13 @@ const verticalIndicatorStyle = location => {
       }
 
       if (location === 'bottom') {
-        let overflowHeight = this.get('overflowHeight') || 0;
         let visibleFooterHeight = this.get('visibleFooterHeight') || 0;
         let scrollbarHeight = this.get('scrollbarHeight') || 0;
+        let footerRatio = this.get('footerRatio');
 
         // when footer occupies > 50% of the overflow height, we are now
         // scrolling the footer rows, so indicator should jump to table bottom
-        if (overflowHeight > 0 && visibleFooterHeight / overflowHeight <= 0.5) {
+        if (footerRatio <= 0.5) {
           offset += visibleFooterHeight;
         }
 
@@ -143,6 +144,7 @@ export default Component.extend({
   tableWidth: null,
   headerHeight: null,
   visibleFooterHeight: null,
+  footerRatio: null,
 
   columnTree: readOnly('api.columnTree'),
   scrollIndicators: readOnly('api.scrollIndicators'),
@@ -218,8 +220,17 @@ export default Component.extend({
     if (footerCell) {
       let footerCellY = footerCell.getBoundingClientRect().y;
       let overflowRect = el.getBoundingClientRect();
-      let scale = overflowHeight / overflowRect.height;
-      visibleFooterHeight = scale * (overflowRect.height - (footerCellY - overflowRect.y));
+      let scale = el.offsetHeight / overflowRect.height;
+
+      visibleFooterHeight = Math.min(
+        el.clientHeight - scale * (footerCellY - overflowRect.y),
+        el.clientHeight
+      );
+    }
+
+    let footerRatio;
+    if (overflowHeight > 0) {
+      footerRatio = visibleFooterHeight / el.offsetHeight;
     }
 
     this.setProperties({
@@ -237,6 +248,7 @@ export default Component.extend({
       headerHeight,
 
       visibleFooterHeight,
+      footerRatio,
     });
   },
 

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -63,6 +63,8 @@ const verticalIndicatorStyle = location => {
     'tableWidth',
     'headerHeight',
     'footerHeight',
+    'footerBottom',
+    'footerScrollTop',
     'scrollbarHeight',
     function() {
       let style = [];
@@ -76,8 +78,10 @@ const verticalIndicatorStyle = location => {
 
       if (location === 'bottom') {
         let footerHeight = this.get('footerHeight') || 0;
+        let footerBottom = this.get('footerBottom') || 0;
+        let footerScrollTop = this.get('footerScrollTop') || 0;
         let scrollbarHeight = this.get('scrollbarHeight') || 0;
-        offset += footerHeight + scrollbarHeight;
+        offset += footerHeight + footerBottom + footerScrollTop + scrollbarHeight;
       }
 
       style.push(`${location}:${offset}px;`);
@@ -134,6 +138,8 @@ export default Component.extend({
   tableWidth: null,
   headerHeight: null,
   footerHeight: null,
+  footerBottom: null,
+  footerScrollTop: null,
 
   columnTree: readOnly('api.columnTree'),
   scrollIndicators: readOnly('api.scrollIndicators'),
@@ -206,6 +212,21 @@ export default Component.extend({
     let headerHeight = header ? header.offsetHeight : null;
     let footerHeight = footer ? footer.offsetHeight : null;
 
+    // calculate minimum `bottom` style for sticky footer cells; can be negative
+    // see `repositionStickyElements()` in `table-sticky-polyfill.js`
+    let footerBottom = 0;
+
+    if (footer) {
+      let footerCell = footer.querySelector('tr:last-child > td');
+      if (footerCell) {
+        let bottom = parseInt(footerCell.style.bottom, 10);
+        footerBottom = isNaN(bottom) ? 0 : bottom;
+      }
+    }
+
+    // calculate how far into the footer we have scrolled
+    let footerScrollTop = Math.max(-Math.min(footerBottom, 0) - scrollBottom, 0);
+
     this.setProperties({
       scrollLeft,
       scrollRight,
@@ -220,6 +241,8 @@ export default Component.extend({
       tableWidth,
       headerHeight,
       footerHeight,
+      footerBottom,
+      footerScrollTop,
     });
   },
 

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -59,6 +59,7 @@ const horizontalIndicatorStyle = side => {
 const verticalIndicatorStyle = location => {
   return computed(
     `columnTree.${location}FixedNodes.@each.width`,
+    'overflowHeight',
     'overflowWidth',
     'tableWidth',
     'headerHeight',
@@ -75,9 +76,17 @@ const verticalIndicatorStyle = location => {
       }
 
       if (location === 'bottom') {
-        let scrollbarHeight = this.get('scrollbarHeight') || 0;
+        let overflowHeight = this.get('overflowHeight') || 0;
         let visibleFooterHeight = this.get('visibleFooterHeight') || 0;
-        offset += visibleFooterHeight + scrollbarHeight;
+        let scrollbarHeight = this.get('scrollbarHeight') || 0;
+
+        // when footer occupies > 50% of the overflow height, we are now
+        // scrolling the footer rows, so indicator should jump to table bottom
+        if (overflowHeight > 0 && visibleFooterHeight / overflowHeight <= 0.5) {
+          offset += visibleFooterHeight;
+        }
+
+        offset += scrollbarHeight;
       }
 
       style.push(`${location}:${offset}px;`);

--- a/tests/dummy/app/pods/docs/guides/header/scroll-indicators/controller.js
+++ b/tests/dummy/app/pods/docs/guides/header/scroll-indicators/controller.js
@@ -63,6 +63,8 @@ export default Controller.extend({
   }),
 
   footerRows: computed(function() {
-    return generateRows(1);
+    return generateRows(100, 1, (row, key) => {
+      return String.fromCharCode(key.charCodeAt(0) + 7);
+    });
   }),
 });

--- a/tests/integration/components/scroll-indicators-test.js
+++ b/tests/integration/components/scroll-indicators-test.js
@@ -199,10 +199,34 @@ module('Integration | scroll indicators', function() {
 
       await generateTable(this, {
         rowCount: 100,
-        footerRowCount: 2,
+        footerRowCount: 10,
       });
 
-      assert.ok(isOffset('bottom', table.footer.height), 'bottom indicator is above footer');
+      // sanity check: footer rows are restricted to 50% of table height when
+      // scrolled to the top, so bottom rows are hidden
+      assert.ok(
+        table.visibleFooterHeight() < table.footer.height,
+        'part of footer is obscured before scrolling'
+      );
+
+      assert.ok(
+        isOffset('bottom', table.visibleFooterHeight()),
+        'bottom indicator is positioned above footer before scrolling'
+      );
+
+      // scroll _almost_ all the way down
+      let overflow = await table.overflow();
+      let maxScroll = overflow.scrollHeight - overflow.clientHeight;
+
+      // the `2` here is because qunit runs at 1/2 scale
+      await scrollTo('[data-test-ember-table-overflow]', 0, maxScroll - 2);
+
+      // all but the last pixel of the footer is now visible, so the bottom
+      // indicator needs to placed higher
+      assert.ok(
+        isOffset('bottom', table.footer.height - 1),
+        'bottom indicator is positioned above footer after scrolling'
+      );
     });
 
     test('negative table margins do not break scroll indicators', async function(assert) {

--- a/tests/integration/components/scroll-indicators-test.js
+++ b/tests/integration/components/scroll-indicators-test.js
@@ -194,7 +194,31 @@ module('Integration | scroll indicators', function() {
       assert.ok(isOffset('top', table.header.height), 'top indicator is below header');
     });
 
-    test('bottom scroll indicator positioned above footer', async function(assert) {
+    test('bottom scroll indicator positioned above non-scrollable footer', async function(assert) {
+      this.set('scrollIndicators', 'vertical');
+
+      await generateTable(this, {
+        rowCount: 100,
+        footerRowCount: 2,
+      });
+
+      assert.ok(
+        isOffset('bottom', table.footer.height),
+        'bottom indicator is above footer initially'
+      );
+
+      // scroll almost to bottom
+      let overflow = await table.overflow();
+      let maxScroll = overflow.scrollHeight - overflow.clientHeight;
+      await scrollTo('[data-test-ember-table-overflow]', 0, maxScroll * 0.9);
+
+      assert.ok(
+        isOffset('bottom', table.footer.height),
+        'bottom indicator is above footer after scrolling'
+      );
+    });
+
+    test('bottom scroll indicator positioned above scrollable footer', async function(assert) {
       this.set('scrollIndicators', 'vertical');
 
       await generateTable(this, {

--- a/tests/integration/components/scroll-indicators-test.js
+++ b/tests/integration/components/scroll-indicators-test.js
@@ -199,32 +199,33 @@ module('Integration | scroll indicators', function() {
 
       await generateTable(this, {
         rowCount: 100,
-        footerRowCount: 10,
+        footerRowCount: 100,
       });
 
-      // sanity check: footer rows are restricted to 50% of table height when
-      // scrolled to the top, so bottom rows are hidden
-      assert.ok(
-        table.visibleFooterHeight() < table.footer.height,
-        'part of footer is obscured before scrolling'
-      );
+      let visibleFooterHeight = table.visibleFooterHeight();
 
       assert.ok(
-        isOffset('bottom', table.visibleFooterHeight()),
+        isOffset('bottom', visibleFooterHeight),
         'bottom indicator is positioned above footer before scrolling'
       );
 
-      // scroll _almost_ all the way down
+      // scroll more than half way, but not all the way; because there are an
+      // equal number of rows in body and footer, this guarantees that more
+      // footer will be visible
       let overflow = await table.overflow();
       let maxScroll = overflow.scrollHeight - overflow.clientHeight;
+      await scrollTo('[data-test-ember-table-overflow]', 0, maxScroll * 0.75);
 
-      // the `2` here is because qunit runs at 1/2 scale
-      await scrollTo('[data-test-ember-table-overflow]', 0, maxScroll - 2);
+      let newVisibleFooterHeight = table.visibleFooterHeight();
 
-      // all but the last pixel of the footer is now visible, so the bottom
-      // indicator needs to placed higher
+      // sanity check: ensure visible footer height has actually changed
       assert.ok(
-        isOffset('bottom', table.footer.height - 1),
+        newVisibleFooterHeight > visibleFooterHeight,
+        'more footer is visible after scrolling'
+      );
+
+      assert.ok(
+        isOffset('bottom', newVisibleFooterHeight),
         'bottom indicator is positioned above footer after scrolling'
       );
     });

--- a/tests/integration/components/scroll-indicators-test.js
+++ b/tests/integration/components/scroll-indicators-test.js
@@ -206,7 +206,7 @@ module('Integration | scroll indicators', function() {
 
       assert.ok(
         isOffset('bottom', visibleFooterHeight),
-        'bottom indicator is positioned above footer before scrolling'
+        'bottom indicator is positioned above footer initially'
       );
 
       // scroll more than half way, but not all the way; because there are an
@@ -216,17 +216,9 @@ module('Integration | scroll indicators', function() {
       let maxScroll = overflow.scrollHeight - overflow.clientHeight;
       await scrollTo('[data-test-ember-table-overflow]', 0, maxScroll * 0.75);
 
-      let newVisibleFooterHeight = table.visibleFooterHeight();
-
-      // sanity check: ensure visible footer height has actually changed
       assert.ok(
-        newVisibleFooterHeight > visibleFooterHeight,
-        'more footer is visible after scrolling'
-      );
-
-      assert.ok(
-        isOffset('bottom', newVisibleFooterHeight),
-        'bottom indicator is positioned above footer after scrolling'
+        isOffset('bottom', 0),
+        'bottom indicator is positioned at bottom of table when footer scrolls'
       );
     });
 


### PR DESCRIPTION
Addresses bottom scroll indicator placement when footer is large enough to scroll. Scroll indicator drops down to bottom of table when body is fully scrolled and obscured footer rows begin to scroll into view. Docs updated to show this example.

![20210129 ET Footer Scrolling V2](https://user-images.githubusercontent.com/2594635/106324446-25b8cc00-6247-11eb-8a97-66ce16ac6793.gif)

Note the border rendering issues with the sticky footer cells. I double-checked, and this is existing behavior. Looks to be related to https://github.com/Addepar/ember-table/issues/771.