### PR TITLE
ts: add TableColumnMeta type

### DIFF
--- a/types/components/ember-td/component.d.ts
+++ b/types/components/ember-td/component.d.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { EmberTableColumn,  EmberTableRow, TableRowMeta } from 'ember-table';
+import { EmberTableColumn,  EmberTableRow, TableColumnMeta, TableRowMeta } from 'ember-table';
 
 export interface EmberTdSignature<RowType, ColumnType> {
   Element: HTMLTableCellElement;
@@ -20,7 +20,7 @@ export interface EmberTdSignature<RowType, ColumnType> {
       columnValue: ColumnType,
       rowValue: RowType,
       cellMeta: unknown,
-      columnMeta: unknown,
+      columnMeta: TableColumnMeta,
       rowMeta: TableRowMeta,
     ];
   };

--- a/types/components/ember-th/component.d.ts
+++ b/types/components/ember-th/component.d.ts
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { TableColumnMeta } from 'ember-table';
 
 export interface EmberThSignature<ColumnType> {
   Element: HTMLTableCellElement;
@@ -11,7 +12,7 @@ export interface EmberThSignature<ColumnType> {
   Blocks: {
     default: [
       columnValue: ColumnType,
-      columnMeta: unknown,
+      columnMeta: TableColumnMeta,
     ];
   };
 }

--- a/types/components/ember-th/resize-handle/component.d.ts
+++ b/types/components/ember-th/resize-handle/component.d.ts
@@ -1,9 +1,10 @@
 import Component from '@ember/component';
+import { TableColumnMeta } from 'ember-table';
 
 export interface ResizeHandleSignature {
   Element: HTMLTableCellElement;
   Args: {
-    columnMeta: unknown;
+    columnMeta: TableColumnMeta;
   };
 }
 

--- a/types/components/ember-th/sort-indicator/component.d.ts
+++ b/types/components/ember-th/sort-indicator/component.d.ts
@@ -1,9 +1,10 @@
 import Component from '@ember/component';
+import { TableColumnMeta } from 'ember-table';
 
 export interface SortIndicatorSignature {
   Element: HTMLTableCellElement;
   Args: {
-    columnMeta: unknown;
+    columnMeta: TableColumnMeta;
   };
 }
 

--- a/types/components/ember-tr/component.d.ts
+++ b/types/components/ember-tr/component.d.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { EmberTableColumn, EmberTableRow, TableRowMeta } from 'ember-table';
+import { EmberTableColumn, EmberTableRow, TableColumnMeta, TableRowMeta } from 'ember-table';
 import EmberTdComponent from 'ember-table/components/ember-td/component';
 
 export interface EmberTrSignature<
@@ -25,7 +25,7 @@ export interface EmberTrSignature<
         cell: CellComponentType;
         cellMeta: unknown;
         cellValue: RowType[keyof RowType];
-        columnMeta: unknown;
+        columnMeta: TableColumnMeta;
         columnValue: ColumnType;
         rowMeta: TableRowMeta;
         rowValue: RowType;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,3 +30,23 @@ export interface TableRowMeta {
   next: unknown | null;
   prev: unknown | null;
 }
+
+export interface TableColumnMeta {
+  isLeaf: boolean;
+  isFixed: 'left' | 'right' | undefined;
+  isSortable: boolean;
+  isResizable: boolean;
+  isReorderable: boolean;
+  isSlack: boolean;
+  width: number;
+  offsetLeft: number;
+  offsetRight: number;
+  rowSpan: number;
+  columnSpan: number;
+  index: number | undefined;
+  isLastRendered: boolean;
+  sortIndex: number;
+  isSorted: boolean;
+  isMultiSorted: boolean;
+  isSortedAsc: boolean;
+}


### PR DESCRIPTION
## Why?
I was attempting to use a property of `columnMeta` and was getting TS errors.

## What?
Add `TableColumnMeta` type based on [addon/-private/column-tree.js](https://github.com/Addepar/ember-table/blob/master/addon/-private/column-tree.js).