### PR TITLE
Only remove ResizeSensor if it exists

### DIFF
--- a/addon/components/ember-table-loading-more/component.js
+++ b/addon/components/ember-table-loading-more/component.js
@@ -144,7 +144,9 @@ export default Component.extend({
 
   removeListeners() {
     this.get('scrollElement').removeEventListener('scroll', this._updateTransform);
-    this._scrollElementResizeSensor.detach();
+    if (this._scrollElementResizeSensor) {
+      this._scrollElementResizeSensor.detach();
+    }
   },
 
   updateTransform() {


### PR DESCRIPTION
Repro:
```hbs
<t.loadingMore
  @isLoading={{true}}
  @center={{false}}
/>
```

1. The `didInsertElement` hook fires,
2. it calls `this.centerChanged`,
3. which calls `this.removeListeners`, since `center` is false.

The problem is that `addListeners` has never been called, and `_scrollElementResizeSensor` doesn't exist. So you get a JS console error.

One possible fix is in this PR.

There's technically a workaround, but it's stomach-turning:

```hbs
<t.loadingMore
  @isLoading={{true}}
  @center={{this.eventuallyFalse}}
  {{did-insert (action (mut this.eventuallyFalse) false)}}
/>
```

Let `@center` start as true, and then set it to false slightly later... now `addListeners` was called, so there's no console error and you eventually get the state you want 😬