### PR TITLE
Drop adde-lint, use eslint directly for "lint:js" run-script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /blueprints/*/files/**/*.js
 **/*.ts
+dist/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs:deploy": "ember try:one ember-default-docs --- ember deploy production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:files": "ember adde-lint --file-names",
-    "lint:js": "ember adde-lint --javascript",
+    "lint:js": "eslint .",
     "lint:sass": "ember adde-lint --sass",
     "release": "release-it",
     "start": "ember serve",


### PR DESCRIPTION
For the "lint:js" run script, drop the usage of the custom `@addepar/ember-toolbox`-supplied `ember adde-lint` command, replacing it with direct usage of `eslint` instead.

Technically speaking, this is broader lint coverage than we had before.
The adde-lint command (as in `ember adde-lint`) is defined at [Addepar/addepar-ember-toolbox@897b838/index.js#L29-L44](https://github.com/Addepar/addepar-ember-toolbox/blob/897b838c696c422bdf70c81983e6ecc29db2e34b/index.js#L29-L44)
For --javascript, the [lint subcommand code](https://github.com/Addepar/addepar-ember-toolbox/blob/897b838c696c422bdf70c81983e6ecc29db2e34b/lib/lint.js#L79-L113) concats the STANDARD_APP_FILES and STANDARD_APP_PATHS ([defined here](https://github.com/Addepar/addepar-ember-toolbox/blob/897b838c696c422bdf70c81983e6ecc29db2e34b/lib/lint.js#L6-L17)) and then filters out any that don't exist. It passes those as explicit args to the eslint command.

It seems more future-safe to lint using the catchall `.`.
In order to make linting work correctly I had to add `dist/` to the `.eslintignore` file.
I used `DEBUG=eslint:cli-engine npx eslint .` (from stackoverflow, here: https://stackoverflow.com/questions/70284958/how-to-list-files-being-linted-by-eslint) to double-check which files are linted.