### PR TITLE
fix(ts): fix types for ember-tr onClick and onDoubleClick

### DIFF
--- a/types/components/ember-tr/component.d.ts
+++ b/types/components/ember-tr/component.d.ts
@@ -12,12 +12,12 @@ export interface EmberTrSignature<
     /**
      * An action that is called when a row is clicked. Will be called with the row and the event.
      */
-    onClick?: ((row: RowType, event: Event) => void);
+    onClick?: (event: { event: Event, rowValue: RowType, rowMeta: TableRowMeta }) => void;
 
     /**
      * An action that is called when a row is double clicked. Will be called with the row and the event.
      */
-    onDoubleClick?: ((row: RowType, event: Event) => void);
+    onDoubleClick?: (event: { event: Event, rowValue: RowType, rowMeta: TableRowMeta }) => void;
   };
   Blocks: {
     default: [


### PR DESCRIPTION
While using the `@onClick` argument on a `EmberTr` component, I noticed the value I was getting back didn't match its type.

I based the type off of the implementation of the `click` and `doubleClick` function here: https://github.com/Addepar/ember-table/blob/393d36f22fce0c513133d1c165a54332490d4fcc/addon/components/ember-tr/component.js#L97-L131