### PR TITLE
Fix BaseTableCell left/right css properties not reset when isFixed is removed

### DIFF
--- a/addon/components/-private/base-table-cell.js
+++ b/addon/components/-private/base-table-cell.js
@@ -62,11 +62,12 @@ export default Component.extend({
       this.element.style.minWidth = width;
       this.element.style.maxWidth = width;
 
-      if (this.get('isFixedLeft')) {
-        this.element.style.left = `${Math.round(this.get('columnMeta.offsetLeft'))}px`;
-      } else if (this.get('isFixedRight')) {
-        this.element.style.right = `${Math.round(this.get('columnMeta.offsetRight'))}px`;
-      }
+      this.element.style.left = this.get('isFixedLeft')
+        ? `${Math.round(this.get('columnMeta.offsetLeft'))}px`
+        : null;
+      this.element.style.right = this.get('isFixedRight')
+        ? `${Math.round(this.get('columnMeta.offsetRight'))}px`
+        : null;
 
       if (this.get('isSlack')) {
         this.element.style.paddingLeft = 0;


### PR DESCRIPTION
## The problem

When dynamically controlling the columns "isFixed" property as shown in the [docs](https://opensource.addepar.com/ember-table/docs/guides/header/fixed-columns), it seems that the `left` and `right` css properties of the DOM element are not reset when the `isFixed` property is removed after being set "left" or "right".

https://user-images.githubusercontent.com/176766/197480486-bb234d2b-871f-461e-b834-c7ca527d115f.mov

## The solution

Instead of setting the `left`/`right` css properties of the element only when the `isFixed` value is set to `left` or `right`, we need to also explicitly remove the css property when isFixed is `null` or `undefined`. 

https://user-images.githubusercontent.com/176766/197481565-53e742c7-84b6-41a8-8300-210f91862afa.mov


