### PR TITLE
Adopt a branch of addon docs dropped Google fonts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   test-ember-try:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 10
 
     strategy:
       matrix:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -101,7 +101,7 @@ module.exports = function() {
           npm: {
             devDependencies: {
               'ember-data': '~3.24.0',
-              'ember-cli-addon-docs': '^5.1.0',
+              'ember-cli-addon-docs': 'ember-learn/ember-cli-addon-docs#mixonic/swap-default-fonts',
               'ember-cli-addon-docs-yuidoc': '^1.0.0',
               'ember-cli-deploy': '^1.0.2',
               'ember-cli-deploy-build': '^1.1.1',


### PR DESCRIPTION
To avoid loading fonts from a 3rd party domain, adopt a change in an upstream PR.

https://github.com/ember-learn/ember-cli-addon-docs/pull/1421