### PR TITLE
Add is-last-column and is-slack classes to table cells

### DIFF
--- a/addon-test-support/pages/-private/ember-table-body.js
+++ b/addon-test-support/pages/-private/ember-table-body.js
@@ -9,6 +9,16 @@ import { findElement } from 'ember-classy-page-object/extend';
 
 import { click } from 'ember-native-dom-helpers';
 
+export const BodyCell = PageObject.extend({
+  scope: 'td',
+
+  doubleClick: triggerable('dblclick'),
+
+  isFirstColumn: hasClass('is-first-column'),
+  isLastColumn: hasClass('is-last-column'),
+  isSlack: hasClass('is-slack'),
+});
+
 export default PageObject.extend({
   scope: 'tbody',
 
@@ -36,10 +46,13 @@ export default PageObject.extend({
     /**
       List of all cells for the selected row.
     */
-    cells: collection({
-      scope: 'td:not([data-test-ember-table-slack])',
+    cells: collection('td:not([data-test-ember-table-slack])', BodyCell),
 
-      doubleClick: triggerable('dblclick'),
+    /**
+      Slack cell from this row, if present.
+    */
+    slackCell: BodyCell.extend({
+      scope: 'td[data-test-ember-table-slack]',
     }),
 
     /**

--- a/addon-test-support/pages/-private/ember-table-body.js
+++ b/addon-test-support/pages/-private/ember-table-body.js
@@ -9,6 +9,10 @@ import { findElement } from 'ember-classy-page-object/extend';
 
 import { click } from 'ember-native-dom-helpers';
 
+/**
+ * Page object for single table `td` cell; also used by the footer page object
+ * to represent footer cells.
+ */
 export const BodyCell = PageObject.extend({
   scope: 'td',
 

--- a/addon-test-support/pages/-private/ember-table-footer.js
+++ b/addon-test-support/pages/-private/ember-table-footer.js
@@ -1,10 +1,9 @@
 import { collection } from 'ember-classy-page-object';
-import EmberTableBody from './ember-table-body';
+import EmberTableBody, { BodyCell } from './ember-table-body';
 
 export default EmberTableBody.extend({
   scope: 'tfoot',
 
-  footers: collection({
-    scope: 'td:not([data-test-ember-table-slack])',
-  }),
+  footers: collection('td:not([data-test-ember-table-slack])', BodyCell),
+  slackFooters: collection('td[data-test-ember-table-slack]', BodyCell),
 });

--- a/addon-test-support/pages/-private/ember-table-header.js
+++ b/addon-test-support/pages/-private/ember-table-header.js
@@ -45,8 +45,16 @@ const Header = PageObject.extend({
     return findElement(this).dataset.testLeafHeader;
   },
 
+  get isRendered() {
+    return findElement(this).style.display !== 'none';
+  },
+
   isFixedLeft: hasClass('is-fixed-left'),
   isFixedRight: hasClass('is-fixed-right'),
+
+  isFirstColumn: hasClass('is-first-column'),
+  isLastColumn: hasClass('is-last-column'),
+  isSlack: hasClass('is-slack'),
 
   contextMenu: triggerable('contextmenu'),
 
@@ -131,14 +139,14 @@ export default {
   scope: 'thead',
 
   /**
-   * List of columns in the header.
+   * Selects all non-slack `th` header elements from all header rows.
    */
   headers: collection('th:not([data-test-ember-table-slack])', Header),
 
   /**
-   * List of columns in the header, excluding slack column if present.
+   * Selects all slack `th` header elements from all header rows.
    */
-  contentHeaders: collection('th:not([data-test-ember-table-slack])', Header),
+  slackHeaders: collection('th[data-test-ember-table-slack]', Header),
 
   /**
     Returns the height of the entire thead element.
@@ -154,11 +162,13 @@ export default {
     return Number(findElement(this).getAttribute('data-test-row-count'));
   },
 
-  get slackHeader() {
-    return findElement(this, '[data-test-ember-table-slack]');
-  },
-
   rows: collection({
     scope: 'tr',
+
+    headers: collection('th:not([data-test-ember-table-slack])', Header),
+
+    slackHeader: Header.extend({
+      scope: 'th[data-test-ember-table-slack]',
+    }),
   }),
 };

--- a/addon-test-support/pages/ember-table.js
+++ b/addon-test-support/pages/ember-table.js
@@ -30,8 +30,16 @@ export default PageObject.extend({
   rows: alias('body.rows'),
   getCell: alias('body.getCell'),
 
+  /**
+   * Page object collection of header cells from all header rows.
+   */
   headers: alias('header.headers'),
-  slackHeader: alias('header.slackHeader'),
+
+  /**
+   * Page object collection of slack header cells from all header rows.
+   */
+  slackHeaders: alias('header.slackHeaders'),
+
   footers: alias('footer.footers'),
 
   /**

--- a/addon/components/-private/base-table-cell.js
+++ b/addon/components/-private/base-table-cell.js
@@ -10,9 +10,17 @@ export default Component.extend({
   columnValue: null,
 
   attributeBindings: ['slackAttribute:data-test-ember-table-slack'],
-  classNameBindings: ['isFirstColumn', 'isFixedLeft', 'isFixedRight', 'textAlign'],
+  classNameBindings: [
+    'isFirstColumn',
+    'isLastColumn',
+    'isFixedLeft',
+    'isFixedRight',
+    'textAlign',
+    'isSlack',
+  ],
 
   isFirstColumn: equal('columnMeta.index', 0),
+  isLastColumn: readOnly('columnMeta.isLastRendered'),
   isFixedLeft: equal('columnMeta.isFixed', 'left'),
   isFixedRight: equal('columnMeta.isFixed', 'right'),
   isSlack: readOnly('columnMeta.isSlack'),

--- a/tests/integration/components/cell-test.js
+++ b/tests/integration/components/cell-test.js
@@ -118,4 +118,114 @@ module('Integration | cell', function() {
       assert.equal(get(rows[0], 'A'), 'Z', 'value updated successfully');
     });
   });
+
+  componentModule('positional css classes', function() {
+    test('applies is-first-column, is-last-column classes', async function(assert) {
+      let columnCount = 3;
+      let rows = [
+        {
+          A: 'A',
+          B: 'B',
+          C: 'C',
+        },
+      ];
+
+      this.set('columns', generateColumns(columnCount));
+      this.set('rows', rows);
+
+      this.render(hbs`
+        {{#ember-table as |t|}}
+          {{ember-thead api=t columns=columns}}
+          {{ember-tbody api=t rows=rows}}
+        {{/ember-table}}
+      `);
+
+      await wait();
+
+      let cells = document.querySelectorAll('.ember-table td');
+
+      assert.ok(
+        cells[0].classList.contains('is-first-column'),
+        'is-first-column class is applied to first column cell'
+      );
+
+      assert.notOk(
+        cells[1].classList.contains('is-first-column'),
+        'is-first-column class is not applied to middle column cell'
+      );
+
+      assert.notOk(
+        cells[2].classList.contains('is-first-column'),
+        'is-first-column class is not applied to last column cell'
+      );
+
+      assert.notOk(
+        cells[0].classList.contains('is-last-column'),
+        'is-last-column class is not applied to first column cell'
+      );
+
+      assert.notOk(
+        cells[1].classList.contains('is-last-column'),
+        'is-last-column class is not applied to middle column cell'
+      );
+
+      assert.ok(
+        cells[2].classList.contains('is-last-column'),
+        'is-last-column class is applied to last column cell'
+      );
+    });
+
+    test('applies is-first-column class to last column cells in slack mode', async function(assert) {
+      let columnCount = 1;
+      let rows = [
+        {
+          A: 'A',
+        },
+      ];
+
+      this.set('columns', generateColumns(columnCount));
+      this.set('rows', rows);
+
+      this.render(hbs`
+        {{#ember-table as |t|}}
+          {{ember-thead
+            api=t
+            columns=columns
+            widthConstraint="eq-container-slack"
+            initialFillMode="equal-column"}}
+
+          {{ember-tbody api=t rows=rows}}
+        {{/ember-table}}
+      `);
+
+      await wait();
+
+      let cells = document.querySelectorAll('.ember-table td');
+
+      // initially, slack column has zero width
+      assert.ok(
+        cells[0].classList.contains('is-last-column'),
+        'is-last-column class is applied to last supplied column cell'
+      );
+
+      assert.notOk(
+        cells[1].classList.contains('is-last-column'),
+        'is-last-column class is not applied to slack column cell'
+      );
+
+      // shrink header, giving slack column non-zero width
+      let firstHeader = table.headers.objectAt(0);
+      await firstHeader.resize(firstHeader.width - 1);
+
+      assert.notOk(
+        cells[0].classList.contains('is-last-column'),
+        'is-last-column class is not applied to last supplied column cell'
+      );
+
+      assert.ok(
+        cells[1].classList.contains('is-last-column'),
+        'is-last-column class is applied to slack column cell'
+      );
+    });
+  });
 });

--- a/tests/integration/components/cell-test.js
+++ b/tests/integration/components/cell-test.js
@@ -175,7 +175,7 @@ module('Integration | cell', function() {
       );
     });
 
-    test('applies is-first-column class to last column cells in slack mode', async function(assert) {
+    test('applies positional classes correctly in slack mode', async function(assert) {
       let columnCount = 1;
       let rows = [
         {
@@ -202,7 +202,18 @@ module('Integration | cell', function() {
 
       let cells = document.querySelectorAll('.ember-table td');
 
-      // initially, slack column has zero width
+      // slack column should be marked
+      assert.notOk(
+        cells[0].classList.contains('is-slack'),
+        'is-slack class is not applied supplied column cell'
+      );
+
+      assert.ok(
+        cells[1].classList.contains('is-slack'),
+        'is-slack class is applied to slack column cell'
+      );
+
+      // initially, slack column has zero width, so "A" is the last column
       assert.ok(
         cells[0].classList.contains('is-last-column'),
         'is-last-column class is applied to last supplied column cell'

--- a/tests/integration/components/cell-test.js
+++ b/tests/integration/components/cell-test.js
@@ -142,37 +142,18 @@ module('Integration | cell', function() {
 
       await wait();
 
-      let cells = document.querySelectorAll('.ember-table td');
+      let row = table.rows.objectAt(0);
+      let cells = row.cells.toArray();
 
-      assert.ok(
-        cells[0].classList.contains('is-first-column'),
-        'is-first-column class is applied to first column cell'
-      );
+      // `is-first-column` class only appears on first cell
+      assert.ok(cells[0].isFirstColumn, 'is-first-column applied to first column cell');
+      assert.notOk(cells[1].isFirstColumn, 'is-first-column not applied to middle column cell');
+      assert.notOk(cells[2].isFirstColumn, 'is-first-column not applied to last column cell');
 
-      assert.notOk(
-        cells[1].classList.contains('is-first-column'),
-        'is-first-column class is not applied to middle column cell'
-      );
-
-      assert.notOk(
-        cells[2].classList.contains('is-first-column'),
-        'is-first-column class is not applied to last column cell'
-      );
-
-      assert.notOk(
-        cells[0].classList.contains('is-last-column'),
-        'is-last-column class is not applied to first column cell'
-      );
-
-      assert.notOk(
-        cells[1].classList.contains('is-last-column'),
-        'is-last-column class is not applied to middle column cell'
-      );
-
-      assert.ok(
-        cells[2].classList.contains('is-last-column'),
-        'is-last-column class is applied to last column cell'
-      );
+      // `is-last-column` class only appears on last cell
+      assert.notOk(cells[0].isLastColumn, 'is-last-column not applied to first column cell');
+      assert.notOk(cells[1].isLastColumn, 'is-last-column not applied to middle column cell');
+      assert.ok(cells[2].isLastColumn, 'is-last-column applied to last column cell');
     });
 
     test('applies positional classes correctly in slack mode', async function(assert) {
@@ -200,43 +181,23 @@ module('Integration | cell', function() {
 
       await wait();
 
-      let cells = document.querySelectorAll('.ember-table td');
+      let header = table.headers.objectAt(0);
+      let row = table.rows.objectAt(0);
+      let cell = row.cells.objectAt(0);
+      let slackCell = row.slackCell;
 
-      // slack column should be marked
-      assert.notOk(
-        cells[0].classList.contains('is-slack'),
-        'is-slack class is not applied supplied column cell'
-      );
+      // slack header should be marked accordingly
+      assert.notOk(cell.isSlack, 'is-slack not applied to normal cell');
+      assert.ok(slackCell.isSlack, 'is-slack applied to slack cell');
 
-      assert.ok(
-        cells[1].classList.contains('is-slack'),
-        'is-slack class is applied to slack column cell'
-      );
+      // initially, slack column has zero width, so "A" gets `is-last-column` class
+      assert.ok(cell.isLastColumn, 'is-last-column applied to normal cell');
+      assert.notOk(slackCell.isLastColumn, 'is-last-column not applied to slack cell');
 
-      // initially, slack column has zero width, so "A" is the last column
-      assert.ok(
-        cells[0].classList.contains('is-last-column'),
-        'is-last-column class is applied to last supplied column cell'
-      );
-
-      assert.notOk(
-        cells[1].classList.contains('is-last-column'),
-        'is-last-column class is not applied to slack column cell'
-      );
-
-      // shrink header, giving slack column non-zero width
-      let firstHeader = table.headers.objectAt(0);
-      await firstHeader.resize(firstHeader.width - 1);
-
-      assert.notOk(
-        cells[0].classList.contains('is-last-column'),
-        'is-last-column class is not applied to last supplied column cell'
-      );
-
-      assert.ok(
-        cells[1].classList.contains('is-last-column'),
-        'is-last-column class is applied to slack column cell'
-      );
+      // shrink cell "A"; now slack column gets the `is-last-column` class
+      await header.resize(header.width - 1);
+      assert.notOk(cell.isLastColumn, 'is-last-column not applied to normal cell');
+      assert.ok(slackCell.isLastColumn, 'is-last-column applied to slack cell');
     });
   });
 });

--- a/tests/integration/components/headers/ember-th-test.js
+++ b/tests/integration/components/headers/ember-th-test.js
@@ -1,7 +1,8 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
 
-import { generateTableValues } from '../../../helpers/generate-table';
+import { generateTableValues, generateColumns } from '../../../helpers/generate-table';
 import TablePage from 'ember-table/test-support/pages/ember-table';
 
 let table = new TablePage();
@@ -57,4 +58,81 @@ test('A header cell accepts a block', async function(assert) {
   assert.ok(!firstHeader.sortIndicator.isPresent, 'No sort indicator is rendered');
   assert.notOk(firstHeader.sortToggle.isPresent, 'No sort toggle is rendered');
   assert.notOk(firstHeader.resizeHandle.isPresent, 'No resize area is rendered');
+});
+
+test('applies is-first-column, is-last-column classes', async function(assert) {
+  let columnCount = 3;
+  let rows = [
+    {
+      A: 'A',
+      B: 'B',
+      C: 'C',
+    },
+  ];
+
+  this.set('columns', generateColumns(columnCount));
+  this.set('rows', rows);
+
+  this.render(hbs`
+    {{#ember-table as |t|}}
+      {{ember-thead api=t columns=columns}}
+      {{ember-tbody api=t rows=rows}}
+    {{/ember-table}}
+  `);
+
+  await wait();
+
+  let headers = table.headers.toArray();
+
+  // `is-first-column` class only appears on first header
+  assert.ok(headers[0].isFirstColumn, 'is-first-column applied to first header');
+  assert.notOk(headers[1].isFirstColumn, 'is-first-column not applied to middle header');
+  assert.notOk(headers[2].isFirstColumn, 'is-first-column not applied to last header');
+
+  // `is-last-column` class only appears on last header
+  assert.notOk(headers[0].isLastColumn, 'is-last-column not applied to first header');
+  assert.notOk(headers[1].isLastColumn, 'is-last-column not applied to middle header');
+  assert.ok(headers[2].isLastColumn, 'is-last-column applied to last header');
+});
+
+test('applies positional classes correctly in slack mode', async function(assert) {
+  let columnCount = 1;
+  let rows = [
+    {
+      A: 'A',
+    },
+  ];
+
+  this.set('columns', generateColumns(columnCount));
+  this.set('rows', rows);
+
+  this.render(hbs`
+    {{#ember-table as |t|}}
+      {{ember-thead
+        api=t
+        columns=columns
+        widthConstraint="eq-container-slack"
+        initialFillMode="equal-column"}}
+
+      {{ember-tbody api=t rows=rows}}
+    {{/ember-table}}
+  `);
+
+  await wait();
+
+  let header = table.headers.objectAt(0);
+  let slackHeader = table.slackHeaders.objectAt(0);
+
+  // slack header should be marked accordingly
+  assert.notOk(header.isSlack, 'is-slack not applied to normal header');
+  assert.ok(slackHeader.isSlack, 'is-slack applied to slack header');
+
+  // initially, slack column has zero width, so "A" gets `is-last-column` class
+  assert.ok(header.isLastColumn, 'is-last-column applied to normal header');
+  assert.notOk(slackHeader.isLastColumn, 'is-last-column not applied to slack header');
+
+  // shrink header "A"; now slack column gets the `is-last-column` class
+  await header.resize(header.width - 1);
+  assert.notOk(header.isLastColumn, 'is-last-column not applied to normal header');
+  assert.ok(slackHeader.isLastColumn, 'is-last-column applied to slack header');
 });

--- a/tests/integration/components/headers/main-test.js
+++ b/tests/integration/components/headers/main-test.js
@@ -21,13 +21,14 @@ module('Integration | header | main', function() {
 
       let containerWidth = table.containerWidth;
       let tableWidth = table.width;
+      let slackHeader = table.slackHeaders.objectAt(0);
 
       assert.ok(
         Math.abs(tableWidth - containerWidth) <= 5,
         'First column takes extra space in first column resize mode.'
       );
 
-      assert.notOk(table.header.slackHeader, 'slack column does not exist');
+      assert.notOk(slackHeader.isPresent, 'slack column does not exist');
     });
 
     test('eq-container when larger', async function(assert) {
@@ -41,13 +42,14 @@ module('Integration | header | main', function() {
 
       let containerWidth = table.containerWidth;
       let tableWidth = table.width;
+      let slackHeader = table.slackHeaders.objectAt(0);
 
       assert.ok(
         Math.abs(tableWidth - containerWidth) <= 5,
         'First column takes extra space in first column resize mode.'
       );
 
-      assert.notOk(table.header.slackHeader, 'slack column does not exist');
+      assert.notOk(slackHeader.isPresent, 'slack column does not exist');
     });
 
     test('eq-container with containerWidthAdjustment', async function(assert) {
@@ -60,6 +62,7 @@ module('Integration | header | main', function() {
 
       let containerWidth = table.containerWidth;
       let tableWidth = table.width;
+      let slackHeader = table.slackHeaders.objectAt(0);
 
       assert.equal(
         tableWidth - containerWidth,
@@ -67,7 +70,7 @@ module('Integration | header | main', function() {
         'Table width is adjusted from container width by the specified amount.'
       );
 
-      assert.notOk(table.header.slackHeader, 'slack column does not exist');
+      assert.notOk(slackHeader.isPresent, 'slack column does not exist');
     });
 
     test('gte-container', async function(assert) {
@@ -81,13 +84,14 @@ module('Integration | header | main', function() {
 
       let containerWidth = table.containerWidth;
       let tableWidth = table.width;
+      let slackHeader = table.slackHeaders.objectAt(0);
 
       assert.ok(
         Math.abs(tableWidth - containerWidth) <= 5,
         'First column takes extra space in first column resize mode.'
       );
 
-      assert.notOk(table.header.slackHeader, 'slack column does not exist');
+      assert.notOk(slackHeader.isPresent, 'slack column does not exist');
     });
 
     test('lte-container', async function(assert) {
@@ -101,13 +105,14 @@ module('Integration | header | main', function() {
 
       let containerWidth = table.containerWidth;
       let tableWidth = table.width;
+      let slackHeader = table.slackHeaders.objectAt(0);
 
       assert.ok(
         Math.abs(tableWidth - containerWidth) <= 5,
         'First column takes extra space in first column resize mode.'
       );
 
-      assert.notOk(table.header.slackHeader, 'slack column does not exist');
+      assert.notOk(slackHeader.isPresent, 'slack column does not exist');
     });
 
     test('eq-container-slack', async function(assert) {
@@ -121,27 +126,27 @@ module('Integration | header | main', function() {
 
       let containerWidth = table.containerWidth;
       let header = table.headers.objectAt(0);
-      assert.equal(table.width, containerWidth, 'table fits container exactly');
+      let slackHeader = table.slackHeaders.objectAt(0);
 
-      let slackHeader = await table.header.slackHeader;
-      assert.notEqual(slackHeader.style.display, 'none', 'slack column is rendered');
-      assert.equal(slackHeader.offsetWidth, containerWidth - 100, 'slack column fills whitespace');
+      assert.equal(table.width, containerWidth, 'table fits container exactly');
+      assert.ok(slackHeader.isRendered, 'slack column is rendered');
+      assert.equal(slackHeader.width, containerWidth - 100, 'slack column fills whitespace');
 
       // expand column a little bit
       await header.resize(200);
       assert.equal(table.width, containerWidth, 'table fits container exactly');
-      assert.notEqual(slackHeader.style.display, 'none', 'slack column is rendered');
-      assert.equal(slackHeader.offsetWidth, containerWidth - 200, 'slack column fills whitespace');
+      assert.ok(slackHeader.isRendered, 'slack column is rendered');
+      assert.equal(slackHeader.width, containerWidth - 200, 'slack column fills whitespace');
 
       // expand column to fill container
       await header.resize(containerWidth);
       assert.equal(table.width, containerWidth, 'table fits container exactly');
-      assert.equal(slackHeader.style.display, 'none', 'slack column is not rendered');
+      assert.notOk(slackHeader.isRendered, 'slack column is not rendered');
 
       // try to expand column beyond container
       await header.resize(containerWidth + 100);
       assert.equal(table.width, containerWidth, 'table fits container exactly');
-      assert.equal(slackHeader.style.display, 'none', 'slack column is not rendered');
+      assert.notOk(slackHeader.isRendered, 'slack column is not rendered');
     });
 
     test('gte-container-slack', async function(assert) {
@@ -155,27 +160,27 @@ module('Integration | header | main', function() {
 
       let containerWidth = table.containerWidth;
       let header = table.headers.objectAt(0);
-      assert.equal(table.width, containerWidth, 'table fits container exactly');
+      let slackHeader = table.slackHeaders.objectAt(0);
 
-      let slackHeader = await table.header.slackHeader;
-      assert.notEqual(slackHeader.style.display, 'none', 'slack column is rendered');
-      assert.equal(slackHeader.offsetWidth, containerWidth - 100, 'slack column fills whitespace');
+      assert.equal(table.width, containerWidth, 'table fits container exactly');
+      assert.ok(slackHeader.isRendered, 'slack column is rendered');
+      assert.equal(slackHeader.width, containerWidth - 100, 'slack column fills whitespace');
 
       // expand column a little bit
       await header.resize(200);
       assert.equal(table.width, containerWidth, 'table fits container exactly');
-      assert.notEqual(slackHeader.style.display, 'none', 'slack column is rendered');
-      assert.equal(slackHeader.offsetWidth, containerWidth - 200, 'slack column fills whitespace');
+      assert.ok(slackHeader.isRendered, 'slack column is rendered');
+      assert.equal(slackHeader.width, containerWidth - 200, 'slack column fills whitespace');
 
       // expand column to fill container
       await header.resize(containerWidth);
       assert.equal(table.width, containerWidth, 'table fits container exactly');
-      assert.equal(slackHeader.style.display, 'none', 'slack column is not rendered');
+      assert.notOk(slackHeader.isRendered, 'slack column is not rendered');
 
       // expand column beyond container
       await header.resize(containerWidth + 100);
       assert.equal(table.width, containerWidth + 100, 'table extends beyond container');
-      assert.equal(slackHeader.style.display, 'none', 'slack column is not rendered');
+      assert.notOk(slackHeader.isRendered, 'slack column is not rendered');
     });
   });
 
@@ -314,34 +319,30 @@ module('Integration | header | main', function() {
       let containerWidth = table.containerWidth;
       let header1 = table.headers.objectAt(0);
       let header2 = table.headers.objectAt(1);
-      let slackHeader = await table.header.slackHeader;
+      let slackHeader = table.slackHeaders.objectAt(0);
 
       // `fillMode` is ignored because we are in slack mode
       assert.equal(header1.width, 100, 'first column is default size');
       assert.equal(header2.width, 100, 'second column is default size');
-      assert.equal(
-        slackHeader.offsetWidth,
-        containerWidth - 200,
-        'slack column fills remaining space'
-      );
+      assert.equal(slackHeader.width, containerWidth - 200, 'slack column fills remaining space');
 
       // expand first column to eliminate slack
       await header1.resize(containerWidth - 100);
       assert.equal(header1.width, containerWidth - 100, 'first column is resized');
       assert.equal(header2.width, 100, 'second column remains default size');
-      assert.equal(slackHeader.offsetWidth, 0, 'slack column is unused');
+      assert.notOk(slackHeader.isRendered, 'slack column is not rendered');
 
       // expand second column beyond container; `equal-column` fill mode is applied
       await header2.resize(200);
       assert.equal(header1.width, containerWidth - 150, 'first column receives equal share');
       assert.equal(header2.width, 150, 'second column receives equal share');
-      assert.equal(slackHeader.offsetWidth, 0, 'slack column is unused');
+      assert.notOk(slackHeader.isRendered, 'slack column is not rendered');
 
       // shrink second column to original size; slack is applied
       await header2.resize(100);
       assert.equal(header1.width, containerWidth - 150, 'first column is unaffected');
-      assert.equal(header2.width, 100, 'second column is resized');
-      assert.equal(slackHeader.offsetWidth, 50, 'slack column receives the balance');
+      assert.ok(slackHeader.isRendered, 'slack column is rendered');
+      assert.equal(slackHeader.width, 50, 'slack column receives the balance');
     });
 
     test('eq-container-slack with initialFillMode', async function(assert) {
@@ -358,24 +359,25 @@ module('Integration | header | main', function() {
       let containerWidth = table.containerWidth;
       let header1 = table.headers.objectAt(0);
       let header2 = table.headers.objectAt(1);
-      let slackHeader = await table.header.slackHeader;
+      let slackHeader = table.slackHeaders.objectAt(0);
 
       // `first-column` initial fill mode is applied
       assert.equal(header1.width, containerWidth - 100, 'first column receives fill');
       assert.equal(header2.width, 100, 'second column remains default size');
-      assert.equal(slackHeader.offsetWidth, 0, 'slack column is unused');
+      assert.notOk(slackHeader.isRendered, 'slack column is not rendered');
 
       // expand second column beyond container; `equal-column` fill mode is applied
       await header2.resize(200);
       assert.equal(header1.width, containerWidth - 150, 'first column receives equal share');
       assert.equal(header2.width, 150, 'second column receives equal share');
-      assert.equal(slackHeader.offsetWidth, 0, 'slack column is unused');
+      assert.notOk(slackHeader.isRendered, 'slack column is not rendered');
 
       // shrink second column to original size; slack is applied
       await header2.resize(100);
       assert.equal(header1.width, containerWidth - 150, 'first column is unaffected');
       assert.equal(header2.width, 100, 'second column is resized');
-      assert.equal(slackHeader.offsetWidth, 50, 'slack column receives the balance');
+      assert.ok(slackHeader.isRendered, 'slack column is rendered');
+      assert.equal(slackHeader.width, 50, 'slack column receives the balance');
     });
 
     test('gte-container-slack', async function(assert) {
@@ -390,15 +392,14 @@ module('Integration | header | main', function() {
 
       let containerWidth = table.containerWidth;
       let header = table.headers.objectAt(0);
-      let slackHeader = await table.header.slackHeader;
+      let slackHeader = table.slackHeaders.objectAt(0);
 
       assert.equal(header.width, containerWidth, 'fill mode is applied on initial run');
-      assert.equal(slackHeader.offsetWidth, 0, 'slack column is hidden');
+      assert.notOk(slackHeader.isRendered, 'slack column is not rendered');
 
       await header.resize(100);
-
       assert.equal(header.width, 100, 'header is resized');
-      assert.equal(slackHeader.offsetWidth, containerWidth - 100, 'slack column is expanded');
+      assert.equal(slackHeader.width, containerWidth - 100, 'slack column is expanded');
     });
   });
 


### PR DESCRIPTION
Changes:
- Adds an `is-slack` class to slack `th` and `td` elements
- Adds an `is-last-column` class to the rightmost column cells. In slack modes, the rightmost column can be either the slack column (when slack is visible) or its immediate neighbor to the left (when no slack is visible).
- Adds tests for the above and the previously-untested `is-first-column` class
- Improves the page object to better handle slack and nested columns
