### PR TITLE
Deprecate Property Fallback Lookup (no implicit this)

### DIFF
--- a/addon/components/ember-table/template.hbs
+++ b/addon/components/ember-table/template.hbs
@@ -1,15 +1,15 @@
 <div
   data-test-ember-table-overflow
   class="ember-table-overflow"
-  id="{{elementId}}-overflow"
+  id="{{this.elementId}}-overflow"
 >
   <table>
     {{yield (hash
-      api=api
-      head=(component "ember-thead" api=api)
-      body=(component "ember-tbody" api=api)
-      foot=(component "ember-tfoot" api=api)
+      api=this.api
+      head=(component "ember-thead" api=this.api)
+      body=(component "ember-tbody" api=this.api)
+      foot=(component "ember-tfoot" api=this.api)
     )}}
   </table>
 </div>
-{{-ember-table-private/scroll-indicators api=api}}
+{{-ember-table-private/scroll-indicators api=this.api}}

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -1,32 +1,32 @@
-{{#vertical-collection wrappedRows
-  containerSelector=_containerSelector
+{{#vertical-collection this.wrappedRows
+  containerSelector=this._containerSelector
 
-  estimateHeight=estimateRowHeight
-  key=key
-  staticHeight=staticHeight
-  bufferSize=bufferSize
-  renderAll=renderAll
+  estimateHeight=this.estimateRowHeight
+  key=this.key
+  staticHeight=this.staticHeight
+  bufferSize=this.bufferSize
+  renderAll=this.renderAll
 
-  firstReached=firstReached
-  lastReached=lastReached
-  firstVisibleChanged=firstVisibleChanged
-  lastVisibleChanged=lastVisibleChanged
-  idForFirstItem=idForFirstItem
+  firstReached=this.firstReached
+  lastReached=this.lastReached
+  firstVisibleChanged=this.firstVisibleChanged
+  lastVisibleChanged=this.lastVisibleChanged
+  idForFirstItem=this.idForFirstItem
 
   as |rowValue|
 }}
   {{#-ember-table-private/row-wrapper
     rowValue=rowValue
-    columns=columns
+    columns=this.columns
 
-    columnMetaCache=columnMetaCache
-    rowMetaCache=rowMetaCache
+    columnMetaCache=this.columnMetaCache
+    rowMetaCache=this.rowMetaCache
 
-    canSelect=canSelect
-    rowSelectionMode=rowSelectionMode
-    checkboxSelectionMode=checkboxSelectionMode
+    canSelect=this.canSelect
+    rowSelectionMode=this.rowSelectionMode
+    checkboxSelectionMode=this.checkboxSelectionMode
 
-    rowsCount=wrappedRows.length
+    rowsCount=this.wrappedRows.length
 
     as |api|
   }}
@@ -45,6 +45,6 @@
     {{/if}}
   {{/-ember-table-private/row-wrapper}}
 
-{{else if shouldYieldToInverse}}
+{{else if this.shouldYieldToInverse}}
   {{yield to='inverse'}}
 {{/vertical-collection}}

--- a/addon/components/ember-td/template.hbs
+++ b/addon/components/ember-td/template.hbs
@@ -1,13 +1,13 @@
-{{#if isFirstColumn}}
+{{#if this.isFirstColumn}}
   <div class="et-cell-container">
-    {{#if canSelect}}
+    {{#if this.canSelect}}
       <span
-        class="et-toggle-select {{unless shouldShowCheckbox 'et-speech-only'}}"
+        class="et-toggle-select {{unless this.shouldShowCheckbox 'et-speech-only'}}"
         data-test-select-row-container
       >
         {{-ember-table-private/simple-checkbox
           data-test-select-row=true
-          checked=rowMeta.isGroupSelected
+          checked=this.rowMeta.isGroupSelected
           onClick=(action "onSelectionToggled")
           ariaLabel="Select row"
         }}
@@ -16,31 +16,31 @@
     {{/if}}
 
     {{#if canCollapse}}
-      <span class="et-toggle-collapse et-depth-indent {{depthClass}}">
+      <span class="et-toggle-collapse et-depth-indent {{this.depthClass}}">
         {{-ember-table-private/simple-checkbox
           data-test-collapse-row=true
-          checked=rowMeta.isCollapsed
+          checked=this.rowMeta.isCollapsed
           onChange=(action "onCollapseToggled")
           ariaLabel="Collapse row"
         }}
         <span></span>
       </span>
     {{else}}
-      <div class="et-depth-indent et-depth-placeholder {{depthClass}}"></div>
+      <div class="et-depth-indent et-depth-placeholder {{this.depthClass}}"></div>
     {{/if}}
 
     <div class="et-cell-content">
       {{#if hasBlock}}
-        {{yield cellValue columnValue rowValue cellMeta columnMeta rowMeta rowsCount}}
+        {{yield this.cellValue this.columnValue this.rowValue this.cellMeta this.columnMeta this.rowMeta this.rowsCount}}
       {{else}}
-        {{cellValue}}
+        {{this.cellValue}}
       {{/if}}
     </div>
   </div>
 {{else}}
   {{#if hasBlock}}
-    {{yield cellValue columnValue rowValue cellMeta columnMeta rowMeta rowsCount}}
+    {{yield this.cellValue this.columnValue this.rowValue this.cellMeta this.columnMeta this.rowMeta this.rowsCount}}
   {{else}}
-    {{cellValue}}
+    {{this.cellValue}}
   {{/if}}
 {{/if}}

--- a/addon/components/ember-tfoot/template.hbs
+++ b/addon/components/ember-tfoot/template.hbs
@@ -1,16 +1,16 @@
-{{#each wrappedRowArray as |rowValue|}}
+{{#each this.wrappedRowArray as |rowValue|}}
   {{#-ember-table-private/row-wrapper
     rowValue=rowValue
-    columns=columns
+    columns=this.columns
 
-    columnMetaCache=columnMetaCache
-    rowMetaCache=rowMetaCache
+    columnMetaCache=this.columnMetaCache
+    rowMetaCache=this.rowMetaCache
 
-    canSelect=canSelect
-    rowSelectionMode=rowSelectionMode
-    checkboxSelectionMode=checkboxSelectionMode
+    canSelect=this.canSelect
+    rowSelectionMode=this.rowSelectionMode
+    checkboxSelectionMode=this.checkboxSelectionMode
 
-    rowsCount=wrappedRowArray.length
+    rowsCount=this.wrappedRowArray.length
 
     as |api|
   }}

--- a/addon/components/ember-th/resize-handle/template.hbs
+++ b/addon/components/ember-th/resize-handle/template.hbs
@@ -1,4 +1,4 @@
-  {{#if isResizable}}
+  {{#if this.isResizable}}
     <div data-test-resize-handle class="et-header-resize-area">
     </div>
   {{/if}}

--- a/addon/components/ember-th/sort-indicator/template.hbs
+++ b/addon/components/ember-th/sort-indicator/template.hbs
@@ -1,15 +1,15 @@
-{{#if isSorted}}
-  <span data-test-sort-indicator class="et-sort-indicator {{if isSortedAsc 'is-ascending' 'is-descending'}}">
+{{#if this.isSorted}}
+  <span data-test-sort-indicator class="et-sort-indicator {{if this.isSortedAsc 'is-ascending' 'is-descending'}}">
     {{#if hasBlock}}
-      {{yield columnMeta}}
+      {{yield this.columnMeta}}
     {{else}}
-      {{#if isMultiSorted}}
-        {{sortIndex}}
+      {{#if this.isMultiSorted}}
+        {{this.sortIndex}}
       {{/if}}
     {{/if}}
   </span>
 {{/if}}
 
-{{#if isSortable}}
+{{#if this.isSortable}}
   <button data-test-sort-toggle class="et-sort-toggle et-speech-only">Toggle Sort</button>
 {{/if}}

--- a/addon/components/ember-th/template.hbs
+++ b/addon/components/ember-th/template.hbs
@@ -1,9 +1,9 @@
 {{#if hasBlock}}
-  {{yield columnValue columnMeta rowMeta}}
+  {{yield this.columnValue this.columnMeta this.rowMeta}}
 {{else}}
-  {{columnValue.name}}
+  {{this.columnValue.name}}
 
-  {{ember-th/sort-indicator columnMeta=columnMeta}}
+  {{ember-th/sort-indicator columnMeta=this.columnMeta}}
 
-  {{ember-th/resize-handle columnMeta=columnMeta}}
+  {{ember-th/resize-handle columnMeta=this.columnMeta}}
 {{/if}}

--- a/addon/components/ember-thead/template.hbs
+++ b/addon/components/ember-thead/template.hbs
@@ -1,4 +1,4 @@
-{{#each wrappedRows as |api|}}
+{{#each this.wrappedRows as |api|}}
   {{#if hasBlock}}
     {{yield (hash
       cells=api.cells

--- a/addon/components/ember-tr/template.hbs
+++ b/addon/components/ember-tr/template.hbs
@@ -1,6 +1,6 @@
-{{#each cells as |api|}}
+{{#each this.cells as |api|}}
   {{#if hasBlock}}
-    {{#if isHeader}}
+    {{#if this.isHeader}}
       {{yield (hash
         columnValue=api.columnValue
         columnMeta=api.columnMeta


### PR DESCRIPTION
See https://deprecations.emberjs.com/v3.x/#toc_this-property-fallback


**Further work for another PR:** 
Read-only fields could perhaps be rewritten to use the @-syntax directly in the templates (for simplification).

E.g. resize-handle (and sort-indicator) could be a simple template-only component by using the @-syntax directly in the template:
```diff
-{{#if this.isResizable}}
+{{#if @columnsMeta.isResizable}}
  <div data-test-resize-handle class="et-header-resize-area">
  </div>
{{/if}}
```