### PR TITLE
Add `@babel/*` plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,18 @@ const replace = require('broccoli-string-replace');
 module.exports = {
   name: 'ember-table',
 
+  options: {
+    babel: {
+      plugins: [
+        '@babel/plugin-proposal-object-rest-spread',
+        '@babel/plugin-proposal-optional-chaining',
+        '@babel/plugin-proposal-nullish-coalescing-operator',
+        '@babel/plugin-proposal-numeric-separator',
+        '@babel/plugin-proposal-optional-catch-binding',
+      ],
+    },
+  },
+
   included() {
     this._super.included.apply(this, arguments);
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.13",
+    "@babel/plugin-proposal-numeric-separator": "^7.12.13",
+    "@babel/plugin-proposal-object-rest-spread": "^7.12.13",
+    "@babel/plugin-proposal-optional-catch-binding": "^7.12.13",
+    "@babel/plugin-proposal-optional-chaining": "^7.12.13",
     "@html-next/vertical-collection": "^1.0.0-beta.14",
     "broccoli-string-replace": "^0.1.2",
     "css-element-queries": "^0.4.0",
@@ -47,11 +52,6 @@
     "@addepar/prettier-config": "^1.0.0",
     "@addepar/sass-lint-config": "^2.0.1",
     "@addepar/style-toolbox": "~0.8.1",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.13",
-    "@babel/plugin-proposal-numeric-separator": "^7.12.13",
-    "@babel/plugin-proposal-object-rest-spread": "^7.12.13",
-    "@babel/plugin-proposal-optional-catch-binding": "^7.12.13",
-    "@babel/plugin-proposal-optional-chaining": "^7.12.13",
     "@types/ember": "^2.8.22",
     "babel-eslint": "^10.0.1",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
This change makes sure that none of the consumers, that do not have
these features enabled, continue to work without issues.

Follow up on https://github.com/Addepar/ember-table/pull/862