### PR TITLE
fix: use selectingChildrenSelectsParent instead of selectingChildrenSelectsParents

### DIFF
--- a/types/components/ember-tbody/component.d.ts
+++ b/types/components/ember-tbody/component.d.ts
@@ -104,7 +104,7 @@ export interface EmberTbodyArgs<RowType extends EmberTableRow> {
   /**
    * When `true`, this option causes selecting all of a node's children to also select the node itself.
    */
-  selectingChildrenSelectsParents?: boolean;
+  selectingChildrenSelectsParent?: boolean;
 
   /**
    * The currently selected rows.


### PR DESCRIPTION
While using `ember-table`, I noticed I was getting a type error when passing `selectingChildrenSelectsParent` to the `t.body` component (see [Selection Mode docs](https://opensource.addepar.com/ember-table/docs/guides/body/row-selection#selection-modes) and [usage in code](https://github.com/Addepar/ember-table/blob/master/addon/components/ember-tbody/component.js#L97))

I had a quick scan through the code and noticed in the types it was wrongfully defined as `selectingChildrenSelectsParents` (with a trailing "s").

This PR fixes that.