### PR TITLE
Compare offsetHeight/getComputedStyle at scale

### DIFF
--- a/tests/unit/-private/element-utils-test.js
+++ b/tests/unit/-private/element-utils-test.js
@@ -57,4 +57,96 @@ module('Unit | Private | element', function(hooks) {
       getScale(div);
     });
   });
+
+  test('can get the scale of element with table header', function(assert) {
+    let table = document.createElement('table');
+    table.style.borderSpacing = '0';
+
+    let thead = document.createElement('thead');
+    table.append(thead);
+
+    let row = document.createElement('tr');
+    row.style.lineHeight = '8.5px';
+    row.style.height = '8.5px';
+    let cell = document.createElement('td');
+    cell.style.padding = '0px';
+    cell.textContent = 'header cell';
+    row.append(cell);
+    thead.append(row);
+
+    let tbody = document.createElement('tbody');
+    tbody.style.borderTopWidth = '1px';
+    tbody.style.borderTopStyle = 'solid';
+    table.append(tbody);
+
+    for (let i = 0; i < 50; i++) {
+      let row = document.createElement('tr');
+      row.style.lineHeight = '40px';
+      row.style.height = '40px';
+      let cell = document.createElement('td');
+      cell.style.padding = '0px';
+      cell.textContent = `cell ${i}`;
+      row.append(cell);
+      tbody.append(row);
+    }
+
+    this.element.append(table);
+
+    assert.equal(getScale(table), 1, 'scale on a simple element is correct');
+
+    table.style.transform = 'scale(0.5)';
+
+    assert.equal(getScale(table), 2, 'scale on a scaled element is correct');
+  });
+
+  /*
+   * For very large numbers of items and rows, Chrome seems to start to
+   * yield internally inconsistent values between computed height and
+   * offset height. Assert that we've covered that case.
+   */
+  test('can get the scale of element with table header and extraordinary item count and height', function(assert) {
+    let table = document.createElement('table');
+    table.style.borderSpacing = '0';
+
+    let thead = document.createElement('thead');
+    table.append(thead);
+
+    let row = document.createElement('tr');
+    row.style.lineHeight = '1.5px';
+    row.style.height = '1.5px';
+    let cell = document.createElement('td');
+    cell.style.padding = '0px';
+    cell.textContent = 'header cell';
+    row.append(cell);
+    thead.append(row);
+
+    let tbody = document.createElement('tbody');
+    tbody.style.borderTopWidth = '1px';
+    tbody.style.borderTopStyle = 'solid';
+    table.append(tbody);
+
+    /*
+     * This pushes the height of the box above 7 digits, which
+     * seems to reliably trigger the internal bug is triggered.
+     * It has been observed on macOS at a lower value of 500k.
+     */
+    for (let i = 0; i < 250; i++) {
+      let row = document.createElement('tr');
+      row.style.lineHeight = '4000px';
+      row.style.height = '4000px';
+      let cell = document.createElement('td');
+      cell.style.padding = '0px';
+      cell.textContent = `cell ${i}`;
+      row.append(cell);
+      tbody.append(row);
+    }
+
+    this.element.append(table);
+
+    assert.equal(getScale(table), 1, 'scale on a simple element is correct');
+
+    table.style.transform = 'scale(0.5)';
+
+    assert.equal(getScale(table), 2, 'scale on a scaled element is correct');
+  });
 });


### PR DESCRIPTION
At very large heights based on many child elements, Chrome and even Firefox begin to diverge the computed height values from what you see at lower scales. This makes their comparison with offsetHeight less reliable at high scales.

However, at large height values the exactness of the height measurement also matters less. At the end, only a limited level of precision is desired in the scale value and later code throws away noise at the lower end.

So, use a more forgiving comparison methodology (% shift in the change) vs requiring the two values to be only a single digit off.

I've asserted this on a table in our product which triggers the exception with a height of 100877px, but not below that number. This fix as written avoids the exception.