### PR TITLE
We want to know the column on which sorting was turned off

### DIFF
--- a/addon/components/ember-th/component.js
+++ b/addon/components/ember-th/component.js
@@ -175,6 +175,8 @@ export default BaseTableCell.extend({
       newSortings.push({ valuePath, isAscending: false });
     } else if (existingSorting.isAscending === false) {
       newSortings.push({ valuePath, isAscending: true });
+    } else {
+      newSortings.push({ valuePath });
     }
 
     this.get('api').sendUpdateSort(newSortings);


### PR DESCRIPTION
Suppose we have table of car data, something like:

| Make  | Model | Year|
| ------|------- | ------------- |
| Toyota | Camry | 2021
| Ford  | Escape | 2022 |
|  ... | ... |...

Our `template.hbs` has
```
<EmberTable as |t|>
    <t.head
        @onUpdateSorts={{action this.onUpdateSortsCallback}}
        ...
```
and our `component.js` has
```
@action
onUpdateSortsCallback(sorts: EmberTableSort[]) {
    console.log(sorts);
}
```