### PR TITLE
Remove obsolete polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
-    "ember-debug-handlers-polyfill": "^1.1.1",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-faker": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6319,11 +6319,6 @@ ember-copy@^1.0.0:
     ember-cli-typescript "^3.1.3"
     ember-inflector "^3.0.1"
 
-ember-debug-handlers-polyfill@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.1.1.tgz#e9ae0a720271a834221179202367421b580002ef"
-  integrity sha512-lO7FBAqJjzbL+IjnWhVfQITypPOJmXdZngZR/Vdn513W4g/Q6Sjicao/mDzeDCb48Y70C4Facwk0LjdIpSZkRg==
-
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
   resolved "https://registry.npmjs.org/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"


### PR DESCRIPTION
[ember-debug-handlers-polyfill](ember-polyfills/ember-debug-handlers-polyfill) provides an implementation of [emberjs/rfcs#65](emberjs/rfcs@master/text/0065-deprecation-warning-handlers.md)
(added to Ember in [emberjs/ember.js#11833](emberjs/ember.js#11833) and released in Ember v2.1.0) that can be used with versions of Ember prior to v2.1.0.

Related to https://github.com/Addepar/ember-table/issues/819