### PR TITLE
Ember v6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
             ember-lts-3.28,
             ember-lts-4.4,
             ember-lts-4.12,
-            # ember-release,
+            ember-lts-5.4,
+            ember-lts-5.12,
+            ember-release,
             # ember-production,
             ember-default-docs
           ]

--- a/addon/components/ember-td/component.js
+++ b/addon/components/ember-td/component.js
@@ -1,6 +1,6 @@
 import BaseTableCell from '../-private/base-table-cell';
 
-import { computed } from '@ember/object';
+import { computed, action } from '@ember/object';
 import { alias, readOnly } from '@ember/object/computed';
 
 import layout from './template';
@@ -121,31 +121,29 @@ export default BaseTableCell.extend({
     );
   }),
 
-  actions: {
-    onSelectionToggled(event) {
-      let rowMeta = this.get('rowMeta');
-      let checkboxSelectionMode = this.get('checkboxSelectionMode') || this.get('rowSelectionMode');
+  onSelectionToggled: action(function(event) {
+    let rowMeta = this.get('rowMeta');
+    let checkboxSelectionMode = this.get('checkboxSelectionMode') || this.get('rowSelectionMode');
 
-      if (rowMeta && checkboxSelectionMode === SELECT_MODE.MULTIPLE) {
-        let toggle = true;
-        let range = event.shiftKey;
+    if (rowMeta && checkboxSelectionMode === SELECT_MODE.MULTIPLE) {
+      let toggle = true;
+      let range = event.shiftKey;
 
-        rowMeta.select({ toggle, range });
-      } else if (rowMeta && checkboxSelectionMode === SELECT_MODE.SINGLE) {
-        rowMeta.select();
-      }
+      rowMeta.select({ toggle, range });
+    } else if (rowMeta && checkboxSelectionMode === SELECT_MODE.SINGLE) {
+      rowMeta.select();
+    }
 
-      this.sendFullAction('onSelect');
-    },
+    this.sendFullAction('onSelect');
+  }),
 
-    onCollapseToggled() {
-      let rowMeta = this.get('rowMeta');
+  onCollapseToggled: action(function() {
+    let rowMeta = this.get('rowMeta');
 
-      rowMeta.toggleCollapse();
+    rowMeta.toggleCollapse();
 
-      this.sendFullAction('onCollapse');
-    },
-  },
+    this.sendFullAction('onCollapse');
+  }),
 
   click(event) {
     this.sendFullAction('onClick', { event });

--- a/addon/components/ember-td/template.hbs
+++ b/addon/components/ember-td/template.hbs
@@ -7,7 +7,7 @@
       >
         <EmberTableSimpleCheckbox
           @checked={{this.rowMeta.isGroupSelected}}
-          @onClick={{action "onSelectionToggled"}}
+          @onClick={{this.onSelectionToggled}}
           @ariaLabel="Select row"
           @dataTestSelectRow={{this.isTesting}}
         />
@@ -19,7 +19,7 @@
       <span class="et-toggle-collapse et-depth-indent {{this.depthClass}}">
         <EmberTableSimpleCheckbox
           @checked={{this.rowMeta.isCollapsed}}
-          @onChange={{action "onCollapseToggled"}}
+          @onChange={{this.onCollapseToggled}}
           @ariaLabel="Collapse row"
           @dataTestCollapseRow={{this.isTesting}}
         />

--- a/addon/components/ember-th/component.js
+++ b/addon/components/ember-th/component.js
@@ -6,7 +6,7 @@ import { readOnly } from '@ember/object/computed';
 import { closest } from '../../-private/utils/element';
 
 import layout from './template';
-import { get } from '@ember/object';
+import { get, action } from '@ember/object';
 
 const COLUMN_INACTIVE = 0;
 const COLUMN_RESIZING = 1;
@@ -128,11 +128,9 @@ export default BaseTableCell.extend({
     this._super(...arguments);
   },
 
-  actions: {
-    sendDropdownAction(...args) {
-      this.onDropdownAction?.(...args);
-    },
-  },
+  sendDropdownAction: action(function(...args) {
+    this.onDropdownAction?.(...args);
+  }),
 
   click(event) {
     let isSortable = this.get('isSortable');

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -70,6 +70,22 @@ module.exports = function() {
           },
         },
         {
+          name: 'ember-lts-5.4',
+          npm: {
+            devDependencies: {
+              'ember-source': '~5.4.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-5.12',
+          npm: {
+            devDependencies: {
+              'ember-source': '~5.12.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {
@@ -118,6 +134,9 @@ module.exports = function() {
               'ember-cli-deploy-build': '^1.1.1',
               'ember-cli-deploy-git': '^1.3.3',
               'ember-cli-deploy-git-ci': '^1.0.1',
+            },
+            resolutions: {
+              '@handlebars/parser': '~2.1.0',
             },
           },
         },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-terser": "^4.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
-    "ember-export-application-global": "^2.0.0",
     "ember-faker": "^1.5.0",
     "ember-load-initializers": "^2.0.0",
     "ember-math-helpers": "~2.11.3",

--- a/tests/dummy/app/components/custom-cell/template.hbs
+++ b/tests/dummy/app/components/custom-cell/template.hbs
@@ -1,5 +1,5 @@
 {{! BEGIN-SNIPPET custom-cell.hbs }}
-<div class="custom-header text-{{color}}">
+<div class="custom-header text-{{this.color}}">
   Cell {{yield}}
 </div>
 {{! END-SNIPPET }}

--- a/tests/dummy/app/components/custom-header/template.hbs
+++ b/tests/dummy/app/components/custom-header/template.hbs
@@ -1,5 +1,5 @@
 {{! BEGIN-SNIPPET custom-header.hbs }}
-<div class="custom-header bg-{{color}}">
+<div class="custom-header bg-{{this.color}}">
   Column {{yield}}
 </div>
 {{! END-SNIPPET }}

--- a/tests/dummy/app/components/examples/aborting-a-selection/template.hbs
+++ b/tests/dummy/app/components/examples/aborting-a-selection/template.hbs
@@ -4,7 +4,7 @@
 
   <t.body
     @rows={{this.rows}}
-    @onSelect={{action this.selectRows}}
+    @onSelect={{this.selectRows}}
     @selection={{this.selection}}
   />
 </EmberTable>

--- a/tests/dummy/app/components/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/components/examples/infinite-scroll/template.hbs
@@ -1,6 +1,6 @@
 <div class='demo-options'>
   <label>
-    <Input @type="checkbox" @checked={{centerSpinner}} />
+    <Input @type="checkbox" @checked={{this.centerSpinner}} />
     Enable Centering
   </label>
 </div>

--- a/tests/dummy/app/components/examples/row-selection/template.hbs
+++ b/tests/dummy/app/components/examples/row-selection/template.hbs
@@ -5,7 +5,7 @@
 
     <t.body
       @rows={{this.rows}}
-      @onSelect={{action (mut selection)}}
+      @onSelect={{fn (mut this.selection)}}
       @selection={{this.selection}}
     />
   </EmberTable>

--- a/tests/dummy/app/components/examples/selected-rows/template.hbs
+++ b/tests/dummy/app/components/examples/selected-rows/template.hbs
@@ -5,7 +5,7 @@
 
     <t.body
       @rows={{this.rowWithChildren}}
-      @onSelect={{action (mut preselection)}}
+      @onSelect={{fn (mut this.preselection)}}
       @selection={{this.preselection}}
     />
   </EmberTable>

--- a/tests/dummy/app/components/examples/selection-modes/template.hbs
+++ b/tests/dummy/app/components/examples/selection-modes/template.hbs
@@ -10,7 +10,7 @@
       @checkboxSelectionMode={{this.checkboxSelectionMode}}
       @selectingChildrenSelectsParent={{this.selectingChildrenSelectsParent}}
 
-      @onSelect={{action (mut demoSelection)}}
+      @onSelect={{fn (mut this.demoSelection)}}
       @selection={{this.demoSelection}}
     />
   </EmberTable>
@@ -33,7 +33,7 @@
 </div>
 <div class="demo-options-group">
   <h4>selectingChildrenSelectsParent</h4>
-  <label> <Input @type="checkbox" @checked={{selectingChildrenSelectsParent}} /> </label>
+  <label> <Input @type="checkbox" @checked={{this.selectingChildrenSelectsParent}} /> </label>
 </div>
 
 {{! END-SNIPPET }}

--- a/tests/dummy/app/components/examples/sorting-empty-values/template.hbs
+++ b/tests/dummy/app/components/examples/sorting-empty-values/template.hbs
@@ -14,7 +14,7 @@
           @sorts={{this.sorts}}
           @sortEmptyLast={{this.sortEmptyLast}}
 
-          @onUpdateSorts={{action (mut this.sorts)}}
+          @onUpdateSorts={{fn (mut this.sorts)}}
 
           @widthConstraint='gte-container'
           @fillMode='first-column'

--- a/tests/dummy/app/components/main/table-meta-data/cell-selection/component.js
+++ b/tests/dummy/app/components/main/table-meta-data/cell-selection/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computed, action } from '@ember/object';
 import { generateRows } from 'dummy/utils/generators';
 
 export default Component.extend({
@@ -20,26 +20,24 @@ export default Component.extend({
   }),
 
   // BEGIN-SNIPPET table-meta-data-cell-selection.js
-  actions: {
-    setSelected(cellMeta, columnMeta, rowMeta) {
-      // If we have selected before, unselect the previous selection
-      if (this._hasSelection) {
-        this._lastSelectedCellMeta.set('selected', false);
-        this._lastSelectedColumnMeta.set('selected', false);
-        this._lastSelectedRowMeta.set('selected', false);
-      }
+  setSelected: action(function(cellMeta, columnMeta, rowMeta) {
+    // If we have selected before, unselect the previous selection
+    if (this._hasSelection) {
+      this._lastSelectedCellMeta.set('selected', false);
+      this._lastSelectedColumnMeta.set('selected', false);
+      this._lastSelectedRowMeta.set('selected', false);
+    }
 
-      // Set selection on the meta objects
-      cellMeta.set('selected', true);
-      columnMeta.set('selected', true);
-      rowMeta.set('selected', true);
+    // Set selection on the meta objects
+    cellMeta.set('selected', true);
+    columnMeta.set('selected', true);
+    rowMeta.set('selected', true);
 
-      // Store the meta objects to unset in the future
-      this._lastSelectedCellMeta = cellMeta;
-      this._lastSelectedColumnMeta = columnMeta;
-      this._lastSelectedRowMeta = rowMeta;
-      this._hasSelection = true;
-    },
-  },
+    // Store the meta objects to unset in the future
+    this._lastSelectedCellMeta = cellMeta;
+    this._lastSelectedColumnMeta = columnMeta;
+    this._lastSelectedRowMeta = rowMeta;
+    this._hasSelection = true;
+  }),
   // END-SNIPPET
 });

--- a/tests/dummy/app/components/main/table-meta-data/cell-selection/template.hbs
+++ b/tests/dummy/app/components/main/table-meta-data/cell-selection/template.hbs
@@ -27,7 +27,7 @@
 
               as |cell column row cellMeta columnMeta rowMeta|
             >
-              <div onclick={{action "setSelected" cellMeta columnMeta rowMeta}} class="cell-content">
+              <div onclick={{fn this.setSelected cellMeta columnMeta rowMeta}} class="cell-content">
                 {{cell}}
               </div>
             </r.cell>

--- a/tests/dummy/app/controllers/docs/guides/header/fixed-columns.js
+++ b/tests/dummy/app/controllers/docs/guides/header/fixed-columns.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { A as emberA } from '@ember/array';
-import { get, set } from '@ember/object';
+import { get, set, action } from '@ember/object';
 
 import { generateRows } from 'dummy/utils/generators';
 import { computed } from '@ember/object';
@@ -64,13 +64,11 @@ export default Controller.extend({
   }),
   // END-SNIPPET
 
-  actions: {
-    toggleFixed(column) {
-      if (get(column, 'isFixed')) {
-        set(column, 'isFixed', false);
-      } else {
-        set(column, 'isFixed', 'left');
-      }
-    },
-  },
+  toggleFixed: action(function(column) {
+    if (get(column, 'isFixed')) {
+      set(column, 'isFixed', false);
+    } else {
+      set(column, 'isFixed', 'left');
+    }
+  }),
 });

--- a/tests/dummy/app/controllers/docs/guides/header/sorting.js
+++ b/tests/dummy/app/controllers/docs/guides/header/sorting.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
+import { computed, action } from '@ember/object';
 import faker from 'faker';
 import { getRandomInt } from 'dummy/utils/generators';
 
@@ -77,31 +77,29 @@ export default Controller.extend({
   }),
 
   // BEGIN-SNIPPET docs-example-2-state-sortings.js
-  actions: {
-    twoStateSorting(sorts) {
-      if (sorts.length > 1) {
-        // multi-column sort, default behavior
-        this.set('sorts', sorts);
-        return;
-      }
-
-      let hasExistingSort = this.sorts && this.sorts.length;
-      let isDefaultSort = !sorts.length;
-
-      if (hasExistingSort && isDefaultSort) {
-        // override empty sorts with reversed previous sort
-        let newSorts = [
-          {
-            valuePath: this.sorts[0].valuePath,
-            isAscending: !this.sorts[0].isAscending,
-          },
-        ];
-        this.set('sorts', newSorts);
-        return;
-      }
-
+  twoStateSorting: action(function(sorts) {
+    if (sorts.length > 1) {
+      // multi-column sort, default behavior
       this.set('sorts', sorts);
-    },
-  },
+      return;
+    }
+
+    let hasExistingSort = this.sorts && this.sorts.length;
+    let isDefaultSort = !sorts.length;
+
+    if (hasExistingSort && isDefaultSort) {
+      // override empty sorts with reversed previous sort
+      let newSorts = [
+        {
+          valuePath: this.sorts[0].valuePath,
+          isAscending: !this.sorts[0].isAscending,
+        },
+      ];
+      this.set('sorts', newSorts);
+      return;
+    }
+
+    this.set('sorts', sorts);
+  }),
   // END-SNIPPET
 });

