### PR TITLE
Add custom class names to table element

### DIFF
--- a/addon/components/ember-table/template.hbs
+++ b/addon/components/ember-table/template.hbs
@@ -3,7 +3,7 @@
   class="ember-table-overflow"
   id="{{this.elementId}}-overflow"
 >
-  <table>
+  <table class="{{this.tableClassNames}}"
     {{yield (hash
       api=this.api
       head=(component "ember-thead" api=this.api)


### PR DESCRIPTION
This fixes https://github.com/Addepar/ember-table/issues/578

```
<EmberTable @tableClassNames="my-custom-class" as |t|>
  <t.head @columns={{this.columns}} />

  <t.body @rows={{this.rows}} />
</EmberTable>
```