### PR TITLE
Fix bottom scroll indicator placement in Safari

### DIFF
--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -226,6 +226,9 @@ export default Component.extend({
         el.clientHeight - scale * (footerCellY - overflowRect.y),
         el.clientHeight
       );
+
+      // can be negative if sticky footers don't work in browser (e.g. Safari)
+      visibleFooterHeight = Math.max(visibleFooterHeight, 0);
     }
 
     let footerRatio;


### PR DESCRIPTION
Fixes placement of the bottom scroll indicator in Safari, where sticky footers do not currently work.