### PR TITLE
Set/Remove `isResizing` property on `TableColumnMeta`

### DIFF
--- a/addon-test-support/pages/-private/ember-table-body.js
+++ b/addon-test-support/pages/-private/ember-table-body.js
@@ -21,6 +21,7 @@ export const BodyCell = PageObject.extend({
   isFirstColumn: hasClass('is-first-column'),
   isLastColumn: hasClass('is-last-column'),
   isSlack: hasClass('is-slack'),
+  isResizing: hasClass('is-resizing'),
 });
 
 export default PageObject.extend({

--- a/addon-test-support/pages/-private/ember-table-header.js
+++ b/addon-test-support/pages/-private/ember-table-header.js
@@ -94,6 +94,7 @@ const Header = PageObject.extend({
   isFirstColumn: hasClass('is-first-column'),
   isLastColumn: hasClass('is-last-column'),
   isSlack: hasClass('is-slack'),
+  isResizing: hasClass('is-resizing'),
 
   contextMenu: triggerable('contextmenu'),
 

--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -80,6 +80,8 @@ const TableColumnMeta = EmberObject.extend({
 
   isResizable: readOnly('_node.isResizable'),
 
+  isResizing: readOnly('_node.isResizing'),
+
   isReorderable: readOnly('_node.isReorderable'),
 
   isSlack: readOnly('_node.isSlack'),
@@ -154,6 +156,8 @@ const ColumnTreeNode = EmberObject.extend({
   _subcolumnNodes: null,
 
   isSlack: false,
+
+  isResizing: false,
 
   init() {
     this._super(...arguments);
@@ -1075,6 +1079,7 @@ export default EmberObject.extend({
 
     // Add the class after at least one update has occured
     this.container.classList.add('is-resizing');
+    node.set('isResizing', true);
 
     this._updateResize(node, delta);
   },
@@ -1127,6 +1132,7 @@ export default EmberObject.extend({
     }
 
     this.container.classList.remove('is-resizing');
+    node.set('isResizing', false);
 
     this.onResize?.(get(node, 'column'));
   },

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -38,6 +38,7 @@ const fullTable = hbs`
           <EmberTh
             @api={{r}}
             @onContextMenu={{this.onHeaderCellContextMenu}}
+            @class={{if r.columnMeta.isResizing "is-resizing"}}
           />
         </EmberTr>
       </EmberThead>
@@ -72,6 +73,7 @@ const fullTable = hbs`
             @api={{r}}
             @onClick={{this.onCellClick}}
             @onDoubleClick={{this.onCellDoubleClick}}
+            @class={{if r.columnMeta.isResizing "is-resizing"}}
             as |value|
           >
             {{value}}

--- a/tests/integration/components/headers/resize-test.js
+++ b/tests/integration/components/headers/resize-test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import { waitUntil } from '@ember/test-helpers';
 
 import {
   configureTableGeneration,
@@ -115,6 +116,40 @@ module('Integration | header | resize', function() {
         table.headers.objectAt(1).logicalWidth,
         originalWidth + 30,
         'not disabled column can be resized'
+      );
+    });
+
+    test('resizing sets isResizing property on column meta', async function(assert) {
+      await generateTable(this);
+
+      let firstHeader = table.headers.toArray()[0];
+      let firstCell = table.getCell(0, 0);
+
+      assert.notOk(firstHeader.isResizing, 'isResizing is false by default on column header');
+      assert.notOk(firstCell.isResizing, 'isResizing is false by default on column cells');
+
+      let originalWidth = firstHeader.logicalWidth;
+      let resume = firstHeader.resize(originalWidth + 100);
+
+      await waitUntil(() => firstHeader.isResizing);
+      assert.ok(
+        firstHeader.isResizing,
+        'isResizing property is set on corresponding column header when resizing'
+      );
+      assert.ok(
+        firstCell.isResizing,
+        'isResizing property is set on corresponding column cells when resizing'
+      );
+
+      await resume;
+
+      assert.notOk(
+        firstHeader.isResizing,
+        'isResizing is reset to false on column header after resizing'
+      );
+      assert.notOk(
+        firstCell.isResizing,
+        'isResizing is  reset to false on column cells after resizing'
       );
     });
   });


### PR DESCRIPTION
## Summary
Adds `isResizing` property to the columnMeta.

## Description
Consuming applications need the ability to style table columns based on whether or not they are being resized. Currently, ember table only add a `is-resizing` class to the container, but no modifications are made to the column.
By adding the `isResizing` property, consumers can style appropriately. For example, using the something akin to the snippet below in a consuming application:
```
 <EmberTd @class={{if r.columnMeta.isResizing "is-resizing")}}>
```


Note the `is-resizing` class being added/removed appropriately on the `td` element.