### PR TITLE
Detect row count test selector to enable observers

### DIFF
--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -11,7 +11,7 @@ import CollapseTree, { SELECT_MODE } from '../../-private/collapse-tree';
 import defaultTo from '../../-private/utils/default-to';
 
 import layout from './template';
-import { assert, runInDebug } from '@ember/debug';
+import { assert } from '@ember/debug';
 
 /**
   The table body component. This component manages the main bulk of the rows of
@@ -266,13 +266,18 @@ export default Component.extend({
 
     this._updateCollapseTree();
 
-    runInDebug(() => {
+    /*
+     * Ember test selectors will remove data-test-row-count from the bindings,
+     * so if it is missing there is no need to all the count.
+     */
+    if (this.attributeBindings.includes('data-test-row-count')) {
+      this._isObservingDebugRowCount = true;
       let scheduleUpdate = (this._scheduleUpdate = () => {
         run.scheduleOnce('actions', this, this._updateDataTestRowCount);
       });
       this.collapseTree.addObserver('rows', scheduleUpdate);
       this.collapseTree.addObserver('[]', scheduleUpdate);
-    });
+    }
 
     assert(
       'You must create an {{ember-thead}} with columns before creating an {{ember-tbody}}',
@@ -317,10 +322,10 @@ export default Component.extend({
       this.rowMetaCache.delete(row);
     }
 
-    runInDebug(() => {
+    if (this._isObservingDebugRowCount) {
       this.collapseTree.removeObserver('rows', this._scheduleUpdate);
       this.collapseTree.removeObserver('[]', this._scheduleUpdate);
-    });
+    }
     this.collapseTree.destroy();
   },
 


### PR DESCRIPTION
These observers were installed based on `runInDebug`. As ember-test-selectors uses its own configuable logic for when to strip test selectors, the two systems of "debug" mode can get out of sync.

For example, if you build Ember in a "test" environment but with a production Ember.js asset, then `runInDebug` is a no-op despite the test selectors being in place. You may configure Ember CLI this way if you want to ensure your application tests run in a mode similar to production.

Swap them to detect the attribute binding presence, which should not be there when ember-test-selectors is stripping selectors/bindings.