### PR TITLE
Check for undefined attributeBindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
             ember-lts-3.12,
             ember-lts-3.16,
             ember-lts-3.20,
+            ember-lts-3.24,
+            ember-production,
             ember-release,
             ember-beta,
             ember-canary,

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -269,6 +269,11 @@ export default Component.extend({
     /*
      * Ember test selectors will remove data-test-row-count from the bindings,
      * so if it is missing there is no need to all the count.
+     *
+     * Even when ember-table is testing a production build, the test selectors
+     * addon remains enabled and causes `this.attributeBindings` to be present.
+     * In an actual app build, `this.attributeBindings` may be undefined.
+     * Guard against it being `undefined` before checking for the attribute.
      */
     if (this.attributeBindings && this.attributeBindings.includes('data-test-row-count')) {
       this._isObservingDebugRowCount = true;

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -270,7 +270,7 @@ export default Component.extend({
      * Ember test selectors will remove data-test-row-count from the bindings,
      * so if it is missing there is no need to all the count.
      */
-    if (this.attributeBindings.includes('data-test-row-count')) {
+    if (this.attributeBindings && this.attributeBindings.includes('data-test-row-count')) {
       this._isObservingDebugRowCount = true;
       let scheduleUpdate = (this._scheduleUpdate = () => {
         run.scheduleOnce('actions', this, this._updateDataTestRowCount);

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -92,7 +92,15 @@ module.exports = function() {
           name: 'ember-lts-3.20',
           npm: {
             devDependencies: {
-              'ember-source': '~3.18.0',
+              'ember-source': '~3.20.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.24',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.24.0',
             },
           },
         },
@@ -122,6 +130,13 @@ module.exports = function() {
         },
         {
           name: 'ember-default',
+          npm: {
+            devDependencies: {},
+          },
+        },
+        {
+          name: 'ember-production',
+          command: 'ember test -e production',
           npm: {
             devDependencies: {},
           },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -17,7 +17,8 @@ module.exports = function(defaults) {
       ],
     },
     'ember-faker': {
-      enabled: true, // Always enable for dummy app because the docs examples use faker
+      /* Always enable for dummy app because the docs examples use faker */
+      enabled: true,
     },
   });
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "ember-table",
   "version": "3.0.2-3",
   "description": "An addon to support large data set and a number of features around table.",
-  "keywords": [
-    "ember-addon"
-  ],
+  "keywords": ["ember-addon"],
   "license": "BSD-3-Clause",
   "author": "",
   "directories": {
@@ -67,7 +65,7 @@
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-uglify": "^2.0.0",
+    "ember-cli-terser": "^4.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-faker": "^1.5.0",
@@ -78,7 +76,7 @@
     "ember-qunit": "^4.5.1",
     "ember-radio-button": "^1.2.3",
     "ember-resolver": "^5.1.1",
-    "ember-source": "~3.24.0",
+    "ember-source": "~3.28.0",
     "ember-source-channel-url": "^1.0.1",
     "ember-truth-helpers": "^2.0.0",
     "ember-try": "^1.1.0",

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -10,6 +10,8 @@ import { run } from '@ember/runloop';
 import { scrollTo } from 'ember-native-dom-helpers';
 import { registerTestWarnHandler } from '../../helpers/warn-handlers';
 
+import { runInDebug } from '@ember/debug';
+
 let table = new TablePage({
   validateSelected(...selectedIndexes) {
     let valid = true;
@@ -674,26 +676,28 @@ module('Integration | selection', () => {
         assert.ok(table.rows.objectAt(0).isSelected, 'Parent row is selected');
       });
 
-      test('Issue 747: Programmatic selection that includes a row not part of `rows`', async function(assert) {
-        let capturedWarningIds = [];
-        registerTestWarnHandler((_message, { id }) => capturedWarningIds.push(id));
+      runInDebug(() => {
+        test('Issue 747: Programmatic selection that includes a row not part of `rows`', async function(assert) {
+          let capturedWarningIds = [];
+          registerTestWarnHandler((_message, { id }) => capturedWarningIds.push(id));
 
-        let rows = generateRows(1, 1);
-        await generateTable(this, { rows });
+          let rows = generateRows(1, 1);
+          await generateTable(this, { rows });
 
-        run(() => this.set('selection', [...rows, { fakeRow: true }]));
-        assert.ok(true, 'after setting bad selection, no error');
-        assert.ok(table.validateSelected(0), 'First row is selected');
+          run(() => this.set('selection', [...rows, { fakeRow: true }]));
+          assert.ok(true, 'after setting bad selection, no error');
+          assert.ok(table.validateSelected(0), 'First row is selected');
 
-        // De-select selected row
-        await table.rows.objectAt(0).checkbox.click();
-        assert.ok(true, 'after un-checking, no error');
-        assert.ok(table.validateSelected(), 'No rows remain selected');
+          // De-select selected row
+          await table.rows.objectAt(0).checkbox.click();
+          assert.ok(true, 'after un-checking, no error');
+          assert.ok(table.validateSelected(), 'No rows remain selected');
 
-        assert.ok(
-          capturedWarningIds.includes('ember-table.selection-invalid'),
-          'ember-table warns about invalid selection'
-        );
+          assert.ok(
+            capturedWarningIds.includes('ember-table.selection-invalid'),
+            'ember-table warns about invalid selection'
+          );
+        });
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,6 +1028,13 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
+"@glimmer/vm-babel-plugins@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.80.0.tgz#e9a6b496501eed367b94c928dc48a954830af3b5"
+  integrity sha512-ZW6+L+FzjDZngGj87zn3MRRA/MrchC7Con33mCcI36v8u48maheB351uhQe+fBVU300IfyzNMvAdwdVKS5VIFw==
+  dependencies:
+    babel-plugin-debug-macros "^0.3.4"
+
 "@html-next/vertical-collection@2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-2.0.0.tgz#469f30966cf665afcc24a80b59cd0725134b7f79"
@@ -1615,7 +1622,7 @@ async-disk-cache@^1.2.1:
     rsvp "^3.0.18"
     username-sync "^1.0.2"
 
-async-promise-queue@^1.0.3, async-promise-queue@^1.0.4:
+async-promise-queue@^1.0.3, async-promise-queue@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.5.tgz#cb23bce9fce903a133946a700cc85f27f09ea49d"
   integrity sha512-xi0aQ1rrjPWYmqbwr18rrSKbSaXIeIwSd1J4KAgVfkq8utNbdZoht7GfvfY6swFUAMJ9obkc4WPJmtGwl+B8dw==
@@ -2893,7 +2900,7 @@ broccoli-plugin@^2.0.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^4.0.2:
+broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3:
   version "4.0.7"
   resolved "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz#dd176a85efe915ed557d913744b181abe05047db"
   integrity sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==
@@ -2988,22 +2995,21 @@ broccoli-string-replace@^0.1.2:
     broccoli-persistent-filter "^1.1.5"
     minimatch "^3.0.3"
 
-broccoli-uglify-sourcemap@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.2.0.tgz#2ff49389bdf342a550c3596750ba2dde95a8f7d4"
-  integrity sha1-L/STib3zQqVQw1lnULot3pWo99Q=
+broccoli-terser-sourcemap@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/broccoli-terser-sourcemap/-/broccoli-terser-sourcemap-4.1.0.tgz#5f37441b64a3b6bfb0c67e9af232259c9576f115"
+  integrity sha512-zkNnjsAbP+M5rG2aMM1EE4BmXPUSxFKmtLUkUs2D1DLTOJQoF1xlOjGWjjKYCFy5tw8t4+tgGJ+HVa2ucJZ8sw==
   dependencies:
-    async-promise-queue "^1.0.4"
-    broccoli-plugin "^1.2.1"
-    debug "^3.1.0"
-    lodash.defaultsdeep "^4.6.0"
-    matcher-collection "^1.0.5"
-    mkdirp "^0.5.0"
+    async-promise-queue "^1.0.5"
+    broccoli-plugin "^4.0.3"
+    debug "^4.1.0"
+    lodash.defaultsdeep "^4.6.1"
+    matcher-collection "^2.0.1"
     source-map-url "^0.4.0"
-    symlink-or-copy "^1.0.1"
-    terser "^3.7.5"
-    walk-sync "^0.3.2"
-    workerpool "^2.3.0"
+    symlink-or-copy "^1.3.1"
+    terser "^5.3.0"
+    walk-sync "^2.2.0"
+    workerpool "^6.0.0"
 
 browserslist@^3.2.6:
   version "3.2.8"
@@ -3505,7 +3511,7 @@ commander@7.1.0:
   resolved "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
   integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
 
-commander@^2.14.1, commander@^2.19.0, commander@^2.6.0, commander@^2.8.1, commander@^2.9.0:
+commander@^2.14.1, commander@^2.20.0, commander@^2.6.0, commander@^2.8.1, commander@^2.9.0:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4358,6 +4364,13 @@ ember-cli-string-utils@^1.0.0, ember-cli-string-utils@^1.1.0:
   resolved "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz#39b677fc2805f55173735376fcef278eaa4452a1"
   integrity sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=
 
+ember-cli-terser@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/ember-cli-terser/-/ember-cli-terser-4.0.2.tgz#c436a9e4159f76a615b051cba0584844652b7dcd"
+  integrity sha512-Ej77K+YhCZImotoi/CU2cfsoZaswoPlGaM5TB3LvjvPDlVPRhxUHO2RsaUVC5lsGeRLRiHCOxVtoJ6GyqexzFA==
+  dependencies:
+    broccoli-terser-sourcemap "^4.1.0"
+
 ember-cli-test-loader@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz#3fb8d5d1357e4460d3f0a092f5375e71b6f7c243"
@@ -4382,14 +4395,6 @@ ember-cli-typescript@^2.0.2:
     semver "^6.0.0"
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
-
-ember-cli-uglify@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/ember-cli-uglify/-/ember-cli-uglify-2.1.0.tgz#4a0641fe4768d7ab7d4807aca9924cc77c544184"
-  integrity sha512-lDzdAUfhGx5AMBsgyR54ibENVp/LRQuHNWNaP2SDjkAXDyuYFgW0iXIAfGbxF6+nYaesJ9Tr9AKOfTPlwxZDSg==
-  dependencies:
-    broccoli-uglify-sourcemap "^2.1.1"
-    lodash.defaultsdeep "^4.6.0"
 
 ember-cli-version-checker@^1.0.2:
   version "1.3.1"
@@ -4686,19 +4691,21 @@ ember-source-channel-url@^1.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.24.0:
-  version "3.24.4"
-  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.24.4.tgz#db3f70cbe4155d48474177f1564627a1fc980f64"
-  integrity sha512-C5sFGxT743n2PCaTnpvy3GWHdPz+/Ve9qjcSdfRjUvFCSYNhsRkxkpXRvXEU8WoUXY35Pm4vV9RsiorX1M+/Tw==
+ember-source@~3.28.0:
+  version "3.28.0"
+  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.28.0.tgz#aee9e712d80d7c39d2cc34b958d6e6e00c5dd40e"
+  integrity sha512-7cjzZlJE1Fun3+ygM5f7ubJviyHUU1LGHWyodQfbua6wkvieU2GYV0QNTUJQHe0JEAUr+Jm7x4/FuNIYB/dvpA==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
     "@babel/plugin-transform-object-assign" "^7.8.3"
     "@ember/edition-utils" "^1.2.0"
+    "@glimmer/vm-babel-plugins" "0.80.0"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
     broccoli-concat "^4.2.4"
     broccoli-debug "^0.6.4"
+    broccoli-file-creator "^2.1.1"
     broccoli-funnel "^2.0.2"
     broccoli-merge-trees "^4.2.0"
     chalk "^4.0.0"
@@ -4711,9 +4718,9 @@ ember-source@~3.24.0:
     ember-cli-version-checker "^5.1.1"
     ember-router-generator "^2.0.0"
     inflection "^1.12.0"
-    jquery "^3.5.0"
+    jquery "^3.5.1"
     resolve "^1.17.0"
-    semver "^6.1.1"
+    semver "^7.3.4"
     silent-error "^1.1.1"
 
 ember-test-selectors@^2.1.0:
@@ -7298,7 +7305,7 @@ jest-validate@^23.5.0:
     leven "^2.1.0"
     pretty-format "^23.6.0"
 
-jquery@^3.2.1, jquery@^3.5.0:
+jquery@^3.2.1, jquery@^3.5.1:
   version "3.6.0"
   resolved "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
@@ -7728,7 +7735,7 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.defaultsdeep@^4.6.0:
+lodash.defaultsdeep@^4.6.0, lodash.defaultsdeep@^4.6.1:
   version "4.6.1"
   resolved "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz#512e9bd721d272d94e3d3a63653fa17516741ca6"
   integrity sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==
@@ -7980,14 +7987,14 @@ markdown-it@^8.3.0, markdown-it@^8.3.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-matcher-collection@^1.0.0, matcher-collection@^1.0.5, matcher-collection@^1.1.1:
+matcher-collection@^1.0.0, matcher-collection@^1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz#1076f506f10ca85897b53d14ef54f90a5c426838"
   integrity sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==
   dependencies:
     minimatch "^3.0.2"
 
-matcher-collection@^2.0.0:
+matcher-collection@^2.0.0, matcher-collection@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz#90be1a4cf58d6f2949864f65bb3b0f3e41303b29"
   integrity sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==
@@ -10121,7 +10128,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@~0.5.10:
+source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -10162,6 +10169,11 @@ source-map@~0.1.x:
   integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@~0.7.2:
+  version "0.7.3"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 sourcemap-validator@^1.1.0:
   version "1.1.1"
@@ -10542,14 +10554,14 @@ term-size@^2.1.0:
   resolved "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
   integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
 
-terser@^3.7.5:
-  version "3.17.0"
-  resolved "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"
-  integrity sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==
+terser@^5.3.0:
+  version "5.7.1"
+  resolved "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz#2dc7a61009b66bb638305cb2a824763b116bf784"
+  integrity sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==
   dependencies:
-    commander "^2.19.0"
-    source-map "~0.6.1"
-    source-map-support "~0.5.10"
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
 
 testem@^2.0.0:
   version "2.17.0"
@@ -11222,6 +11234,11 @@ workerpool@^3.1.1:
     "@babel/core" "^7.3.4"
     object-assign "4.1.1"
     rsvp "^4.8.4"
+
+workerpool@^6.0.0:
+  version "6.1.5"
+  resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz#0f7cf076b6215fd7e1da903ff6f22ddd1886b581"
+  integrity sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==
 
 wrap-ansi@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
When we deploy our application using v3.0.2-3, we see the following console error:

```
TypeError: Cannot read property 'includes' of undefined
```

The stack trace points to https://github.com/Addepar/ember-table/blob/06ad94fc42cf68a87256faff494cf19dd84938c4/addon/components/ember-tbody/component.js#L273 which was introduced in https://github.com/Addepar/ember-table/pull/893

This PR adds an additional condition to check that `this.attributeBindings` is defined before calling `.includes()` on it. This fixes the error we see in our deployed application.