### PR TITLE
Fix scrollLeft error on resize before element inserted

### DIFF
--- a/addon/components/ember-table-loading-more/component.js
+++ b/addon/components/ember-table-loading-more/component.js
@@ -149,6 +149,13 @@ export default Component.extend({
 
   updateTransform() {
     let scrollElement = this.get('scrollElement');
+
+    // this method can be triggered by the resize sensor before the element
+    // (and `scrollElement`) exists
+    if (!scrollElement) {
+      return;
+    }
+
     let translateX = 0;
 
     if (this.get('center')) {


### PR DESCRIPTION
Resolves a bug in the `ember-table-loading-more` component where the `updateTransform` method gets triggered by the `ResizeSensor` before the element is inserted.