### PR TITLE
Drop < Ember 3.28 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,6 @@ jobs:
           [
             embroider-safe,
             # embroider-optimized,
-            ember-lts-3.12,
-            ember-lts-3.20,
-            ember-lts-3.24,
             ember-lts-3.28,
             ember-lts-4.4,
             ember-lts-4.12,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Ember Table versions each support a range of browsers and framework versions:
 
 | Ember Table Version | Ember Versions Supported     | Browser Support |
 | ------------------- | ---------------------------- | --------------- |
-| 5.x                 | 3.12 - 4.x                   | Last two versions of Chrome, Safari, Edge, Firefox on desktop and mobile. |
+| 6.x (prerelease)    | 3.38 - 6.x                   | Last two versions of Chrome, Safari, Edge, Firefox on desktop and mobile. |
+| 5.x                 | 3.12 - 4.x (possibly 5.x?)   | Last two versions of Chrome, Safari, Edge, Firefox on desktop and mobile. |
 | 4.x                 | 2.18 - 4.x                   | Last two versions of Chrome, Safari, Edge, Firefox on desktop and mobile. |
 | 3.x                 | 2.8 - 3.28 (last 3.x version | Last two versions of Chrome, Safari, Edge, Firefox on desktop and mobile. |
 | 2.x                 | 1.11 - 3.8 (or around 3.8)   | IE11+ and newer browsers |
@@ -19,9 +20,6 @@ Ember Table versions each support a range of browsers and framework versions:
 ```bash
 ember install ember-table
 ```
-### Using ember-table with Ember <= 3.24
-Use resolutions in your package.json to pin down `ember-classy-page-object` to version `0.7.0`.
-Newer versions are used to support Ember >= 3.28
 
 ## Features
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -14,38 +14,6 @@ module.exports = function() {
         embroiderSafe(),
         embroiderOptimized(),
         {
-          name: 'ember-lts-3.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.12.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-3.16',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.16.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-3.20',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.20.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-3.24',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.24.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.28',
           npm: {
             devDependencies: {


### PR DESCRIPTION
In accordance with https://github.com/Addepar/ember-table/issues/995, drop versions of Ember older than 3.28 from the test suite.