### PR TITLE
Disabled "ember-release" scenario in ember-try

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
             ember-lts-3.24,
             ember-lts-3.28,
             ember-lts-4.4,
-            ember-release,
+            ember-lts-4.12,
+            # ember-release,
             # ember-production,
             ember-default-docs
           ]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ columns: [
 ```
 
 `rows` could be a javascript array, ember array or any data structure that implements `length` and
-`objectAt(index)`. This flexibity gives application to avoid having all data at front but loads more
+`objectAt(index)`. This flexibility gives application to avoid having all data at front but loads more
 data as user scrolls. Each object in the `rows` data structure should contains all fields defined
 by all `valuePath` in `columns` array.
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -59,13 +59,22 @@ module.exports = function() {
           },
         },
         {
-          name: 'ember-release',
+          name: 'ember-lts-4.12',
           npm: {
             devDependencies: {
-              'ember-source': urls[0],
+              'ember-source': '~4.4.0',
             },
           },
         },
+        // TEMPORARY DISABLE
+        // {
+        //   name: 'ember-release',
+        //   npm: {
+        //     devDependencies: {
+        //       'ember-source': urls[0],
+        //     },
+        //   },
+        // },
         {
           name: 'ember-beta',
           npm: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -62,19 +62,18 @@ module.exports = function() {
           name: 'ember-lts-4.12',
           npm: {
             devDependencies: {
-              'ember-source': '~4.4.0',
+              'ember-source': '~4.12.0',
             },
           },
         },
-        // TEMPORARY DISABLE
-        // {
-        //   name: 'ember-release',
-        //   npm: {
-        //     devDependencies: {
-        //       'ember-source': urls[0],
-        //     },
-        //   },
-        // },
+        {
+          name: 'ember-release',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[0],
+            },
+          },
+        },
         {
           name: 'ember-beta',
           npm: {


### PR DESCRIPTION
This PR disabled "ember-release" scenario in ember-try, as it started to return `5.0.0` and fail the CI for all new PRs.

Proper `5.0.0` support will be fixed and this check will be re-introduced in another PR for same ticket.

Ticket: WEBCORE-2069

Release Notes: We have discovered that ember-table is currently incompatible with ember 5.0.0 due to breaking changes in upstream