### PR TITLE
Limit horizontal scroll indicator to table height

### DIFF
--- a/addon/components/-private/scroll-indicators/component.js
+++ b/addon/components/-private/scroll-indicators/component.js
@@ -20,6 +20,7 @@ const horizontalIndicatorStyle = side => {
     `columnTree.${side}FixedNodes.@each.width`,
     'overflowHeight',
     'scrollbarWidth',
+    'tableHeight',
     function() {
       let style = [];
 
@@ -42,7 +43,9 @@ const horizontalIndicatorStyle = side => {
       // height
       let overflowHeight = this.get('overflowHeight');
       if (!isNone(overflowHeight)) {
-        style.push(`height:${overflowHeight}px;`);
+        let tableHeight = this.get('tableHeight');
+        let height = isNone(tableHeight) ? overflowHeight : Math.min(overflowHeight, tableHeight);
+        style.push(`height:${height}px;`);
       }
 
       return htmlSafe(style.join(''));
@@ -141,6 +144,7 @@ export default Component.extend({
 
   overflowHeight: null,
   overflowWidth: null,
+  tableHeight: null,
   tableWidth: null,
   headerHeight: null,
   visibleFooterHeight: null,
@@ -211,7 +215,8 @@ export default Component.extend({
 
     let overflowHeight = el.clientHeight;
     let overflowWidth = el.clientWidth;
-    let tableWidth = table ? table.clientWidth : null;
+    let tableWidth = table ? table.offsetWidth : null;
+    let tableHeight = table ? table.offsetHeight : null;
     let headerHeight = header ? header.offsetHeight : null;
 
     // part of the footer can be obscured until the table is scrolled to the
@@ -248,6 +253,7 @@ export default Component.extend({
 
       overflowHeight,
       overflowWidth,
+      tableHeight,
       tableWidth,
       headerHeight,
 


### PR DESCRIPTION
Prevents horizontal scroll indicators from extending beyond table height. This occurs when the overflow container is given an explicit height that exceeds the height of the table.

**Before:**
<img width="648" alt="20210302 Ember Table Horiz Scroll Indicators Before" src="https://user-images.githubusercontent.com/2594635/109716161-79824200-7b72-11eb-8112-322f90a795e9.png">

**After:**
<img width="649" alt="20210302 Ember Table Horiz Scroll Indicators After" src="https://user-images.githubusercontent.com/2594635/109716170-7dae5f80-7b72-11eb-8a08-05225188b133.png">
