### PR TITLE
Fix keyUp event bug in ember-th

### DIFF
--- a/addon-test-support/pages/-private/ember-table-header.js
+++ b/addon-test-support/pages/-private/ember-table-header.js
@@ -1,6 +1,6 @@
 import PageObject, { alias, collection, hasClass, triggerable } from 'ember-classy-page-object';
 import { findElement } from 'ember-classy-page-object/extend';
-import { click } from '@ember/test-helpers';
+import { click, triggerKeyEvent } from '@ember/test-helpers';
 
 import { mouseDown, mouseMove, mouseUp } from '../../helpers/mouse';
 import { getScale } from '../../helpers/element';
@@ -194,6 +194,10 @@ const Header = PageObject.extend({
   */
   async clickWith(options) {
     await click(findElement(this), options);
+  },
+
+  async enterKeyup() {
+    await triggerKeyEvent(findElement(this), 'keyup', 'Enter');
   },
 
   isSortable: hasClass('is-sortable'),

--- a/addon/components/ember-th/component.js
+++ b/addon/components/ember-th/component.js
@@ -160,7 +160,7 @@ export default BaseTableCell.extend({
       event.key === 'Enter' &&
       isSortable
     ) {
-      this.updateSort();
+      this.updateSort({ toggle: false });
     }
   },
 

--- a/tests/integration/components/sort-test.js
+++ b/tests/integration/components/sort-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { generateTable } from '../../helpers/generate-table';
 import { componentModule } from '../../helpers/module';
 
-import { findAll, triggerKeyEvent } from '@ember/test-helpers';
+import { findAll } from '@ember/test-helpers';
 
 import TablePage from 'ember-table/test-support/pages/ember-table';
 

--- a/tests/integration/components/sort-test.js
+++ b/tests/integration/components/sort-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { generateTable } from '../../helpers/generate-table';
 import { componentModule } from '../../helpers/module';
 
-import { findAll } from '@ember/test-helpers';
+import { findAll, triggerKeyEvent } from '@ember/test-helpers';
 
 import TablePage from 'ember-table/test-support/pages/ember-table';
 
@@ -420,6 +420,33 @@ module('Integration | sort', function() {
       await generateTable(this, { columns, rows });
 
       assert.equal(findAll('.is-sortable').length, 1, 'only one column is sortable');
+    });
+
+    test('can sort a column with keyboard enter on header', async function(assert) {
+      let columns = [
+        {
+          name: 'Name',
+          valuePath: 'name',
+        },
+      ];
+
+      let rows = [{ name: 'Zoe' }, { name: 'Alex' }, { name: 'Liz' }];
+
+      await generateTable(this, { columns, rows });
+
+      let firstHeader = table.headers.objectAt(0);
+
+      assert.ok(firstHeader.isSortable, 'sort class applied correctly');
+      assert.ok(checkRowOrder(table, ['Zoe', 'Alex', 'Liz']));
+
+      await firstHeader.enterKeyup();
+      assert.ok(checkRowOrder(table, ['Zoe', 'Liz', 'Alex']));
+
+      await firstHeader.enterKeyup();
+      assert.ok(checkRowOrder(table, ['Alex', 'Liz', 'Zoe']));
+
+      await firstHeader.enterKeyup();
+      assert.ok(checkRowOrder(table, ['Zoe', 'Alex', 'Liz']));
     });
   });
 });


### PR DESCRIPTION
In `addon/components/ember-th/component.js` there is a keyUp event which will trigger `updateSort` function with Enter key. However, the current code will show the error in the below screen shot when user hitting Enter ( when focusing on the header columns )
This PR is trying to fix this bug with providing a `toggle: false` in `this.updateSort` when being called in the keyUp event.

![Screenshot 2023-04-24 at 8 51 29 AM](https://user-images.githubusercontent.com/99705158/234050799-d631cc80-8fb7-4d9a-acc4-bc0979b93b9d.png)

### Reviewer note
not sure if we want to support the `toggle` the same way as in the click event
`let toggle = event.ctrlKey || event.metaKey;`

