### PR TITLE
fix: add 'eq-container-slack' and 'gte-container-slack' to widthConstraint union type

### DIFF
--- a/types/components/ember-thead/component.d.ts
+++ b/types/components/ember-thead/component.d.ts
@@ -118,7 +118,7 @@ export interface EmberTheadArgs<RowType, ColumnType> {
   /**
    * Sets a constraint on the table's size, such that it must be greater than, less than, or equal to the size of the containing element.
    */
-  widthConstraint?: 'none' | 'eq-container' | 'gte-container' | 'lte-container';
+  widthConstraint?: 'none' | 'eq-container' | 'eq-container-slack' | 'gte-container' | 'gte-container-slack' | 'lte-container';
 }
 
 export interface EmberTheadSignature<


### PR DESCRIPTION
I noticed the `widthConstraint` type of the `ember-thead` comopnent, didn't accept the `'eq-container-slack'` and `'gte-container-slack'` options that are defined in the [docs](https://opensource.addepar.com/ember-table/docs/guides/header/size-constraints)