### PR TITLE
Pass rows count to sub-components

### DIFF
--- a/addon/components/-private/row-wrapper.js
+++ b/addon/components/-private/row-wrapper.js
@@ -88,6 +88,7 @@ export default Component.extend({
 
       let rowValue = this.get('rowValue');
       let rowMeta = this.get('rowMeta');
+      let rowsCount = this.get('rowsCount');
       let canSelect = this.get('canSelect');
       let checkboxSelectionMode = canSelect ? this.get('checkboxSelectionMode') : 'none';
       let rowSelectionMode = canSelect ? this.get('rowSelectionMode') : 'none';
@@ -116,6 +117,7 @@ export default Component.extend({
           rowMeta,
           rowSelectionMode,
           rowValue,
+          rowsCount,
         });
       });
 

--- a/addon/components/-private/row-wrapper.js
+++ b/addon/components/-private/row-wrapper.js
@@ -65,7 +65,8 @@ export default Component.extend({
       let rowsCount = this.get('rowsCount');
 
       return { rowValue, rowMeta, cells, rowSelectionMode, rowsCount };
-  }),
+    }
+  ),
 
   rowMeta: computed('rowValue', function() {
     let rowValue = this.get('rowValue');

--- a/addon/components/-private/row-wrapper.js
+++ b/addon/components/-private/row-wrapper.js
@@ -35,6 +35,7 @@ export default Component.extend({
   rowMetaCache: undefined,
   rowSelectionMode: undefined,
   rowValue: undefined,
+  rowsCount: undefined,
 
   init() {
     this._super(...arguments);
@@ -48,14 +49,22 @@ export default Component.extend({
     this._super(...arguments);
   },
 
-  api: computed('rowValue', 'rowMeta', 'cells', 'canSelect', 'rowSelectionMode', function() {
-    let rowValue = this.get('rowValue');
-    let rowMeta = this.get('rowMeta');
-    let cells = this.get('cells');
-    let canSelect = this.get('canSelect');
-    let rowSelectionMode = canSelect ? this.get('rowSelectionMode') : 'none';
+  api: computed(
+    'rowValue',
+    'rowMeta',
+    'cells',
+    'canSelect',
+    'rowSelectionMode',
+    'rowsCount',
+    function() {
+      let rowValue = this.get('rowValue');
+      let rowMeta = this.get('rowMeta');
+      let cells = this.get('cells');
+      let canSelect = this.get('canSelect');
+      let rowSelectionMode = canSelect ? this.get('rowSelectionMode') : 'none';
+      let rowsCount = this.get('rowsCount');
 
-    return { rowValue, rowMeta, cells, rowSelectionMode };
+      return { rowValue, rowMeta, cells, rowSelectionMode, rowsCount };
   }),
 
   rowMeta: computed('rowValue', function() {

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -26,6 +26,8 @@
     rowSelectionMode=rowSelectionMode
     checkboxSelectionMode=checkboxSelectionMode
 
+    rowsCount=wrappedRows.length
+
     as |api|
   }}
     {{#if hasBlock}}
@@ -34,6 +36,7 @@
         rowMeta=api.rowMeta
         cells=api.cells
         rowSelectionMode=api.rowSelectionMode
+        rowsCount=api.rowsCount
 
         row=(component "ember-tr" api=api)
       )}}

--- a/addon/components/ember-td/component.js
+++ b/addon/components/ember-td/component.js
@@ -78,6 +78,8 @@ export default BaseTableCell.extend({
 
   rowMeta: readOnly('unwrappedApi.rowMeta'),
 
+  rowsCount: readOnly('unwrappedApi.rowsCount'),
+
   rowSelectionMode: readOnly('unwrappedApi.rowSelectionMode'),
 
   checkboxSelectionMode: readOnly('unwrappedApi.checkboxSelectionMode'),

--- a/addon/components/ember-td/template.hbs
+++ b/addon/components/ember-td/template.hbs
@@ -31,7 +31,7 @@
 
     <div class="et-cell-content">
       {{#if hasBlock}}
-        {{yield cellValue columnValue rowValue cellMeta columnMeta rowMeta}}
+        {{yield cellValue columnValue rowValue cellMeta columnMeta rowMeta rowsCount}}
       {{else}}
         {{cellValue}}
       {{/if}}
@@ -39,7 +39,7 @@
   </div>
 {{else}}
   {{#if hasBlock}}
-    {{yield cellValue columnValue rowValue cellMeta columnMeta rowMeta}}
+    {{yield cellValue columnValue rowValue cellMeta columnMeta rowMeta rowsCount}}
   {{else}}
     {{cellValue}}
   {{/if}}

--- a/addon/components/ember-tfoot/template.hbs
+++ b/addon/components/ember-tfoot/template.hbs
@@ -10,6 +10,8 @@
     rowSelectionMode=rowSelectionMode
     checkboxSelectionMode=checkboxSelectionMode
 
+    rowsCount=wrappedRowArray.length
+
     as |api|
   }}
     {{#if hasBlock}}
@@ -18,6 +20,7 @@
         rowMeta=api.rowMeta
         cells=api.cells
         rowSelectionMode=api.rowSelectionMode
+        rowsCount=api.rowsCount
 
         row=(component "ember-tr" api=api)
       )}}

--- a/addon/components/ember-thead/component.js
+++ b/addon/components/ember-thead/component.js
@@ -337,7 +337,7 @@ export default Component.extend({
             })
           );
 
-          return { cells, isHeader: true };
+          return { cells, isHeader: true, rowsCount: rows.length };
         })
       );
     }

--- a/addon/components/ember-thead/template.hbs
+++ b/addon/components/ember-thead/template.hbs
@@ -3,6 +3,7 @@
     {{yield (hash
       cells=api.cells
       isHeader=api.isHeader
+      rowsCount=api.rowsCount
 
       row=(component "ember-tr" api=api)
     )}}

--- a/addon/components/ember-tr/template.hbs
+++ b/addon/components/ember-tr/template.hbs
@@ -8,6 +8,8 @@
         sorts=api.sorts
         sendUpdateSort=api.sendUpdateSort
 
+        rowsCount=api.rowsCount
+
         cell=(component "ember-th" api=api)
       )}}
     {{else}}
@@ -22,6 +24,8 @@
 
         rowValue=api.rowValue
         rowMeta=api.rowMeta
+
+        rowsCount=api.rowsCount
 
         cell=(component "ember-td" api=api)
       )}}

