### PR TITLE
Allow action handler to abort multi-select, resetting last index state

### DIFF
--- a/addon-test-support/pages/ember-table.js
+++ b/addon-test-support/pages/ember-table.js
@@ -125,6 +125,15 @@ export default PageObject.extend({
   },
 
   /**
+   * Selects a row in the body while holding shift key
+   *
+   * @param {number} index
+   */
+  async selectRowWithShiftClick(index) {
+    await this.body.rows.objectAt(index).clickWith({ shiftKey: true });
+  },
+
+  /**
    * Toggles a row in the body
    *
    * @param {number} index

--- a/tests/dummy/app/pods/docs/guides/body/row-selection/examples/aborting-a-selection/component.js
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/examples/aborting-a-selection/component.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+let shouldAbortSelection;
+
+export default class AbortingASelectionExampleComponent extends Component {
+  // BEGIN-SNIPPET docs-example-aborting-a-selection.js
+  @action
+  selectRows(selection, { abort }) {
+    if (shouldAbortSelection(selection)) {
+      abort();
+      return;
+    }
+
+    this.selection = selection;
+  }
+  // END-SNIPPET
+}

--- a/tests/dummy/app/pods/docs/guides/body/row-selection/examples/aborting-a-selection/template.hbs
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/examples/aborting-a-selection/template.hbs
@@ -1,0 +1,11 @@
+{{! BEGIN-SNIPPET docs-example-aborting-a-selection.hbs }}
+<EmberTable as |t|>
+  <t.head @columns={{columns}} />
+
+  <t.body
+    @rows={{rows}}
+    @onSelect={{action this.selectRows}}
+    @selection={{selection}}
+  />
+</EmberTable>
+{{! END-SNIPPET }}

--- a/tests/dummy/app/pods/docs/guides/body/row-selection/examples/row-selection/template.hbs
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/examples/row-selection/template.hbs
@@ -1,0 +1,13 @@
+<div class="demo-container small">
+  {{! BEGIN-SNIPPET docs-example-row-selection.hbs }}
+  <EmberTable as |t|>
+    <t.head @columns={{columns}} />
+
+    <t.body
+      @rows={{rows}}
+      @onSelect={{action (mut selection)}}
+      @selection={{selection}}
+    />
+  </EmberTable>
+  {{! END-SNIPPET }}
+</div>

--- a/tests/dummy/app/pods/docs/guides/body/row-selection/examples/selected-rows/template.hbs
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/examples/selected-rows/template.hbs
@@ -1,0 +1,13 @@
+<div class="demo-container small">
+  {{! BEGIN-SNIPPET docs-example-selected-rows.hbs }}
+  <EmberTable as |t|>
+    <t.head @columns={{columns}} />
+
+    <t.body
+      @rows={{rowWithChildren}}
+      @onSelect={{action (mut preselection)}}
+      @selection={{preselection}}
+    />
+  </EmberTable>
+  {{! END-SNIPPET }}
+</div>

--- a/tests/dummy/app/pods/docs/guides/body/row-selection/examples/selection-modes/template.hbs
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/examples/selection-modes/template.hbs
@@ -35,5 +35,4 @@
   <h4>selectingChildrenSelectsParent</h4>
   <label> {{input type="checkbox" checked=selectingChildrenSelectsParent}} </label>
 </div>
-
 {{! END-SNIPPET }}

--- a/tests/dummy/app/pods/docs/guides/body/row-selection/examples/selection-modes/template.hbs
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/examples/selection-modes/template.hbs
@@ -1,0 +1,39 @@
+{{! BEGIN-SNIPPET docs-example-selection-modes.hbs }}
+<div class="demo-container">
+  <EmberTable as |t|>
+    <t.head @columns={{columns}} />
+
+    <t.body
+      @rows={{rowsWithChildren}}
+
+      @rowSelectionMode={{rowSelectionMode}}
+      @checkboxSelectionMode={{checkboxSelectionMode}}
+      @selectingChildrenSelectsParent={{selectingChildrenSelectsParent}}
+
+      @onSelect={{action (mut demoSelection)}}
+      @selection={{demoSelection}}
+    />
+  </EmberTable>
+</div>
+<div class="demo-options-group">
+  <h4>Current selection</h4>
+  <div class="demo-current-selection">{{currentSelection}}</div>
+</div>
+<div class="demo-options-group">
+  <h4>rowSelectionMode</h4>
+  <label> <RadioButton @name='row-selection-mode' @value='multiple' @groupValue={{rowSelectionMode}} /> multiple </label>
+  <label> <RadioButton @name='row-selection-mode' @value='single' @groupValue={{rowSelectionMode}} /> single </label>
+  <label> <RadioButton @name='row-selection-mode' @value='none' @groupValue={{rowSelectionMode}} /> none </label>
+</div>
+<div class="demo-options-group">
+  <h4>checkboxSelectionMode</h4>
+  <label> <RadioButton @name='checkbox-selection-mode' @value='multiple' @groupValue={{checkboxSelectionMode}} /> multiple </label>
+  <label> <RadioButton @name='checkbox-selection-mode' @value='single' @groupValue={{checkboxSelectionMode}} /> single </label>
+  <label> <RadioButton @name='checkbox-selection-mode' @value='none' @groupValue={{checkboxSelectionMode}} /> none </label>
+</div>
+<div class="demo-options-group">
+  <h4>selectingChildrenSelectsParent</h4>
+  <label> {{input type="checkbox" checked=selectingChildrenSelectsParent}} </label>
+</div>
+
+{{! END-SNIPPET }}

--- a/tests/dummy/app/pods/docs/guides/body/row-selection/template.md
+++ b/tests/dummy/app/pods/docs/guides/body/row-selection/template.md
@@ -6,19 +6,9 @@ to control the selection using DDAU:
 
 {{#docs-demo as |demo|}}
   {{#demo.example name="docs-example-row-selection"}}
-    <div class="demo-container small">
-      {{! BEGIN-SNIPPET docs-example-row-selection.hbs }}
-      <EmberTable as |t|>
-        <t.head @columns={{columns}} />
-
-        <t.body
-          @rows={{rows}}
-          @onSelect={{action (mut selection)}}
-          @selection={{selection}}
-        />
-      </EmberTable>
-      {{! END-SNIPPET }}
-    </div>
+    {{docs/guides/body/row-selection/examples/row-selection
+      rows=rows
+      columns=columns}}
   {{/demo.example}}
 
   {{demo.snippet name='docs-example-row-selection.hbs'}}
@@ -37,19 +27,9 @@ selected, all of its children _must_ be selected:
 
 {{#docs-demo as |demo|}}
   {{#demo.example name="selected-rows"}}
-    <div class="demo-container small">
-      {{! BEGIN-SNIPPET docs-example-selected-rows.hbs }}
-      <EmberTable as |t|>
-        <t.head @columns={{columns}} />
-
-        <t.body
-          @rows={{rowWithChildren}}
-          @onSelect={{action (mut preselection)}}
-          @selection={{preselection}}
-        />
-      </EmberTable>
-      {{! END-SNIPPET }}
-    </div>
+    {{docs/guides/body/row-selection/examples/selected-rows
+      rowWithChildren=rowWithChildren
+      columns=columns}}
   {{/demo.example}}
 
   {{demo.snippet label='component.js' name='docs-example-selected-rows.js'}}
@@ -87,47 +67,29 @@ itself.
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='selection-modes'}}
-    {{! BEGIN-SNIPPET docs-example-selection-modes.hbs }}
-    <div class="demo-container">
-      <EmberTable as |t|>
-        <t.head @columns={{columns}} />
-
-        <t.body
-          @rows={{rowsWithChildren}}
-
-          @rowSelectionMode={{rowSelectionMode}}
-          @checkboxSelectionMode={{checkboxSelectionMode}}
-          @selectingChildrenSelectsParent={{selectingChildrenSelectsParent}}
-
-          @onSelect={{action (mut demoSelection)}}
-          @selection={{demoSelection}}
-        />
-      </EmberTable>
-    </div>
-    <div class="demo-options-group">
-      <h4>Current selection</h4>
-      <div class="demo-current-selection">{{currentSelection}}</div>
-    </div>
-    <div class="demo-options-group">
-      <h4>rowSelectionMode</h4>
-      <label> <RadioButton @name='row-selection-mode' @value='multiple' @groupValue={{rowSelectionMode}} /> multiple </label>
-      <label> <RadioButton @name='row-selection-mode' @value='single' @groupValue={{rowSelectionMode}} /> single </label>
-      <label> <RadioButton @name='row-selection-mode' @value='none' @groupValue={{rowSelectionMode}} /> none </label>
-    </div>
-    <div class="demo-options-group">
-      <h4>checkboxSelectionMode</h4>
-      <label> <RadioButton @name='checkbox-selection-mode' @value='multiple' @groupValue={{checkboxSelectionMode}} /> multiple </label>
-      <label> <RadioButton @name='checkbox-selection-mode' @value='single' @groupValue={{checkboxSelectionMode}} /> single </label>
-      <label> <RadioButton @name='checkbox-selection-mode' @value='none' @groupValue={{checkboxSelectionMode}} /> none </label>
-    </div>
-    <div class="demo-options-group">
-      <h4>selectingChildrenSelectsParent</h4>
-      <label> {{input type="checkbox" checked=selectingChildrenSelectsParent}} </label>
-    </div>
-
-    {{! END-SNIPPET }}
+    {{docs/guides/body/row-selection/examples/selection-modes
+      rowsWithChildren=rowsWithChildren
+      columns=columns
+      rowSelectionMode=rowSelectionMode
+      checkboxSelectionMode=checkboxSelectionMode
+      selectingChildrenSelectsParent=selectingChildrenSelectsParent
+      demoSelection=demoSelection
+      currentSelection=currentSelection}}
   {{/demo.example}}
 
   {{demo.snippet name='docs-example-selection-modes.hbs'}}
   {{demo.snippet label='component.js' name='docs-example-selection-modes.js'}}
+{{/docs-demo}}
+
+## Aborting a Selection
+
+Row selection follows a <a href="https://embermap.com/topics/component-side-effects/data-down-actions-up">DDAU</a> pattern, whereby the `onSelect` action handler supplied to Ember Table has control over which rows become selected. To ignore a user selection, it suffices to simply do nothing in the action handler.
+
+There is, however, some internal state that needs to be reset to fully abort a user selection. For example, Ember Table tracks the _last selected_ row in order to determine the range of rows affected in a user multi-selection. If the intent is to completely prevent a user selection, this value must not change when the action is aborted. Otherwise, a subsequent user multi-selection may target the wrong rows.
+
+To reset all internal state relating to an attempted user selection, call the `abort` function in the options object passed to the `onChange` action handler:
+
+{{#docs-demo as |demo|}}
+  {{demo.snippet name='docs-example-aborting-a-selection.hbs'}}
+  {{demo.snippet label='component.js' name='docs-example-aborting-a-selection.js'}}
 {{/docs-demo}}

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -295,8 +295,6 @@ module('Integration | selection', () => {
 
         // without abort, row 1 would not be selected
         assert.ok(table.validateSelected(0, 1, 2, 3), 'correct rows are selected');
-
-        // this.set('onSelect', undefined);
       });
     });
 

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -289,6 +289,8 @@ module('Integration | selection', () => {
         await table.selectRangeFromClick(0, 2);
 
         assert.ok(table.validateSelected(0, 1, 2), 'rows are selected');
+
+        this.set('onSelect', undefined);
       });
     });
 

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -276,8 +276,8 @@ module('Integration | selection', () => {
         let abortHandler = (selection, { abort }) => abort();
         let selectHandler;
 
-        this.set('onSelect', function() {
-          selectHandler(...arguments);
+        this.set('onSelect', (selection, hash) => {
+          selectHandler(selection, hash);
         });
 
         await generateTable(this);
@@ -296,7 +296,7 @@ module('Integration | selection', () => {
         // without abort, row 1 would not be selected
         assert.ok(table.validateSelected(0, 1, 2, 3), 'correct rows are selected');
 
-        this.set('onSelect', undefined);
+        // this.set('onSelect', undefined);
       });
     });
 

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -270,6 +270,26 @@ module('Integration | selection', () => {
 
         assert.ok(table.validateSelected(0), 'Zoe is selected after external change');
       });
+
+      test('Can abort multi-select so that next multi-select starts from the same row', async function(assert) {
+        let selectHandler;
+
+        this.set('onSelect', function() {
+          selectHandler(...arguments);
+        });
+
+        await generateTable(this);
+
+        assert.ok(table.validateSelected(), 'rows are not selected');
+
+        selectHandler = (selection, abort) => abort();
+        await table.selectRangeFromClick(0, 2);
+
+        selectHandler = selection => this.set('selection', selection);
+        await table.selectRangeFromClick(0, 2);
+
+        assert.ok(table.validateSelected(0, 1, 2), 'rows are selected');
+      });
     });
 
     componentModule('single', function() {

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -272,6 +272,8 @@ module('Integration | selection', () => {
       });
 
       test('Can abort multi-select so that next multi-select starts from the same row', async function(assert) {
+        let successHandler = selection => this.set('selection', selection);
+        let abortHandler = (selection, { abort }) => abort();
         let selectHandler;
 
         this.set('onSelect', function() {
@@ -282,13 +284,17 @@ module('Integration | selection', () => {
 
         assert.ok(table.validateSelected(), 'rows are not selected');
 
-        selectHandler = (selection, abort) => abort();
-        await table.selectRangeFromClick(0, 2);
+        selectHandler = successHandler;
+        await table.selectRow(0);
 
-        selectHandler = selection => this.set('selection', selection);
-        await table.selectRangeFromClick(0, 2);
+        selectHandler = abortHandler;
+        await table.selectRowWithShiftClick(2);
 
-        assert.ok(table.validateSelected(0, 1, 2), 'rows are selected');
+        selectHandler = successHandler;
+        await table.selectRowWithShiftClick(3);
+
+        // without abort, row 1 would not be selected
+        assert.ok(table.validateSelected(0, 1, 2, 3), 'correct rows are selected');
 
         this.set('onSelect', undefined);
       });


### PR DESCRIPTION
## Description

Adds ability to "abort" a selection, resetting the internally-tracked last selected row index. This allows multi-select to function as expected after rejecting a user's selection.

## Use case

Say we want to prevent the user from selecting more than 10 rows.

If the user clicks row 1 and then shift-clicks row 11, we can inspect the proposed new selection in the `onSelect` action, determine it is too large, and show an error without making a change.

However, if they subsequently shift-click row 5, Ember Table will attempt to add rows 5-11 to the selection, as row 11 was the last clicked.

By calling `abort()`, the internal state is reverted, and shift-clicking row 5 will select rows 1-5.

## Docs Update
* Breaks out examples into separate files to fix broken markdown formatting.

![image](https://user-images.githubusercontent.com/2594635/144508539-fd36a7a8-2e10-46ff-bea6-690e33e2d443.png)
![image](https://user-images.githubusercontent.com/2594635/144508579-75b7e315-ac1d-408e-916b-ff31495652f4.png)
