### PR TITLE
Float vertical-collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.12.13",
     "@babel/plugin-proposal-optional-catch-binding": "^7.12.13",
     "@babel/plugin-proposal-optional-chaining": "^7.12.13",
-    "@html-next/vertical-collection": "2.0.0",
+    "@html-next/vertical-collection": "^2.0.0",
     "broccoli-string-replace": "^0.1.2",
     "css-element-queries": "^0.4.0",
     "ember-classy-page-object": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,17 +1213,17 @@
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
-"@html-next/vertical-collection@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-2.0.0.tgz#469f30966cf665afcc24a80b59cd0725134b7f79"
-  integrity sha512-+RMxBz8tSSFDDA8Q8NBC5Eak50PVHsB73GL7bkPyAuNtdm324nMVrzqJ6TYVg5mTFbc02W261/9jhfbawQbczA==
+"@html-next/vertical-collection@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-2.1.0.tgz#9d655e2dc171ecaa7f5c4c70b3af1f97dd1f282b"
+  integrity sha512-0H1X0vLR9SuK7CX8euwRgAWtX73N26oUGDmZdkeAgmZ1JkU/xR24ae94PpzkqBDzlk0sMv7NPrdDGWnxnXcUvw==
   dependencies:
     babel6-plugin-strip-class-callcheck "^6.0.0"
     broccoli-funnel "^2.0.2"
     broccoli-merge-trees "^3.0.1"
     broccoli-rollup "^4.1.1"
     ember-cli-babel "^7.12.0"
-    ember-cli-htmlbars "^3.0.1"
+    ember-cli-htmlbars "^3.0.0"
     ember-cli-version-checker "^3.1.3"
     ember-compatibility-helpers "^1.2.1"
     ember-raf-scheduler "0.2.0"
@@ -4433,7 +4433,7 @@ ember-cli-htmlbars@^1.1.1:
     json-stable-stringify "^1.0.0"
     strip-bom "^2.0.0"
 
-ember-cli-htmlbars@^3.0.1:
+ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1:
   version "3.1.0"
   resolved "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-3.1.0.tgz#87806c2a0bca2ab52d4fb8af8e2215c1ca718a99"
   integrity sha512-cgvRJM73IT0aePUG7oQ/afB7vSRBV3N0wu9BrWhHX2zkR7A7cUBI7KC9VPk6tbctCXoM7BRGsCC4aIjF7yrfXA==


### PR DESCRIPTION
Vertical Collection 2.1.0 is out: https://github.com/html-next/vertical-collection/releases/tag/v2.1.0 and cleans up some use of deprecated API from that library. See https://github.com/html-next/vertical-collection/pull/343#issuecomment-989466653 for some further details analysis.

Fellow maintainers please feel free to land/release this for ember-table 3.x