--- a/tests/dummy/app/pods/components/main/table-meta-data/cell-selection/component.js
+++ b/tests/dummy/app/pods/components/main/table-meta-data/cell-selection/component.js
@@ -1,0 +1,45 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { generateRows } from '../../../../../utils/generators';
+
+export default Component.extend({
+  rows: computed(function() {
+    return generateRows(100);
+  }),
+
+  columns: computed(function() {
+    return [
+      { name: 'A', valuePath: 'A' },
+      { name: 'B', valuePath: 'B' },
+      { name: 'C', valuePath: 'C' },
+      { name: 'D', valuePath: 'D' },
+      { name: 'E', valuePath: 'E' },
+      { name: 'F', valuePath: 'F' },
+      { name: 'G', valuePath: 'G' },
+    ];
+  }),
+
+  // BEGIN-SNIPPET table-meta-data-cell-selection.js
+  actions: {
+    setSelected(cellMeta, columnMeta, rowMeta) {
+      // If we have selected before, unselect the previous selection
+      if (this._hasSelection) {
+        this._lastSelectedCellMeta.set('selected', false);
+        this._lastSelectedColumnMeta.set('selected', false);
+        this._lastSelectedRowMeta.set('selected', false);
+      }
+
+      // Set selection on the meta objects
+      cellMeta.set('selected', true);
+      columnMeta.set('selected', true);
+      rowMeta.set('selected', true);
+
+      // Store the meta objects to unset in the future
+      this._lastSelectedCellMeta = cellMeta;
+      this._lastSelectedColumnMeta = columnMeta;
+      this._lastSelectedRowMeta = rowMeta;
+      this._hasSelection = true;
+    },
+  },
+  // END-SNIPPET
+});

--- a/tests/dummy/app/pods/components/main/table-meta-data/cell-selection/template.hbs
+++ b/tests/dummy/app/pods/components/main/table-meta-data/cell-selection/template.hbs
@@ -1,0 +1,43 @@
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name="cell-selection"}}
+    <div class="demo-container small">
+      {{! BEGIN-SNIPPET table-meta-data-cell-selection.hbs }}
+      <EmberTable as |t|>
+        <t.head @columns={{columns}} as |h|>
+          <h.row as |r|>
+            <r.cell
+              class="{{if r.columnMeta.selected 'is-column-selected'}}"
+
+              as |column|
+            >
+              {{column.name}}
+            </r.cell>
+          </h.row>
+        </t.head>
+
+        <t.body @rows={{rows}} as |b|>
+          <b.row
+            class="{{if b.rowMeta.selected 'is-row-selected'}}"
+
+            as |r|
+          >
+            <r.cell
+              class="{{if r.cellMeta.selected 'is-cell-selected'}} {{if r.columnMeta.selected 'is-column-selected'}}"
+
+              as |cell column row cellMeta columnMeta rowMeta|
+            >
+              <div onclick={{action "setSelected" cellMeta columnMeta rowMeta}} class="cell-content">
+                {{cell}}
+              </div>
+            </r.cell>
+          </b.row>
+        </t.body>
+      </EmberTable>
+      {{! END-SNIPPET }}
+    </div>
+  {{/demo.example}}
+
+  {{demo.snippet name='table-meta-data-cell-selection.hbs'}}
+  {{demo.snippet name='table-meta-data-cell-selection.js' label='component.js'}}
+{{/docs-demo}}

