### PR TITLE
types: add and use TableRowMeta interface

### DIFF
--- a/types/components/ember-tbody/component.d.ts
+++ b/types/components/ember-tbody/component.d.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { EmberTableColumn, EmberTableRow } from 'ember-table';
+import { EmberTableColumn, EmberTableRow, TableRowMeta } from 'ember-table';
 import EmberTrComponent from 'ember-table/components/ember-tr/component';
 
 type SelectionMode =
@@ -135,7 +135,7 @@ export interface EmberTbodySignature<
     default: [
       {
         row: typeof EmberTrComponent<RowType, ColumnType>;
-        rowMeta: unknown;
+        rowMeta: TableRowMeta;
         rowValue: RowType;
       }
     ];

--- a/types/components/ember-td/component.d.ts
+++ b/types/components/ember-td/component.d.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { EmberTableColumn,  EmberTableRow } from 'ember-table';
+import { EmberTableColumn,  EmberTableRow, TableRowMeta } from 'ember-table';
 
 export interface EmberTdSignature<RowType, ColumnType> {
   Element: HTMLTableCellElement;
@@ -21,7 +21,7 @@ export interface EmberTdSignature<RowType, ColumnType> {
       rowValue: RowType,
       cellMeta: unknown,
       columnMeta: unknown,
-      rowMeta: unknown,
+      rowMeta: TableRowMeta,
     ];
   };
 }

--- a/types/components/ember-tfoot/component.d.ts
+++ b/types/components/ember-tfoot/component.d.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { EmberTableColumn,  EmberTableRow } from 'ember-table';
+import { EmberTableColumn,  EmberTableRow, TableRowMeta } from 'ember-table';
 import EmberTrComponent from 'ember-table/components/ember-tr/component';
 
 export interface EmberTfootSignature<
@@ -14,7 +14,7 @@ export interface EmberTfootSignature<
     default: [
       {
         row: typeof EmberTrComponent<RowType, ColumnType>;
-        rowMeta: unknown;
+        rowMeta: TableRowMeta;
         rowValue: RowType;
       }
     ];

--- a/types/components/ember-tr/component.d.ts
+++ b/types/components/ember-tr/component.d.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { EmberTableColumn, EmberTableRow } from 'ember-table';
+import { EmberTableColumn, EmberTableRow, TableRowMeta } from 'ember-table';
 import EmberTdComponent from 'ember-table/components/ember-td/component';
 
 export interface EmberTrSignature<
@@ -27,7 +27,7 @@ export interface EmberTrSignature<
         cellValue: RowType[keyof RowType];
         columnMeta: unknown;
         columnValue: ColumnType;
-        rowMeta: unknown;
+        rowMeta: TableRowMeta;
         rowValue: RowType;
       }
     ];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,3 +18,15 @@ export interface EmberTableSort {
   isAscending: boolean;
   valuePath: string;
 }
+
+export interface TableRowMeta {
+  isCollapsed: boolean;
+  isSelected: boolean;
+  isGroupSelected: boolean;
+  canCollapse: boolean;
+  depth: number;
+  first: unknown | null;
+  last: unknown | null;
+  next: unknown | null;
+  prev: unknown | null;
+}


### PR DESCRIPTION
## Why?
I'm using the `ember-table` package with TypeScript and noticed I got errors in my template when I attempted to use any of the `rowMeta` properties.

## What?
Define the `TableRowMeta` interface based on [addon/-private/collapse-tree.js](https://github.com/Addepar/ember-table/blob/master/addon/-private/collapse-tree.js) and use it instead of `unknown` in the type declarations.