### PR TITLE
Improve footer tracking for bottom scroll indicator

### DIFF
--- a/addon/-private/sticky/table-sticky-polyfill.js
+++ b/addon/-private/sticky/table-sticky-polyfill.js
@@ -174,7 +174,7 @@ class TableStickyPolyfill {
     let scale = table.offsetHeight / table.getBoundingClientRect().height;
     let containerHeight = table.parentNode.offsetHeight;
 
-    let rows = Array.from(this.element.children);
+    let rows = Array.from(this.element.querySelectorAll('tr'));
     let offset = 0;
     let heights = rows.map(r => r.getBoundingClientRect().height * scale);
 

--- a/addon/-private/sticky/table-sticky-polyfill.js
+++ b/addon/-private/sticky/table-sticky-polyfill.js
@@ -174,6 +174,7 @@ class TableStickyPolyfill {
     let scale = table.offsetHeight / table.getBoundingClientRect().height;
     let containerHeight = table.parentNode.offsetHeight;
 
+    // exclude ResizeSensor divs
     let rows = Array.from(this.element.querySelectorAll('tr'));
     let offset = 0;
     let heights = rows.map(r => r.getBoundingClientRect().height * scale);

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -2,7 +2,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
-import { scheduleOnce } from '@ember/runloop';
+import { bind, scheduleOnce } from '@ember/runloop';
 import { capitalize } from '@ember/string';
 import { htmlSafe } from '@ember/template';
 import { isEmpty, isNone } from '@ember/utils';
@@ -318,9 +318,10 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    this._updateIndicators = () => {
+    // debounced, runloop-safe version
+    this._updateIndicators = bind(this, () => {
       scheduleOnce('actions', this, this.updateIndicators);
-    };
+    });
 
     this._updateListeners();
     addObserver(this, 'enabledIndicators', this._updateListeners);

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -216,6 +216,7 @@ export default Component.extend({
       this._footerMutationObserver.observe(footerElement, {
         subtree: true,
         attributes: true,
+        attributesFilter: ['style'],
         childList: true,
       });
     }

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -2,7 +2,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
-import { run, scheduleOnce } from '@ember/runloop';
+import { bind, scheduleOnce } from '@ember/runloop';
 import { capitalize } from '@ember/string';
 import { htmlSafe } from '@ember/template';
 import { isEmpty, isNone } from '@ember/utils';
@@ -180,11 +180,11 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    // common callback for event listeners
-    this._updateIndicators = () => {
-      // test suite requires this callback to be wrapped in a runloop
-      run(() => scheduleOnce('actions', this, this.updateIndicators));
-    };
+    // common callback for event listeners; the `bind` appears redundant, but is
+    // required by the test suite
+    this._updateIndicators = bind(this, () => {
+      scheduleOnce('actions', this, this.updateIndicators);
+    });
   },
 
   _addListeners() {

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -2,7 +2,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
-import { bind, scheduleOnce } from '@ember/runloop';
+import { scheduleOnce } from '@ember/runloop';
 import { capitalize } from '@ember/string';
 import { htmlSafe } from '@ember/template';
 import { isEmpty, isNone } from '@ember/utils';
@@ -318,10 +318,9 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    // debounced, runloop-safe version
-    this._updateIndicators = bind(this, () => {
+    this._updateIndicators = () => {
       scheduleOnce('actions', this, this.updateIndicators);
-    });
+    };
 
     this._updateListeners();
     addObserver(this, 'enabledIndicators', this._updateListeners);

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -2,7 +2,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
-import { bind, scheduleOnce } from '@ember/runloop';
+import { run, scheduleOnce } from '@ember/runloop';
 import { capitalize } from '@ember/string';
 import { htmlSafe } from '@ember/template';
 import { isEmpty, isNone } from '@ember/utils';
@@ -177,6 +177,16 @@ export default Component.extend({
     }
   }),
 
+  init() {
+    this._super(...arguments);
+
+    // common callback for event listeners
+    this._updateIndicators = () => {
+      // test suite requires this callback to be wrapped in a runloop
+      run(() => scheduleOnce('actions', this, this.updateIndicators));
+    };
+  },
+
   _addListeners() {
     this._isListening = true;
 
@@ -317,12 +327,6 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-
-    // debounced, runloop-safe version
-    this._updateIndicators = bind(this, () => {
-      scheduleOnce('actions', this, this.updateIndicators);
-    });
-
     this._updateListeners();
     addObserver(this, 'enabledIndicators', this._updateListeners);
   },

--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -208,10 +208,12 @@ export default Component.extend({
     }
 
     if (!this._footerResizeSensor) {
+      // triggers when entire footer changes size
       this._footerResizeSensor = new ResizeSensor(footerElement, this._updateIndicators);
     }
 
     if (!this._footerMutationObserver) {
+      // triggers when individual footer cells are updated by sticky polyfill
       this._footerMutationObserver = new MutationObserver(this._updateIndicators);
       this._footerMutationObserver.observe(footerElement, {
         subtree: true,


### PR DESCRIPTION
In order to position the bottom scroll indicator correctly, we need to know if and when the visible portion of the footer changes height. Presently, we detect when the dimensions of the table's container changes, but not specifically when the height of the footer, or the position of its sticky cells, change. These changes can occur without altering the overall height or width of the table, which can leave the bottom scroll indicator floating in the wrong position.

So far this has only been a problem in testing environments, where it manifests as an erratic race condition during initial render. It is exacerbated by increased functionality in the footer (e.g. child rows), because of increased jostling during layout. During a typical application pageload, there are sufficiently many layout changes that the effect is rarely seen.

Since it is possible to programmatically add and remove a footer from the table, we install and remove those listeners dynamically.

Changes:
- Dynamically installs `ResizeSensor` on footer to detect changes in total footer height
- Dynamically installs `MutationObserver` on footer to detect changes to the `style` attribute of `td` elements; we are interested in when `bottom` changes value