--- a/tests/dummy/app/pods/docs/guides/main/table-meta-data/controller.js
+++ b/tests/dummy/app/pods/docs/guides/main/table-meta-data/controller.js
@@ -18,28 +18,4 @@ export default Controller.extend({
       { name: 'G', valuePath: 'G' },
     ];
   }),
-
-  // BEGIN-SNIPPET table-meta-data-cell-selection.js
-  actions: {
-    setSelected(cellMeta, columnMeta, rowMeta) {
-      // If we have selected before, unselect the previous selection
-      if (this._hasSelection) {
-        this._lastSelectedCellMeta.set('selected', false);
-        this._lastSelectedColumnMeta.set('selected', false);
-        this._lastSelectedRowMeta.set('selected', false);
-      }
-
-      // Set selection on the meta objects
-      cellMeta.set('selected', true);
-      columnMeta.set('selected', true);
-      rowMeta.set('selected', true);
-
-      // Store the meta objects to unset in the future
-      this._lastSelectedCellMeta = cellMeta;
-      this._lastSelectedColumnMeta = columnMeta;
-      this._lastSelectedRowMeta = rowMeta;
-      this._hasSelection = true;
-    },
-  },
-  // END-SNIPPET
 });

--- a/tests/dummy/app/pods/docs/guides/main/table-meta-data/template.md
+++ b/tests/dummy/app/pods/docs/guides/main/table-meta-data/template.md
@@ -17,7 +17,7 @@ cell/column/row values at the cell level, and are generally accessible wherever
 their corresponding values are:
 
 ```hbs
-<t.cell as |cell column row cellMeta columnMeta rowMeta|>
+<t.cell as |cell column row cellMeta columnMeta rowMeta rowsCount|>
 ```
 
 ## What are meta objects?
@@ -43,37 +43,43 @@ active to show the user where they are in the table. Ember Table does _not_ have
 this functionality out of the box - let's see how we would implement it with
 meta objects:
 