--- a/tests/dummy/app/controllers/scenarios/performance.js
+++ b/tests/dummy/app/controllers/scenarios/performance.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
+import { computed, action } from '@ember/object';
 import { generateRows, generateColumns } from 'dummy/utils/generators';
 
 export default Controller.extend({
@@ -26,12 +26,10 @@ export default Controller.extend({
     return columns;
   }),
 
-  actions: {
-    onSelect(selection) {
-      this.set('selection', selection);
-    },
-    onUpdateSorts(sorts) {
-      this.set('sorts', sorts);
-    },
-  },
+  onSelect: action(function(selection) {
+    this.set('selection', selection);
+  }),
+  onUpdateSorts: action(function(sorts) {
+    this.set('sorts', sorts);
+  }),
 });

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,7 +1,10 @@
+import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class IndexRoute extends Route {
+  @service router;
+
   redirect() {
-    this.transitionTo('docs');
+    this.router.transitionTo('docs');
   }
 }

--- a/tests/dummy/app/templates/docs/guides/body/rows-and-trees.md
+++ b/tests/dummy/app/templates/docs/guides/body/rows-and-trees.md
@@ -51,7 +51,7 @@ the table body.
     {{! BEGIN-SNIPPET docs-example-tree-rows.hbs }}
     <div class="demo-options">
       <label>
