### PR TITLE
Enforce min and max width constraints before initial fill

### DIFF
--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -676,6 +676,18 @@ export default EmberObject.extend({
       return;
     }
 
+    let leaves = get(this, 'root.leaves');
+
+    // ensures that min and max widths are respected _before_ `applyFillMode()`
+    // decides if the width constraint has been violated
+    leaves.forEach(leaf => {
+      let width = get(leaf, 'width');
+      let minWidth = get(leaf, 'minWidth');
+      let maxWidth = get(leaf, 'maxWidth');
+      let newWidth = Math.min(Math.max(width, minWidth), maxWidth);
+      set(leaf, 'width', newWidth);
+    });
+
     let isSlackModeEnabled = get(this, 'isSlackModeEnabled');
     let initialFillMode = get(this, 'initialFillMode');
 

--- a/tests/integration/components/headers/main-test.js
+++ b/tests/integration/components/headers/main-test.js
@@ -9,6 +9,34 @@ import TablePage from 'ember-table/test-support/pages/ember-table';
 const table = new TablePage();
 
 module('Integration | header | main', function() {
+  componentModule('initial render', function() {
+    test('min column widths respected', async function(assert) {
+      await generateTable(this, {
+        columnCount: 1,
+        columnOptions: {
+          width: 100,
+          minWidth: 200,
+        },
+      });
+
+      let header = table.headers.objectAt(0);
+      assert.equal(header.width, 200, 'column has min width');
+    });
+
+    test('max column widths respected', async function(assert) {
+      await generateTable(this, {
+        columnCount: 1,
+        columnOptions: {
+          width: 200,
+          maxWidth: 100,
+        },
+      });
+
+      let header = table.headers.objectAt(0);
+      assert.equal(header.width, 100, 'column has max width');
+    });
+  });
+
   componentModule('widthConstraint', function() {
     test('eq-container when smaller', async function(assert) {
       await generateTable(this, {
@@ -177,34 +205,6 @@ module('Integration | header | main', function() {
       assert.equal(table.width, containerWidth + 100, 'table extends beyond container');
       assert.equal(slackHeader.style.display, 'none', 'slack column is not rendered');
     });
-
-    test('none respects min widths on initial render', async function(assert) {
-      await generateTable(this, {
-        widthConstraint: 'none',
-        columnCount: 1,
-        columnOptions: {
-          width: 100,
-          minWidth: 200,
-        },
-      });
-
-      let header = table.headers.objectAt(0);
-      assert.equal(header.width, 200, 'column has min width');
-    });
-
-    test('none respects max widths on initial render', async function(assert) {
-      await generateTable(this, {
-        widthConstraint: 'none',
-        columnCount: 1,
-        columnOptions: {
-          width: 200,
-          maxWidth: 100,
-        },
-      });
-
-      let header = table.headers.objectAt(0);
-      assert.equal(header.width, 100, 'column has max width');
-    });
   });
 
   componentModule('fillMode', function() {
@@ -230,6 +230,7 @@ module('Integration | header | main', function() {
         columnCount: 2,
         columnOptions: {
           width: columnWidth,
+          minWidth: columnWidth,
         },
       });
 
@@ -256,6 +257,7 @@ module('Integration | header | main', function() {
         columnCount: 2,
         columnOptions: {
           width: columnWidth,
+          minWidth: columnWidth,
         },
       });
 
@@ -283,6 +285,7 @@ module('Integration | header | main', function() {
         columnCount: 3,
         columnOptions: {
           width: columnWidth,
+          minWidth: columnWidth,
         },
       });
 
@@ -305,6 +308,7 @@ module('Integration | header | main', function() {
         columnCount: 3,
         columnOptions: {
           width: columnWidth,
+          minWidth: columnWidth,
         },
       });
 

--- a/tests/integration/components/headers/main-test.js
+++ b/tests/integration/components/headers/main-test.js
@@ -177,6 +177,34 @@ module('Integration | header | main', function() {
       assert.equal(table.width, containerWidth + 100, 'table extends beyond container');
       assert.equal(slackHeader.style.display, 'none', 'slack column is not rendered');
     });
+
+    test('none respects min widths on initial render', async function(assert) {
+      await generateTable(this, {
+        widthConstraint: 'none',
+        columnCount: 1,
+        columnOptions: {
+          width: 100,
+          minWidth: 200,
+        },
+      });
+
+      let header = table.headers.objectAt(0);
+      assert.equal(header.width, 200, 'column has min width');
+    });
+
+    test('none respects max widths on initial render', async function(assert) {
+      await generateTable(this, {
+        widthConstraint: 'none',
+        columnCount: 1,
+        columnOptions: {
+          width: 200,
+          maxWidth: 100,
+        },
+      });
+
+      let header = table.headers.objectAt(0);
+      assert.equal(header.width, 100, 'column has max width');
+    });
   });
 
   componentModule('fillMode', function() {


### PR DESCRIPTION
Ensures that min and max column widths are enforced on initial render.

Currently, min and max column widths are only enforced in two cases:
* when the `widthConstraint` mode is violated
* when the user manually resizes a column

In particular, if `widthConstraint` is `none`, or the chosen `widthConstraint` is not initially violated (e.g. `lte-container` when there is only one column), min and max column widths will be ignored on initial render.