### PR TITLE
Remove Ember 2.4 from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
       matrix:
         ember-version:
           [
-            ember-lts-2.4,
             ember-lts-2.8,
             ember-lts-2.12,
             ember-lts-2.18,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ handle over 100,000 rows without any rendering or performance issues.
 
 Ember Table 3.x supports:
 
-* Ember 2.4 to latest version of Ember.
+* Ember 2.8 to latest version of Ember.
 
 For older platforms, the final release of Ember Table 2.x (2.2.3) supports:
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -10,37 +10,6 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.4',
-          bower: {
-            dependencies: {
-              ember: 'components/ember#lts-2-4',
-            },
-            resolutions: {
-              ember: 'lts-2-4',
-            },
-          },
-          npm: {
-            resolutions: {
-              // ember-math-helpers has a dependency on newer htmlbars and it
-              // conflicts this older version of ember with a message:
-              // "ember-cli-htmlbars: Cannot find the ember-source addon"...
-              'ember-cli-htmlbars': '^3',
-              // The 1.2.2 release causes an error related to a missing 'match'
-              // property which is due to the lack of ember-source.
-              // See https://github.com/pzuraq/ember-compatibility-helpers/issues/47
-              'ember-compatibility-helpers': '1.2.1',
-            },
-            dependencies: {
-              'ember-compatibility-helpers': '1.2.1',
-            },
-            devDependencies: {
-              'ember-source': null,
-              'ember-cli-addon-docs': null,
-              'ember-angle-bracket-invocation-polyfill': null,
-            },
-          },
-        },
-        {
           name: 'ember-lts-2.8',
           bower: {
             dependencies: {

--- a/tests/dummy/app/pods/docs/guides/main/legacy-usage/template.md
+++ b/tests/dummy/app/pods/docs/guides/main/legacy-usage/template.md
@@ -1,8 +1,8 @@
 # Legacy Usage
 
-Ember Table is compatible (and tested) with Ember 2.4 and up.
+Ember Table is compatible (and tested) with Ember 2.8 and up.
 
-## Usage with Ember 2.4-2.11
+## Usage with Ember 2.8-2.11
 
 You may have noticed that all of the examples for Ember Table on this docs site
 are using angle bracket syntax (.e.g. `foo-bar`). This is an exciting new


### PR DESCRIPTION
Based on the feedback on https://github.com/Addepar/ember-table/issues/819#issuecomment-772814116, we are dropping Ember 2.4 testing matrix.

Related to https://github.com/Addepar/ember-table/issues/819