+<!-- this example breaks markdown parsing below it, so it can't be inline -->
+{{main/table-meta-data/cell-selection}}
+
+## Accessing row indices in templates
+
+Meta objects can be used in templates to render conditional markdown based on
+the index of the current row.
+
 {{#docs-demo as |demo|}}
-  {{#demo.example name="cell-selection"}}
+  {{#demo.example name="row-indices"}}
     <div class="demo-container small">
-      {{! BEGIN-SNIPPET table-meta-data-cell-selection.hbs }}
+      <style>
+        {{! BEGIN-SNIPPET table-meta-data-row-indices.css}}
+        .first-row-cell {
+          font-weight: bold;
+        }
+
+        .last-row-cell {
+          font-style: italic;
+        }
+        {{! END-SNIPPET}}
+      </style>
+
+      {{! BEGIN-SNIPPET table-meta-data-row-indices.hbs }}
       <EmberTable as |t|>
-        <t.head @columns={{columns}} as |h|>
-          <h.row as |r|>
-            <r.cell
-              class="{{if r.columnMeta.selected 'is-column-selected'}}"
-
-              as |column|
-            >
-              {{column.name}}
-            </r.cell>
-          </h.row>
-        </t.head>
-
+        <t.head @columns={{columns}} />
         <t.body @rows={{rows}} as |b|>
-          <b.row
-            class="{{if b.rowMeta.selected 'is-row-selected'}}"
-
-            as |r|
-          >
-            <r.cell
-              class="{{if r.cellMeta.selected 'is-cell-selected'}} {{if r.columnMeta.selected 'is-column-selected'}}"
-
-              as |cell column row cellMeta columnMeta rowMeta|
-            >
-              <div onclick={{action "setSelected" cellMeta columnMeta rowMeta}} class="cell-content">
+          <b.row as |r|>
+            <r.cell as |cell column row cellMeta columnMeta rowMeta rowsCount|>
+              {{#if (eq rowMeta.index 0)}}
+                <span class="first-row-cell">{{cell}}</span>
+              {{!-- `dec` helper is part of `ember-composable-helpers` --}}
+              {{else if (lt rowMeta.index (dec rowsCount))}}
                 {{cell}}
-              </div>
+              {{else}}
+                <span class="last-row-cell">{{cell}}</span>
+              {{/if}}
             </r.cell>
           </b.row>
         </t.body>
@@ -82,6 +88,6 @@ meta objects:
     </div>
   {{/demo.example}}
 
-  {{demo.snippet name='table-meta-data-cell-selection.hbs'}}
-  {{demo.snippet name='table-meta-data-cell-selection.js' label='component.js'}}
+  {{demo.snippet name='table-meta-data-row-indices.hbs'}}
+  {{demo.snippet name='table-meta-data-row-indices.css'}}
 {{/docs-demo}}

--- a/tests/dummy/app/pods/docs/guides/main/table-meta-data/template.md
+++ b/tests/dummy/app/pods/docs/guides/main/table-meta-data/template.md
@@ -31,6 +31,12 @@ internal bookkeeping such as collapse and selection state, but you are free to
 use these objects to store whatever meta information you would like in the
 table.
 
+`rowsCount` is also yielded by the cell component. This count is a reflection
+of how many rows the user can currently see by scrolling through the table. It
+is typically smaller than the total number of rows passed into, say, the
+`ember-tbody` component, because it excludes rows that have been hidden by
+collapsing a parent.
+
 ## What are they used for?
 
 Complex data tables have lots of functionality that requires some amount of

--- a/tests/integration/components/tree-test.js
+++ b/tests/integration/components/tree-test.js
@@ -1,9 +1,11 @@
 import { module, test } from 'ember-qunit';
 import { componentModule } from '../../helpers/module';
+import hbs from 'htmlbars-inline-precompile';
 
 import TablePage from 'ember-table/test-support/pages/ember-table';
 
-import { generateTable, generateRows } from '../../helpers/generate-table';
+import { generateTable, generateColumns, generateRows } from '../../helpers/generate-table';
+
 import wait from 'ember-test-helpers/wait';
 
 let table = new TablePage();
@@ -80,6 +82,37 @@ module('Integration | Tree', () => {
       await wait();
 
       assert.ok(table.rows.objectAt(0).collapse.isPresent, 'collapse toggle is back');
+    });
+  });
+
+  componentModule('row counting', function() {
+    test('rowsCount excludes collapsed rows', async function(assert) {
+      let columnCount = 1;
+      let rowCount = 1;
+      let rowDepth = 2;
+
+      this.set('columns', generateColumns(columnCount));
+      this.set('rows', generateRows(rowCount, rowDepth));
+
+      this.render(hbs`
+        {{#ember-table as |t|}}
+          {{ember-thead api=t columns=columns}}
+          {{#ember-tbody api=t rows=rows as |b|}}
+            {{#ember-tr api=b as |r|}}
+              {{#ember-td api=r as |c|}}
+                {{b.rowsCount}}
+              {{/ember-td}}
+            {{/ember-tr}}
+          {{/ember-tbody}}
+        {{/ember-table}}
+      `);
+
+      await wait();
+
+      assert.equal(table.getCell(0, 0).text, '2', 'rowsCount is correct before collapse');
+
+      await table.rows.objectAt(0).toggleCollapse();
+      assert.equal(table.getCell(0, 0).text, '1', 'rowsCount is correct after collapse');
     });
   });
 });


### PR DESCRIPTION
Passes the effective row count from each of `thead`, `tbody`, `tfoot` down through the component hierarchy. This count excludes rows that are hidden because their parent is collapsed, reflecting what the user actually sees. It is typically smaller than `rows.length`.

This can be used in the template to identify when the current row is the bottom rendered row.

Includes docs update and a supporting test.

Example usage:

```hbs
<EmberTable as |t|>
  <t.head @columns={{columns}} />
  <t.body @rows={{rows}} as |b|>
    <b.row as |r|>
      <r.cell as |cell column row cellMeta columnMeta rowMeta rowsCount|>
        {{#if (eq rowMeta.index 0)}}
          {{!-- custom first row markup --}}
          {{cell}}
        {{else if (lt rowMeta.index (dec rowsCount))}}
          {{!-- middle row markup; `dec` helper is from`ember-composable-helpers` --}}
          {{cell}}
        {{else}}
          {{!-- custom last row markup --}}
          {{cell}}
        {{/if}}
      </r.cell>
    </b.row>
  </t.body>
</EmberTable>
```
