### PR TITLE
fix: import htmlSafe from @ember/template, not @ember/string

### DIFF
--- a/addon/components/ember-table/component.js
+++ b/addon/components/ember-table/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import {
   setupTableStickyPolyfill,
   teardownTableStickyPolyfill,


### PR DESCRIPTION
This fixes the deprecation in Ember 3.25 https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe

Currently this is blocking our ability to use this addon in an Ember 3.28 application.

