### PR TITLE
Remove `sendAction` API

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -166,7 +166,7 @@ export const TableRowMeta = EmberObject.extend({
 
     if (single) {
       tree._lastSelectedIndex = null;
-      tree.sendAction('onSelect', rowValue);
+      tree.onSelect?.(rowValue);
       return;
     }
 
@@ -279,7 +279,7 @@ export const TableRowMeta = EmberObject.extend({
 
     selection = emberA(Array.from(selection));
 
-    tree.sendAction('onSelect', selection);
+    tree.onSelect?.(selection);
 
     tree._lastSelectedIndex = rowIndex;
   },

--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -863,7 +863,7 @@ export default EmberObject.extend({
 
     this.container.classList.remove('is-reordering');
 
-    this.sendAction('onReorder', get(node, 'column'), get(closestColumn, 'column'));
+    this.onReorder?.(get(node, 'column'), get(closestColumn, 'column'));
   },
 
   startResize(node, clientX) {
@@ -938,7 +938,7 @@ export default EmberObject.extend({
 
     this.container.classList.remove('is-resizing');
 
-    this.sendAction('onResize', get(node, 'column'));
+    this.onResize?.(get(node, 'column'));
   },
 
   updateScroll(node, stopAtLeft, stopAtRight, callback) {

--- a/addon/components/-private/simple-checkbox.js
+++ b/addon/components/-private/simple-checkbox.js
@@ -23,7 +23,7 @@ export default Component.extend({
   value: null,
 
   click(event) {
-    this.sendAction('onClick', event);
+    this.onClick?.(event);
   },
 
   change(event) {
@@ -36,6 +36,6 @@ export default Component.extend({
     this.element.checked = this.get('checked');
     this.element.indeterminate = this.get('indeterminate');
 
-    this.sendAction('onChange', checked, { value, indeterminate }, event);
+    this.onChange?.(checked, { value, indeterminate }, event);
   },
 });

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -261,7 +261,7 @@ export default Component.extend({
       items. This is much more convenient for most table operations in general.
     */
     this.collapseTree = CollapseTree.create({
-      sendAction: this.sendAction.bind(this),
+      onSelect: this.onSelect?.bind(this),
     });
 
     this._updateCollapseTree();

--- a/addon/components/ember-td/component.js
+++ b/addon/components/ember-td/component.js
@@ -167,6 +167,7 @@ export default BaseTableCell.extend({
       rowMeta,
     });
 
-    this.sendAction(action, values);
+    let closureAction = this[action];
+    closureAction?.(values);
   },
 });

--- a/addon/components/ember-td/template.hbs
+++ b/addon/components/ember-td/template.hbs
@@ -8,7 +8,7 @@
         {{-ember-table-private/simple-checkbox
           data-test-select-row=true
           checked=rowMeta.isGroupSelected
-          onClick="onSelectionToggled"
+          onClick=(action "onSelectionToggled")
           ariaLabel="Select row"
         }}
         <span></span>
@@ -20,7 +20,7 @@
         {{-ember-table-private/simple-checkbox
           data-test-collapse-row=true
           checked=rowMeta.isCollapsed
-          onChange="onCollapseToggled"
+          onChange=(action "onCollapseToggled")
           ariaLabel="Collapse row"
         }}
         <span></span>

--- a/addon/components/ember-th/component.js
+++ b/addon/components/ember-th/component.js
@@ -128,7 +128,7 @@ export default BaseTableCell.extend({
 
   actions: {
     sendDropdownAction(...args) {
-      this.sendAction('onDropdownAction', ...args);
+      this.onDropdownAction?.(...args);
     },
   },
 
@@ -144,7 +144,7 @@ export default BaseTableCell.extend({
   },
 
   contextMenu(event) {
-    this.sendAction('onContextMenu', event);
+    this.onContextMenu?.(event);
     return false;
   },
 

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -215,7 +215,8 @@ export default Component.extend({
     this.columnMetaCache = new Map();
 
     this.columnTree = ColumnTree.create({
-      sendAction: this.sendAction.bind(this),
+      onReorder: this.onReorder?.bind(this),
+      onResize: this.onResize?.bind(this),
       columnMetaCache: this.columnMetaCache,
       containerWidthAdjustment: this.containerWidthAdjustment,
     });
@@ -329,7 +330,7 @@ export default Component.extend({
   ),
 
   sendUpdateSort(newSorts) {
-    this.sendAction('onUpdateSorts', newSorts);
+    this.onUpdateSorts?.(newSorts);
   },
 
   fillupHandler() {

--- a/addon/components/ember-tr/component.js
+++ b/addon/components/ember-tr/component.js
@@ -120,9 +120,10 @@ export default Component.extend({
     let rowValue = this.get('rowValue');
     let rowMeta = this.get('rowMeta');
 
-    this.sendAction(action, {
-      event,
+    let closureAction = this[action];
 
+    closureAction?.({
+      event,
       rowValue,
       rowMeta,
     });

--- a/tests/dummy/app/pods/docs/guides/header/sorting/template.md
+++ b/tests/dummy/app/pods/docs/guides/header/sorting/template.md
@@ -109,7 +109,7 @@ This demo shows that in action:
           @columns={{columns}}
           @sorts={{sorts}}
 
-          @onUpdateSorts="twoStateSorting"
+          @onUpdateSorts={{action "twoStateSorting"}}
 
           @widthConstraint='gte-container'
           @fillMode='first-column'

--- a/tests/dummy/app/pods/scenarios/performance/template.hbs
+++ b/tests/dummy/app/pods/scenarios/performance/template.hbs
@@ -4,7 +4,7 @@
       api=t
       columns=columns
       sorts=sorts
-      onUpdateSorts="onUpdateSorts"
+      onUpdateSorts=(action "onUpdateSorts")
 
       as |h|
     }}
@@ -18,7 +18,7 @@
       rows=rows
 
       selection=selection
-      onSelect="onSelect"
+      onSelect=(action "onSelect")
 
       as |b|
     }}

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -28,9 +28,9 @@ const fullTable = hbs`
         sortEmptyLast=sortEmptyLast
         widthConstraint=widthConstraint
 
-        onUpdateSorts="onUpdateSorts"
-        onReorder="onReorder"
-        onResize="onResize"
+        onUpdateSorts=(action onUpdateSorts)
+        onReorder=(action onReorder)
+        onResize=(action onResize)
 
         as |h|
       }}
@@ -38,7 +38,7 @@ const fullTable = hbs`
           {{ember-th
             api=r
 
-            onContextMenu="onHeaderCellContextMenu"
+            onContextMenu=(action onHeaderCellContextMenu)
           }}
         {{/ember-tr}}
       {{/ember-thead}}
@@ -56,7 +56,7 @@ const fullTable = hbs`
         idForFirstItem=idForFirstItem
 
 
-        onSelect="onSelect"
+        onSelect=(action onSelect)
         selectingChildrenSelectsParent=selectingChildrenSelectsParent
         checkboxSelectionMode=checkboxSelectionMode
         rowSelectionMode=rowSelectionMode
@@ -68,16 +68,16 @@ const fullTable = hbs`
         {{#component rowComponent
           api=b
 
-          onClick="onRowClick"
-          onDoubleClick="onRowDoubleClick"
+          onClick=(action onRowClick)
+          onDoubleClick=(action onRowDoubleClick)
 
           as |r|
         }}
           {{#ember-td
             api=r
 
-            onClick="onCellClick"
-            onDoubleClick="onCellDoubleClick"
+            onClick=(action onCellClick)
+            onDoubleClick=(action onCellDoubleClick)
 
             as |value|
           }}
@@ -113,6 +113,7 @@ const defaultActions = {
 
   onDropdownAction() {},
   onColumnHeaderAction() {},
+  onHeaderCellContextMenu() {},
   onReorder() {},
   onResize() {},
 
@@ -155,10 +156,8 @@ export function generateTableValues(
   testContext.set('footerRows', footerRows);
 
   for (let action in defaultActions) {
-    let actions = testContext.actions || testContext._actions;
-
-    if (actions && !actions[action]) {
-      testContext.on(action, defaultActions[action].bind(testContext));
+    if (!testContext[action]) {
+      testContext.set(action, defaultActions[action].bind(testContext));
     }
   }
 }

--- a/tests/integration/components/cell-test.js
+++ b/tests/integration/components/cell-test.js
@@ -16,7 +16,7 @@ let table = new TablePage();
 module('Integration | cell', function() {
   componentModule('basic', function() {
     test('sends onClick action', async function(assert) {
-      this.on(
+      this.set(
         'onCellClick',
         ({ event, cellValue, cellMeta, columnValue, columnMeta, rowValue, rowMeta }) => {
           assert.ok(event, 'event sent');
@@ -37,7 +37,7 @@ module('Integration | cell', function() {
     });
 
     test('sends onDoubleClick action', async function(assert) {
-      this.on(
+      this.set(
         'onCellDoubleClick',
         ({ event, cellValue, cellMeta, columnValue, columnMeta, rowValue, rowMeta }) => {
           assert.ok(event, 'event sent');

--- a/tests/integration/components/headers/cell-test.js
+++ b/tests/integration/components/headers/cell-test.js
@@ -9,7 +9,7 @@ let table = new TablePage();
 module('Integration | header | th', function() {
   componentModule('basic', function() {
     test('sends onContextMenu action', async function(assert) {
-      this.on('onHeaderCellContextMenu', event => {
+      this.set('onHeaderCellContextMenu', event => {
         assert.ok(event, 'event sent');
       });
 

--- a/tests/integration/components/headers/ember-th-test.js
+++ b/tests/integration/components/headers/ember-th-test.js
@@ -36,7 +36,7 @@ test('A header cell accepts a block', async function(assert) {
       columns=columns
       sorts=sorts
 
-      onUpdateSorts="onUpdateSorts"
+      onUpdateSorts=(action onUpdateSorts)
 
       as |h|}}
       {{#ember-tr api=h as |r|}}

--- a/tests/integration/components/headers/reorder-test.js
+++ b/tests/integration/components/headers/reorder-test.js
@@ -78,7 +78,7 @@ module('Integration | headers | reorder', function() {
     });
 
     test('column reorder action is sent up to controller', async function(assert) {
-      this.on('onReorder', function(insertedColumn, insertedAfter) {
+      this.set('onReorder', function(insertedColumn, insertedAfter) {
         assert.equal(insertedColumn.name, 'A', 'old column index is correct');
         assert.equal(insertedAfter.name, 'B', 'new column index is correct');
       });

--- a/tests/integration/components/headers/resize-test.js
+++ b/tests/integration/components/headers/resize-test.js
@@ -69,7 +69,7 @@ module('Integration | header | resize', function() {
     });
 
     test('column resize action is sent up to controller', async function(assert) {
-      this.on('onResize', function(column) {
+      this.set('onResize', function(column) {
         assert.equal(column.name, 'B', 'action is sent to controller after resizing');
       });
 

--- a/tests/integration/components/meta-test.js
+++ b/tests/integration/components/meta-test.js
@@ -15,7 +15,7 @@ let otherTable = new TablePage('[data-test-other-table]');
 module('Integration | meta', function() {
   componentModule('basic', function() {
     test('meta caches work', async function(assert) {
-      this.on('onClick', ({ cellMeta, rowMeta, columnMeta }) => {
+      this.set('onClick', ({ cellMeta, rowMeta, columnMeta }) => {
         set(cellMeta, 'wasClicked', true);
         set(columnMeta, 'wasClicked', true);
         set(rowMeta, 'wasClicked', true);
@@ -39,7 +39,7 @@ module('Integration | meta', function() {
               {{#ember-tr api=b as |r|}}
                 {{#ember-td
                   api=r
-                  onClick="onClick"
+                  onClick=(action onClick)
 
                   as |value column row cellMeta columnMeta rowMeta|
                 }}
@@ -111,7 +111,7 @@ module('Integration | meta', function() {
     });
 
     test('meta caches are unique per table instance', async function(assert) {
-      this.on('onClick', ({ cellMeta, rowMeta, columnMeta }) => {
+      this.set('onClick', ({ cellMeta, rowMeta, columnMeta }) => {
         set(cellMeta, 'wasClicked', true);
         set(columnMeta, 'wasClicked', true);
         set(rowMeta, 'wasClicked', true);
@@ -135,7 +135,7 @@ module('Integration | meta', function() {
               {{#ember-tr api=b as |r|}}
                 {{#ember-td
                   api=r
-                  onClick="onClick"
+                  onClick=(action onClick)
 
                   as |value column row cellMeta columnMeta rowMeta|
                 }}
@@ -173,7 +173,7 @@ module('Integration | meta', function() {
               {{#ember-tr api=b as |r|}}
                 {{#ember-td
                   api=r
-                  onClick="onClick"
+                  onClick=(action onClick)
 
                   as |value column row cellMeta columnMeta rowMeta|
                 }}

--- a/tests/integration/components/row-test.js
+++ b/tests/integration/components/row-test.js
@@ -43,7 +43,7 @@ module('Integration | row', function() {
     });
 
     test('sends onClick action', async function(assert) {
-      this.on('onRowClick', ({ event, rowValue, rowMeta }) => {
+      this.set('onRowClick', ({ event, rowValue, rowMeta }) => {
         assert.ok(event, 'event sent');
         assert.ok(rowValue, 'rowValue sent');
         assert.ok(rowMeta, 'rowMeta sent');
@@ -54,7 +54,7 @@ module('Integration | row', function() {
     });
 
     test('sends onDoubleClick action', async function(assert) {
-      this.on('onRowDoubleClick', ({ event, rowValue, rowMeta }) => {
+      this.set('onRowDoubleClick', ({ event, rowValue, rowMeta }) => {
         assert.ok(event, 'event sent');
         assert.ok(rowValue, 'rowValue sent');
         assert.ok(rowMeta, 'rowMeta sent');

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -184,7 +184,7 @@ module('Integration | selection', () => {
       });
 
       test('selecting a child and then a parent dedupes selected rows correctly', async function(assert) {
-        this.on('onSelect', selection => {
+        this.set('onSelect', selection => {
           assert.equal(selection.length, 1, 'correct number of rows selected');
 
           this.set('selection', selection);
@@ -329,7 +329,7 @@ module('Integration | selection', () => {
       test('selection is a single row', async function(assert) {
         assert.expect(1);
 
-        this.on('onSelect', selection => {
+        this.set('onSelect', selection => {
           assert.ok(!Array.isArray(selection), 'selection is not an array');
         });
 
@@ -496,7 +496,7 @@ module('Integration | selection', () => {
       test('selection is an array', async function(assert) {
         assert.expect(1);
 
-        this.on('onSelect', selection => {
+        this.set('onSelect', selection => {
           assert.ok(Array.isArray(selection), 'selection is an array');
         });
 
@@ -524,7 +524,7 @@ module('Integration | selection', () => {
     test('Can disable selection by not using an action', async function(assert) {
       assert.expect(3);
 
-      this.on('onSelect', () => {
+      this.set('onSelect', () => {
         assert.ok(true, 'select called');
       });
 

--- a/tests/integration/components/sort-test.js
+++ b/tests/integration/components/sort-test.js
@@ -131,7 +131,7 @@ module('Integration | sort', function() {
     });
 
     test('sends the onUpdateSorts action', async function(assert) {
-      this.on('onUpdateSorts', sorts => {
+      this.set('onUpdateSorts', sorts => {
         assert.equal(sorts.length, 1);
         assert.equal(sorts[0].valuePath, 'name');
         assert.equal(sorts[0].isAscending, false);


### PR DESCRIPTION
## Summary

As we are dropping support for older version of Ember.js, we need to make sure we trim the usage of old/deprecated APIs, as well. This time around it is the mechanism by which the actions are propagated, or `sendAction` API.

`sendAction` API has been [deprecated](https://github.com/emberjs/rfcs/blob/master/text/0335-deprecate-send-action.md) in favour of [closure actions](https://guides.emberjs.com/v2.4.0/components/triggering-changes-with-actions/) seems like forever ago (Ember 2.0+ but do not quote me on that.)

This PR makes sure we use *only* closure actions moving forward. It also contains a breaking change: the consumers that passed actions via a string (i.g. `onUpdateSorts="myAction"`) will have to change their code to `onUpdateSorts=(action "myAction")`.

This PR targets 3.0 release.

Closes https://github.com/Addepar/ember-table/pull/825
Closes https://github.com/Addepar/ember-table/pull/801
Related to https://github.com/Addepar/ember-table/issues/819

## Known Actions

- [x]  `onSelectionToggled`
- [x]  `onClick`
- [x]  `onCollapseToggled`
- [x]  `onUpdateSorts`
- [x]  `onReorder`
- [x]  `onResize`
- [x]  `onHeaderCellContextMenu`
- [x]  `onSelect`
- [x]  `onRowClick`
- [x]  `onRowDoubleClick`
- [x]  `onCellClick`
- [x]  `onCellDoubleClick`