### PR TITLE
fix sticky-polyfill causing crash on destroy

### DIFF
--- a/addon/-private/sticky/table-sticky-polyfill.js
+++ b/addon/-private/sticky/table-sticky-polyfill.js
@@ -210,6 +210,6 @@ export function setupTableStickyPolyfill(element) {
 }
 
 export function teardownTableStickyPolyfill(element) {
-  TABLE_POLYFILL_MAP.get(element).destroy();
+  TABLE_POLYFILL_MAP.get(element)?.destroy();
   TABLE_POLYFILL_MAP.delete(element);
 }

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -399,5 +399,32 @@ module('Integration | basic', function() {
       document.querySelector('#ember-testing-container').style.height = '600px';
       this.set('showComponent', false);
     });
+
+    test('Destroying table with footerRows after initial render does not trigger error', async function(assert) {
+      assert.expect(0);
+
+      this.set('columns', generateColumns(4));
+      this.set('rows', generateRows(10));
+
+      this.set('showComponent', true);
+
+      await render(hbs`
+        {{#if this.showComponent}}
+          <div id="container" style="height: 500px;">
+            <EmberTable as |t|>
+              <EmberThead @api={{t}} @columns={{this.columns}} />
+              <EmberTbody @api={{t}} @rows={{this.rows}} @estimateHeigh={{13}} />
+              {{#if this.footerRows}}
+                <EmberTfoot @api={{t}} @rows={{this.footerRows}} />
+              {{/if}}
+            </EmberTable>
+          </div>
+        {{/if}}
+      `);
+
+      this.set('footerRows', generateRows(1));
+
+      this.set('showComponent', false);
+    });
   });
 });


### PR DESCRIPTION
When a ember-table is initially rendered without a `tfoot`, and a `tfoot` is added after the initial render (e.g. due to a loading state), the table will cause a crash on destroy.

This happens because the `TABLE_POLYFILL_MAP` does not have an entry for the specific `tfoot` element and thus, we call `.destroy()` on `undefined`.