-        {{input type="checkbox" checked=treeEnabled}}
+        {{input type="checkbox" checked=this.treeEnabled}}
         Enable Tree
       </label>
     </div>
@@ -90,7 +90,7 @@ If you want to disable collapsing at a row level, you can pass
     {{! BEGIN-SNIPPET docs-example-rows-with-collapse.hbs }}
     <div class="demo-options">
       <label>
-        {{input type="checkbox" checked=collapseEnabled}}
+        {{input type="checkbox" checked=this.collapseEnabled}}
         Enable Collapse
       </label>
     </div>

--- a/tests/dummy/app/templates/docs/guides/header/columns.md
+++ b/tests/dummy/app/templates/docs/guides/header/columns.md
@@ -118,15 +118,15 @@ when the column definitions are plain JavaScript arrays. The solution (for now) 
     {{! BEGIN-SNIPPET docs-example-column-resize-reorder.hbs }}
     <div class='demo-options'>
       <label>
-        {{input type="checkbox" checked=resizeEnabled}}
+        {{input type="checkbox" checked=this.resizeEnabled}}
         Enable Resizing
       </label>
       <label>
-        {{input type="checkbox" checked=reorderEnabled}}
+        {{input type="checkbox" checked=this.reorderEnabled}}
         Enable Reordering
       </label>
       <label>
