### PR TITLE
[TRIVIAL] Disable 3.16 scenario in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   test-ember-try:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   test-ember-try:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 12
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,14 @@ jobs:
   test-ember-try:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 7
 
     strategy:
       matrix:
         ember-version:
           [
             ember-lts-3.12,
-            ember-lts-3.16,
+            # ember-lts-3.16,
             ember-lts-3.20,
             ember-lts-3.24,
             ember-lts-3.28,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
         ember-version:
           [
             ember-lts-3.12,
-            # ember-lts-3.16,
             ember-lts-3.20,
             ember-lts-3.24,
             ember-lts-3.28,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   test-ember-try:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 10
 
     strategy:
       matrix:


### PR DESCRIPTION
The Ember 3.12 and 3.16 tests don't reliably finish in under 7 minutes. This is currently blocking merge of https://github.com/Addepar/ember-table/pull/976 because the 3.16 tests need more time to run (a re-run of 3.12 did manage to finish in just under the timeout).

~~This PR bumps the GitHub Actions CI timeout from 7 minutes to 10 minutes.~~

This PR disables the 3.16 scenario in CI since it's the slowest and most inconsistent scenario. It remains configured in ember-try should we need to debug any reported issues, but we will likely drop support for 3.12 and 3.16 altogether in the near future.