### PR TITLE
Mark rows as even or odd for styling purposes

### DIFF
--- a/addon/components/ember-tr/component.js
+++ b/addon/components/ember-tr/component.js
@@ -48,7 +48,7 @@ export default Component.extend({
   layout,
   tagName: 'tr',
   classNames: ['et-tr'],
-  classNameBindings: ['isSelected', 'isGroupSelected', 'isSelectable'],
+  classNameBindings: ['isEven:is-even:is-odd', 'isGroupSelected', 'isSelectable', 'isSelected'],
 
   /**
     The API object passed in by the table body, header, or footer
@@ -87,6 +87,11 @@ export default Component.extend({
   isSelected: readOnly('rowMeta.isSelected'),
 
   isGroupSelected: readOnly('rowMeta.isGroupSelected'),
+
+  isEven: computed('rowMeta.index', function() {
+    let index = this.rowMeta?.index ?? 0;
+    return index % 2 === 0;
+  }),
 
   isSelectable: computed('rowSelectionMode', function() {
     let rowSelectionMode = this.get('rowSelectionMode');

--- a/tests/integration/components/row-test.js
+++ b/tests/integration/components/row-test.js
@@ -14,6 +14,8 @@ let table = new TablePage({
   body: {
     rows: collection({
       isCustomRow: hasClass('custom-row'),
+      isEven: hasClass('is-even'),
+      isOdd: hasClass('is-odd'),
     }),
   },
 });
@@ -34,6 +36,17 @@ const USE_EMBER_ARRAY_PARAMETERS = {
 
 module('Integration | row', function() {
   parameterizedComponentModule('basic', USE_EMBER_ARRAY_PARAMETERS, function() {
+    test('marks rows as even or odd', async function(assert) {
+      await generateTable(this);
+
+      assert.true(table.rows.objectAt(0).isEven, 'First row is even');
+      assert.true(table.rows.objectAt(1).isOdd, 'Second row is odd');
+      assert.true(table.rows.objectAt(2).isEven, 'Third row is even');
+      assert.true(table.rows.objectAt(3).isOdd, 'Fourth row is odd');
+      assert.true(table.rows.objectAt(4).isEven, 'Fifth row is even');
+      assert.true(table.rows.objectAt(5).isOdd, 'Sixth row is odd');
+    });
+
     test('can use a custom row component', async function(assert) {
       await generateTable(this, {
         rowComponent: 'custom-row',


### PR DESCRIPTION
- Addepar's new visual look includes zebra-striping tables
- Since ember-table uses vertical-collection to occlude rows during scroll, this can't be reliably done with CSS selectors like `:nth-child(even)` or `:nth-child(odd)`
- A number of Addepar teams have manually added `class="{{if (eq (modulus-of body.rowMeta.index 2) 0) 'is-even' 'is-odd'}}"` to their ember-table row component calls to add stable row class names that indicate which rows have an even index vs an odd index
- This PR brings this capability into ember-table itself so that we (and other consumers) don't have to repeat this pattern over and over in order to give ember-tables a zebra stripe styling