-        {{input type="checkbox" checked=resizeModeFluid}}
+        {{input type="checkbox" checked=this.resizeModeFluid}}
         Resize Mode Fluid
       </label>
     </div>
@@ -180,8 +180,8 @@ reorder has occured.
       <EmberTable as |t|>
         <t.head
           @columns={{this.columns}}
-          @onResize={{action (mut this.resizeCount) (add this.resizeCount 1)}}
-          @onReorder={{action (mut this.reorderCount) (add this.reorderCount 1)}}
+          @onResize={{fn (mut this.resizeCount) (add this.resizeCount 1)}}
+          @onReorder={{fn (mut this.reorderCount) (add this.reorderCount 1)}}
         />
 
         <t.body @rows={{this.rows}} />

--- a/tests/dummy/app/templates/docs/guides/header/fixed-columns.md
+++ b/tests/dummy/app/templates/docs/guides/header/fixed-columns.md
@@ -55,8 +55,8 @@ you can make fixed columns toggleable for your users.
   {{#demo.example name='dynamic-fixed-columns'}}
     {{examples/fixed-columns-dynamic
       rows=this.rows
-      columns=dynamicFixedColumns
-      toggleFixed=(action "toggleFixed")
+      columns=this.dynamicFixedColumns
+      toggleFixed=this.toggleFixed
     }}
   {{/demo.example}}
 

--- a/tests/dummy/app/templates/docs/guides/header/size-constraints.md
+++ b/tests/dummy/app/templates/docs/guides/header/size-constraints.md
@@ -39,32 +39,32 @@ override the min/max widths provided by columns.
     <div class="demo-options">
       <label>
         eq-container
-        {{radio-button name='width-constraint' value='eq-container' groupValue=widthConstraint}}
+        {{radio-button name='width-constraint' value='eq-container' groupValue=this.widthConstraint}}
       </label>
 
       <label>
         eq-container-slack
-        {{radio-button name='width-constraint' value='eq-container-slack' groupValue=widthConstraint}}
+        {{radio-button name='width-constraint' value='eq-container-slack' groupValue=this.widthConstraint}}
       </label>
 
       <label>
         gte-container
-        {{radio-button name='width-constraint' value='gte-container' groupValue=widthConstraint}}
+        {{radio-button name='width-constraint' value='gte-container' groupValue=this.widthConstraint}}
       </label>
 
       <label>
         gte-container-slack
-        {{radio-button name='width-constraint' value='gte-container-slack' groupValue=widthConstraint}}
+        {{radio-button name='width-constraint' value='gte-container-slack' groupValue=this.widthConstraint}}
       </label>
 
       <label>
         lte-container
-        {{radio-button name='width-constraint' value='lte-container' groupValue=widthConstraint}}
+        {{radio-button name='width-constraint' value='lte-container' groupValue=this.widthConstraint}}
       </label>
 
       <label>
         none
-        {{radio-button name='width-constraint' value='none' groupValue=widthConstraint}}
+        {{radio-button name='width-constraint' value='none' groupValue=this.widthConstraint}}
       </label>
     </div>
 
@@ -72,12 +72,12 @@ override the min/max widths provided by columns.
     <div class="demo-options">
       <label>
         standard
-        {{radio-button name='resize-mode' value='standard' groupValue=resizeMode}}
+        {{radio-button name='resize-mode' value='standard' groupValue=this.resizeMode}}
       </label>
 
       <label>
         fluid
-        {{radio-button name='resize-mode' value='fluid' groupValue=resizeMode}}
+        {{radio-button name='resize-mode' value='fluid' groupValue=this.resizeMode}}
       </label>
     </div>
 
@@ -118,22 +118,22 @@ constraint. The options are:
     <div class="demo-options">
       <label>
         equal-column
-        {{radio-button name='fill-mode' value='equal-column' groupValue=fillMode}}
+        {{radio-button name='fill-mode' value='equal-column' groupValue=this.fillMode}}
       </label>
 
       <label>
         first-column
-        {{radio-button name='fill-mode' value='first-column' groupValue=fillMode}}
+        {{radio-button name='fill-mode' value='first-column' groupValue=this.fillMode}}
       </label>
 
       <label>
         last-column
-        {{radio-button name='fill-mode' value='last-column' groupValue=fillMode}}
+        {{radio-button name='fill-mode' value='last-column' groupValue=this.fillMode}}
       </label>
 
       <label>
         nth-column
-        {{radio-button name='fill-mode' value='nth-column' groupValue=fillMode}}
+        {{radio-button name='fill-mode' value='nth-column' groupValue=this.fillMode}}
       </label>
     </div>
 
@@ -143,7 +143,7 @@ constraint. The options are:
           @columns={{this.columns}}
           @widthConstraint='eq-container'
           @resizeMode='fluid'
-          @fillMode={{fillMode}}
+          @fillMode={{this.fillMode}}
           @fillColumnIndex=1
           @scrollIndicators='horizontal'
         />

--- a/tests/dummy/app/templates/docs/guides/header/sorting.md
+++ b/tests/dummy/app/templates/docs/guides/header/sorting.md
@@ -15,7 +15,7 @@ or `ctrl`.
           @columns={{this.columns}}
           @sorts={{this.sorts}}
 
-          @onUpdateSorts={{action (mut this.sorts)}}
+          @onUpdateSorts={{fn (mut this.sorts)}}
 
           @widthConstraint='gte-container'
           @fillMode='first-column'
@@ -111,9 +111,9 @@ This demo shows that in action:
       <EmberTable as |t|>
         <t.head
           @columns={{this.columns}}
-          @sorts={{sorts}}
+          @sorts={{this.sorts}}
 
-          @onUpdateSorts={{action "twoStateSorting"}}
+          @onUpdateSorts={{this.twoStateSorting}}
 
           @widthConstraint='gte-container'
           @fillMode='first-column'

--- a/tests/dummy/app/templates/docs/guides/main/table-customization.md
+++ b/tests/dummy/app/templates/docs/guides/main/table-customization.md
@@ -51,12 +51,12 @@ components:
     {{! BEGIN-SNIPPET table-customization-example-sorting.hbs }}
     <div class='demo-options'>
       <label>
-        <input type='checkbox' checked={{this.showSortIndicator}} onclick={{action (mut this.showSortIndicator) (not this.showSortIndicator)}}>
+        <input type='checkbox' checked={{this.showSortIndicator}} onclick={{fn (mut this.showSortIndicator) (not this.showSortIndicator)}}>
         Show Sort Indicator
         <span class='small'>(Click header to sort)</span>
       </label>
       <label>
-        <input type='checkbox' checked={{this.showResizeHandle}} onclick={{action (mut this.showResizeHandle) (not this.showResizeHandle)}}>
+        <input type='checkbox' checked={{this.showResizeHandle}} onclick={{fn (mut this.showResizeHandle) (not this.showResizeHandle)}}>
         Show Resize Handle <span class='small'>(Only appears on hover)</span>
       </label>
     </div>
@@ -66,7 +66,7 @@ components:
           @columns={{this.columnsForSorting}}
           @sorts={{this.sorts}}
 
-          @onUpdateSorts={{action (mut sorts)}}
+          @onUpdateSorts={{fn (mut this.sorts)}}
           @widthConstraint='gte-container'
           @fillMode='first-column'
 

--- a/tests/dummy/app/templates/scenarios/performance.hbs
+++ b/tests/dummy/app/templates/scenarios/performance.hbs
@@ -1,12 +1,12 @@
 <div class="demo-container fixed-width">
   <EmberTable as |t|>
-    <EmberThead @api={{t}} @columns={{this.columns}} @sorts={{this.sorts}} @onUpdateSorts={{action "onUpdateSorts"}} as |h|>
+    <EmberThead @api={{t}} @columns={{this.columns}} @sorts={{this.sorts}} @onUpdateSorts={{this.onUpdateSorts}} as |h|>
       <EmberTr @api={{h}} as |r|>
         <EmberTh @api={{r}} />
       </EmberTr>
     </EmberThead>
 
-    <EmberTbody @api={{t}} @rows={{this.rows}} @selection={{this.selection}} @onSelect={{action "onSelect"}} as |b|>
+    <EmberTbody @api={{t}} @rows={{this.rows}} @selection={{this.selection}} @onSelect={{this.onSelect}} as |b|>
       <EmberTr @api={{b}} as |r|>
         <EmberTd @api={{r}} as |value column row cellMeta columnMeta|>
           {{value}}

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -28,16 +28,16 @@ const fullTable = hbs`
         @sorts={{this.sorts}}
         @sortEmptyLast={{this.sortEmptyLast}}
         @widthConstraint={{this.widthConstraint}}
-        @onUpdateSorts={{action this.onUpdateSorts}}
-        @onReorder={{action this.onReorder}}
-        @onResize={{action this.onResize}}
+        @onUpdateSorts={{this.onUpdateSorts}}
+        @onReorder={{this.onReorder}}
+        @onResize={{this.onResize}}
 
         as |h|
       >
         <EmberTr @api={{h}} as |r|>
           <EmberTh
             @api={{r}}
-            @onContextMenu={{action this.onHeaderCellContextMenu}}
+            @onContextMenu={{this.onHeaderCellContextMenu}}
           />
         </EmberTr>
       </EmberThead>
@@ -52,7 +52,7 @@ const fullTable = hbs`
         @key={{this.key}}
         @bufferSize={{this.bufferSize}}
         @idForFirstItem={{this.idForFirstItem}}
-        @onSelect={{action this.onSelect}}
+        @onSelect={{this.onSelect}}
         @selectingChildrenSelectsParent={{this.selectingChildrenSelectsParent}}
         @checkboxSelectionMode={{this.checkboxSelectionMode}}
         @rowSelectionMode={{this.rowSelectionMode}}
@@ -63,15 +63,15 @@ const fullTable = hbs`
       >
         {{#component this.rowComponent
           api=b
-          onClick=(action this.onRowClick)
-          onDoubleClick=(action this.onRowDoubleClick)
+          onClick=(fn this.onRowClick)
+          onDoubleClick=(fn this.onRowDoubleClick)
 
           as |r|
         }}
           <EmberTd
             @api={{r}}
-            @onClick={{action this.onCellClick}}
-            @onDoubleClick={{action this.onCellDoubleClick}}
+            @onClick={{this.onCellClick}}
+            @onDoubleClick={{this.onCellDoubleClick}}
             as |value|
           >
             {{value}}

--- a/tests/integration/components/headers/ember-th-test.js
+++ b/tests/integration/components/headers/ember-th-test.js
@@ -37,7 +37,7 @@ module('[Unit] ember-th', function(hooks) {
       <EmberThead @api={{t}}
         @columns={{this.columns}}
         @sorts={{this.sorts}}
-        @onUpdateSorts={{action this.onUpdateSorts}} as |h|
+        @onUpdateSorts={{this.onUpdateSorts}} as |h|
       >
         <EmberTr @api={{h}} as |r|>
           <EmberTh @api={{r}} as |column|>

--- a/tests/integration/components/headers/ember-thead-test.js
+++ b/tests/integration/components/headers/ember-thead-test.js
@@ -40,8 +40,8 @@ function sumHeaderWidths(table) {
 
 async function renderTable() {
   await render(hbs`
-    <button id="add-column" {{action this.addColumn}}>Add Column</button>
-    <button id="remove-column" {{action this.removeColumn}}>Remove Column</button>
+    <button id="add-column" {{on "click" this.addColumn}}>Add Column</button>
+    <button id="remove-column" {{on "click" this.removeColumn}}>Remove Column</button>
     <EmberTable @data-test-ember-table={{true}} as |t|>
       <EmberThead
         @api={{t}}

--- a/tests/integration/components/meta-test.js
+++ b/tests/integration/components/meta-test.js
@@ -36,7 +36,7 @@ module('Integration | meta', function() {
             </EmberThead>
             <EmberTbody @api={{t}} @rows={{this.rows}} as |b|>
               <EmberTr @api={{b}} as |r|>
-                <EmberTd @api={{r}} @onClick={{action this.onClick}} as |value column row cellMeta columnMeta rowMeta|>
+                <EmberTd @api={{r}} @onClick={{this.onClick}} as |value column row cellMeta columnMeta rowMeta|>
                   {{#if cellMeta.wasClicked}}cell{{/if}}
                   {{#if columnMeta.wasClicked}}column{{/if}}
                   {{#if rowMeta.wasClicked}}row{{/if}}
@@ -127,7 +127,7 @@ module('Integration | meta', function() {
 
             <EmberTbody @api={{t}} @rows={{this.rows}} as |b|>
               <EmberTr @api={{b}} as |r|>
-                <EmberTd @api={{r}} @onClick={{action this.onClick}} as |value column row cellMeta columnMeta rowMeta|>
+                <EmberTd @api={{r}} @onClick={{this.onClick}} as |value column row cellMeta columnMeta rowMeta|>
                   {{#if cellMeta.wasClicked}}cell{{/if}}
                   {{#if columnMeta.wasClicked}}column{{/if}}
                   {{#if rowMeta.wasClicked}}row{{/if}}
@@ -159,7 +159,7 @@ module('Integration | meta', function() {
 
             <EmberTbody @api={{t}} @rows={{this.rows}} as |b|>
               <EmberTr @api={{b}} as |r|>
-                <EmberTd @api={{r}} @onClick={{action this.onClick}} as |value column row cellMeta columnMeta rowMeta|>
+                <EmberTd @api={{r}} @onClick={{this.onClick}} as |value column row cellMeta columnMeta rowMeta|>
                   {{#if cellMeta.wasClicked}}cell{{/if}}
                   {{#if columnMeta.wasClicked}}column{{/if}}
                   {{#if rowMeta.wasClicked}}row{{/if}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6079,11 +6079,6 @@ ember-disable-prototype-extensions@^1.1.2:
   resolved "https://registry.npmjs.org/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
   integrity sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=
 
-ember-export-application-global@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
-  integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
-
 ember-faker@^1.5.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/ember-faker/-/ember-faker-1.6.0.tgz#646267bdd5f9b516ba7574d5d83d5603c7818aa7"


### PR DESCRIPTION
Removed use of `action` helper, `actions` hash, and disambiguated template variables with `this`. These changes enabled the addon to pass Ember v5 (LTS) and v6 (release) tests.

Edit: The *"TableStickyPolyfill: it works"* test (332) seems to be unstable and occasionally fails. The test fails (for me) randomly for various `ember-source` versions before and after the changes of this PR. Rerunning the tests usually clears the issue. This PR doesn't attempt to address this.