### PR TITLE
Replace hasBlock usage with has-block helper

### DIFF
--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -30,7 +30,7 @@
 
     as |api|
   }}
-    {{#if hasBlock}}
+    {{#if (has-block)}}
       {{yield (hash
         rowValue=api.rowValue
         rowMeta=api.rowMeta

--- a/addon/components/ember-td/template.hbs
+++ b/addon/components/ember-td/template.hbs
@@ -30,7 +30,7 @@
     {{/if}}
 
     <div class="et-cell-content">
-      {{#if hasBlock}}
+      {{#if (has-block)}}
         {{yield this.cellValue this.columnValue this.rowValue this.cellMeta this.columnMeta this.rowMeta this.rowsCount}}
       {{else}}
         {{this.cellValue}}
@@ -38,7 +38,7 @@
     </div>
   </div>
 {{else}}
-  {{#if hasBlock}}
+  {{#if (has-block)}}
     {{yield this.cellValue this.columnValue this.rowValue this.cellMeta this.columnMeta this.rowMeta this.rowsCount}}
   {{else}}
     {{this.cellValue}}

--- a/addon/components/ember-tfoot/template.hbs
+++ b/addon/components/ember-tfoot/template.hbs
@@ -14,7 +14,7 @@
 
     as |api|
   }}
-    {{#if hasBlock}}
+    {{#if (has-block)}}
       {{yield (hash
         rowValue=api.rowValue
         rowMeta=api.rowMeta

--- a/addon/components/ember-th/sort-indicator/template.hbs
+++ b/addon/components/ember-th/sort-indicator/template.hbs
@@ -1,6 +1,6 @@
 {{#if this.isSorted}}
   <span data-test-sort-indicator class="et-sort-indicator {{if this.isSortedAsc 'is-ascending' 'is-descending'}}">
-    {{#if hasBlock}}
+    {{#if (has-block)}}
       {{yield this.columnMeta}}
     {{else}}
       {{#if this.isMultiSorted}}

--- a/addon/components/ember-th/template.hbs
+++ b/addon/components/ember-th/template.hbs
@@ -1,4 +1,4 @@
-{{#if hasBlock}}
+{{#if (has-block)}}
   {{yield this.columnValue this.columnMeta this.rowMeta}}
 {{else}}
   {{this.columnValue.name}}

--- a/addon/components/ember-thead/template.hbs
+++ b/addon/components/ember-thead/template.hbs
@@ -1,5 +1,5 @@
 {{#each this.wrappedRows as |api|}}
-  {{#if hasBlock}}
+  {{#if (has-block)}}
     {{yield (hash
       cells=api.cells
       isHeader=api.isHeader

--- a/addon/components/ember-tr/template.hbs
+++ b/addon/components/ember-tr/template.hbs
@@ -1,5 +1,5 @@
 {{#each this.cells as |api|}}
-  {{#if hasBlock}}
+  {{#if (has-block)}}
     {{#if this.isHeader}}
       {{yield (hash
         columnValue=api.columnValue


### PR DESCRIPTION
Ember 3.26 introduces a deprecation for `hasBlock` in favor of `(has-block)`:

- RFC: https://github.com/emberjs/rfcs/pull/689
- PR: https://github.com/emberjs/ember.js/pull/19374
- Deprecation Guide: https://deprecations.emberjs.com/v3.x/#toc_has-block-and-has-block-params

 I was curious how easy this would be to address in ember-table, so this branch tries out the simple find-and-replace. It appears to pass all test scenarios *except* Ember 2.8. I'm not sure there's a polyfill for this (I'm not immediately finding one) to get us compatible back to 2.8, so maybe we just need to sit on it until we're ready to drop 2.8 compat - which I trust would happen before 4.0 drops the deprecated option?